### PR TITLE
Fix of GENIVI: Sdl doesnt send OnSystemRequests

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -405,7 +405,7 @@ class MessageHelper {
 
     static void SendSystemRequestNotification(
         uint32_t connection_key,
-        NsSmartDeviceLink::NsSmartObjects::SmartObject& content);
+        NsSmartDeviceLink::NsSmartObjects::SmartObject*& content);
 
     /**
      * @brief SendLaunchApp allows to send OnSystemRequest with LAUNCH_UP.

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -521,6 +521,15 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile() {
       *(application.get()), resumption, need_restore_vr);
   SendResponse(true, result_code, add_info.c_str(), &response_params);
 
+  // Default HMI level should be set before any permissions validation, since it
+  // relies on HMI level.
+  resumer.SetupDefaultHMILevel(application);
+
+  // Sends OnPermissionChange notification to mobile right after RAI response
+  // and HMI level set-up
+  policy::PolicyHandler::instance()->OnAppRegisteredOnMobile(
+        application->mobile_app_id());
+
   if (result_code != mobile_apis::Result::RESUME_FAILED) {
     resumer.StartResumption(application, hash_id);
   } else {

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_request.cc
@@ -297,6 +297,8 @@ void RegisterAppInterfaceRequest::Run() {
 
     SendRegisterAppInterfaceResponseToMobile();
 
+    MessageHelper::SendQueryApps( (*message_)[strings::params][strings::connection_key].asInt());
+
     MessageHelper::SendLockScreenIconUrlNotification(
         (*message_)[strings::params][strings::connection_key].asInt());
   }

--- a/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
+++ b/src/components/application_manager/src/commands/mobile/register_app_interface_response.cc
@@ -44,7 +44,7 @@ namespace commands {
 void RegisterAppInterfaceResponse::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
+  mobile_apis::Result::eType result_code = mobile_apis::Result::SUCCESS;
   bool success = (*message_)[strings::msg_params][strings::success].asBool();
   bool last_message = !success;
   // Do not close connection in case of APPLICATION_NOT_REGISTERED despite it is an error

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1951,7 +1951,12 @@ void MessageHelper::SendSystemRequestNotification (uint32_t connection_key,
 
   content[strings::params][strings::connection_key] = connection_key;
 
-  ApplicationManagerImpl::instance()->ManageMobileCommand(new SmartObject(content));
+  SmartObject* so = new SmartObject(content);
+#ifdef DEBUG
+  PrintSmartObject(*so);
+#endif
+
+  DCHECK(ApplicationManagerImpl::instance()->ManageMobileCommand(so));
 }
 
 void MessageHelper::SendLaunchApp(uint32_t connection_key,

--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -1921,37 +1921,35 @@ bool MessageHelper::SendStopAudioPathThru() {
 void MessageHelper::SendPolicySnapshotNotification(
   unsigned int connection_key, const std::vector<uint8_t>& policy_data,
   const std::string& url, int timeout) {
+  ApplicationSharedPtr app = ApplicationManagerImpl::instance()->application(connection_key);
+   DCHECK(app.get());
 
-  using namespace mobile_apis;
-  using namespace smart_objects;
-
-  SmartObject content (SmartType_Map);
+  smart_objects::SmartObject * content   = new smart_objects::SmartObject(smart_objects::SmartType_Map);
   if (!url.empty()) {
-    content[strings::msg_params][mobile_notification::syncp_url] = url;
+    (*content)[strings::msg_params][mobile_notification::syncp_url] = url;
   }
 
-  content[strings::msg_params][strings::request_type] = RequestType::HTTP;
-  content[strings::params][strings::binary_data] = SmartObject(policy_data);
-  content[strings::msg_params][strings::file_type] = FileType::BINARY;
+  (*content)[strings::msg_params][strings::request_type] = mobile_apis::RequestType::PROPRIETARY;
+  (*content)[strings::params][strings::binary_data] = smart_objects::SmartObject(policy_data);
+  (*content)[strings::msg_params][strings::file_type] = mobile_apis::FileType::BINARY;
 
-  SendSystemRequestNotification(connection_key, content);
+SendSystemRequestNotification(connection_key, content);
 }
 
 void MessageHelper::SendSystemRequestNotification (uint32_t connection_key,
-    smart_objects::SmartObject& content) {
+    smart_objects::SmartObject*& content) {
 
   using namespace mobile_apis;
   using namespace commands;
-  using namespace smart_objects;
 
-  content[strings::params][strings::function_id] = FunctionID::OnSystemRequestID;
-  content[strings::params][strings::message_type] = messageType::notification;
-  content[strings::params][strings::protocol_type] = CommandImpl::mobile_protocol_type_;
-  content[strings::params][strings::protocol_version] = CommandImpl::protocol_version_;
+  (*content)[strings::params][strings::function_id] = mobile_apis::FunctionID::OnSystemRequestID;
+  (*content)[strings::params][strings::message_type] = mobile_apis::messageType::notification;
+  (*content)[strings::params][strings::protocol_type] =commands::CommandImpl::mobile_protocol_type_;
+  (*content)[strings::params][strings::protocol_version] = commands::CommandImpl::protocol_version_;
 
-  content[strings::params][strings::connection_key] = connection_key;
+  (*content)[strings::params][strings::connection_key] = connection_key;
 
-  SmartObject* so = new SmartObject(content);
+  smart_objects::SmartObject* so = new smart_objects::SmartObject(*content);
 #ifdef DEBUG
   PrintSmartObject(*so);
 #endif
@@ -1966,13 +1964,13 @@ void MessageHelper::SendLaunchApp(uint32_t connection_key,
   using namespace mobile_apis;
   using namespace smart_objects;
 
-  SmartObject content (SmartType_Map);
-  content[strings::msg_params][strings::request_type] = RequestType::LAUNCH_APP;
-  content[strings::msg_params][strings::app_id] = connection_key;
+  SmartObject * content = new SmartObject(SmartType_Map);
+  (*content)[strings::msg_params][strings::request_type] = RequestType::LAUNCH_APP;
+  (*content)[strings::msg_params][strings::app_id] = connection_key;
   if (!urlSchema.empty()) {
-    content[strings::msg_params][strings::url] = urlSchema;
+    (*content)[strings::msg_params][strings::url] = urlSchema;
   } else if (!packageName.empty()) {
-    content[strings::msg_params][strings::url] = packageName;
+    (*content)[strings::msg_params][strings::url] = packageName;
   }
 
   SendSystemRequestNotification(connection_key, content);
@@ -1985,10 +1983,10 @@ void application_manager::MessageHelper::SendQueryApps(
 
   policy::PolicyHandler* policy_handler = policy::PolicyHandler::instance();
 
-  SmartObject content (SmartType_Map);
-  content[strings::msg_params][strings::request_type] = RequestType::QUERY_APPS;
-  content[strings::msg_params][strings::url] = policy_handler->RemoteAppsUrl();
-  content[strings::msg_params][strings::timeout] =
+  SmartObject  *content  = new SmartObject(SmartType_Map);
+  (*content)[strings::msg_params][strings::request_type] = RequestType::QUERY_APPS;
+  (*content)[strings::msg_params][strings::url] = policy_handler->RemoteAppsUrl();
+  (*content)[strings::msg_params][strings::timeout] =
       policy_handler->TimeoutExchange();
 
   Json::Value http;
@@ -2010,8 +2008,8 @@ void application_manager::MessageHelper::SendQueryApps(
   std::string data = http_header.toStyledString();
   std::vector<uint8_t> binary_data(data.begin(), data.end());
 
-  content[strings::params][strings::binary_data] = SmartObject(binary_data);
-  content[strings::msg_params][strings::file_type] = FileType::BINARY;
+  (*content)[strings::params][strings::binary_data] = SmartObject(binary_data);
+  (*content)[strings::msg_params][strings::file_type] = FileType::BINARY;
 
   SendSystemRequestNotification(connection_key, content);
 }

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -744,11 +744,7 @@ bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
   LOG4CXX_AUTO_TRACE(logger_);
   POLICY_LIB_CHECK(false);
 
-  if (last_used_app_ids_.empty()) {
-    LOG4CXX_WARN(logger_, "last_used_app_ids_ is empty");
-    return false;
-  }
-  uint32_t app_id = last_used_app_ids_.back();
+  uint32_t app_id = GetAppIdForSending();/*last_used_app_ids_.back();*/
 
   ApplicationSharedPtr app =
     ApplicationManagerImpl::instance()->application(app_id);

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -838,8 +838,8 @@ void PolicyManagerImpl::MarkUnpairedDevice(const std::string& device_id) {
 
 void PolicyManagerImpl::OnAppRegisteredOnMobile(
     const std::string& application_id) {
-  StartPTExchange();
   SendNotificationOnPermissionsUpdated(application_id);
+  StartPTExchange();
 }
 
 std::string PolicyManagerImpl::RetrieveCertificate() const {


### PR DESCRIPTION
1. OnSystemRequestNotyfication send to mobile
    SDL doesn't initiate PTU when new app has registered. APPLINK-17143
2. Fix for OnSystemRequest will sent if mobile use protokol v.4
    SDL doesn't send OnSystemRequest(QUERY_APPS) to the App. APPLINK-17438