### PR TITLE
Fix of SDL incorrect timeout for Audio/VideoStreaming

### DIFF
--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -130,9 +130,9 @@ ApplicationImpl::ApplicationImpl(uint32_t application_id,
   hmi_states_.push_back(initial_state);
 
   video_stream_suspend_timeout_ =
-      profile::Profile::instance()->video_data_stopped_timeout() / 1000;
+      profile::Profile::instance()->video_data_stopped_timeout();
   audio_stream_suspend_timeout_ =
-      profile::Profile::instance()->audio_data_stopped_timeout() / 1000;
+      profile::Profile::instance()->audio_data_stopped_timeout();
 
   video_stream_suspend_timer_ = ApplicationTimerPtr(
           new timer::TimerThread<ApplicationImpl>(

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -133,7 +133,8 @@ ApplicationManagerImpl::ApplicationManagerImpl()
     sync_primitives::AutoLock lock(timer_pool_lock_);
     ApplicationManagerTimerPtr clearTimerPoolTimer(new TimerThread<ApplicationManagerImpl>(
         "ClearTimerPoolTimer", this, &ApplicationManagerImpl::ClearTimerPool, true));
-    clearTimerPoolTimer->start(10);
+    const uint32_t timeout_ms = 10000;
+    clearTimerPoolTimer->start(timeout_ms);
     timer_pool_.push_back(clearTimerPoolTimer);
 }
 


### PR DESCRIPTION
Defect: Sends OnVideoDataStreaming/OnAudioDataStreaming true/false after every packet

Closses-Bug: APPLINK-17089