### PR TITLE
Fix wrong convert PrerecordedSpeech

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -58,6 +58,8 @@ std::map<std::string, hmi_apis::Common_VrCapabilities::eType>
     vr_enum_capabilities;
 std::map<std::string, hmi_apis::Common_SpeechCapabilities::eType>
     tts_enum_capabilities;
+std::map<std::string, hmi_apis::Common_PrerecordedSpeech::eType>
+    tts_enum_prerecorded_speech;
 std::map<std::string, hmi_apis::Common_ButtonName::eType> button_enum_name;
 std::map<std::string, hmi_apis::Common_TextFieldName::eType>
     text_fields_enum_name;
@@ -102,6 +104,22 @@ void InitCapabilities() {
       std::string("SILENCE"), hmi_apis::Common_SpeechCapabilities::SILENCE));
   tts_enum_capabilities.insert(std::make_pair(
       std::string("FILE"), hmi_apis::Common_SpeechCapabilities::FILE));
+
+  tts_enum_prerecorded_speech.insert(
+      std::make_pair(std::string("HELP_JINGLE"),
+                     hmi_apis::Common_PrerecordedSpeech::HELP_JINGLE));
+  tts_enum_prerecorded_speech.insert(
+      std::make_pair(std::string("INITIAL_JINGLE"),
+                     hmi_apis::Common_PrerecordedSpeech::INITIAL_JINGLE));
+  tts_enum_prerecorded_speech.insert(
+      std::make_pair(std::string("LISTEN_JINGLE"),
+                     hmi_apis::Common_PrerecordedSpeech::LISTEN_JINGLE));
+  tts_enum_prerecorded_speech.insert(
+      std::make_pair(std::string("POSITIVE_JINGLE"),
+                     hmi_apis::Common_PrerecordedSpeech::POSITIVE_JINGLE));
+  tts_enum_prerecorded_speech.insert(
+      std::make_pair(std::string("NEGATIVE_JINGLE"),
+                     hmi_apis::Common_PrerecordedSpeech::NEGATIVE_JINGLE));
 
   button_enum_name.insert(
       std::make_pair(std::string("OK"), hmi_apis::Common_ButtonName::OK));
@@ -1534,7 +1552,7 @@ bool HMICapabilitiesImpl::LoadCapabilitiesFromFile() {
       if (!tts_prerecorded_speech_capabilities_node.isNull()) {
         smart_objects::SmartObject tts_capabilities_so =
             smart_objects::SmartObject(smart_objects::SmartType_Array);
-        ConvertJsonArrayToSoArray<hmi_apis::Common_SpeechCapabilities::eType>(
+        ConvertJsonArrayToSoArray<hmi_apis::Common_PrerecordedSpeech::eType>(
             tts_prerecorded_speech_capabilities_node, tts_capabilities_so);
         set_prerecorded_speech(tts_capabilities_so);
       }

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -1247,6 +1247,48 @@ TEST_F(HMICapabilitiesTest,
       hmi_apis::FunctionID::UI_GetCapabilities);
 }
 
+TEST_F(
+    HMICapabilitiesTest,
+    ConvertJsonArrayToSoArray_ConvertPrerecordedSpeech_SuccessConvertFromStringToEnum) {
+  SetUpLanguageAndLightCapabilitiesExpectation();
+
+  CreateFile(kHmiCapabilitiesCacheFile);
+  const std::string prerecordedSpeechCapabilities =
+      "{ \"TTS\" :{"
+      "\"prerecordedSpeechCapabilities\" :["
+      "\"HELP_JINGLE\","
+      "\"INITIAL_JINGLE\","
+      "\"LISTEN_JINGLE\","
+      "\"POSITIVE_JINGLE\","
+      "\"NEGATIVE_JINGLE\"]}"
+      "}";
+
+  const std::vector<uint8_t> binary_data_to_save(
+      prerecordedSpeechCapabilities.begin(),
+      prerecordedSpeechCapabilities.end());
+  file_system::Write(kHmiCapabilitiesCacheFile, binary_data_to_save);
+
+  hmi_capabilities_->Init(last_state_wrapper_);
+
+  const auto tts_capabilities_so = *(hmi_capabilities_->prerecorded_speech());
+
+  EXPECT_EQ(hmi_apis::Common_PrerecordedSpeech::HELP_JINGLE,
+            static_cast<hmi_apis::Common_PrerecordedSpeech::eType>(
+                tts_capabilities_so[0].asInt()));
+  EXPECT_EQ(hmi_apis::Common_PrerecordedSpeech::INITIAL_JINGLE,
+            static_cast<hmi_apis::Common_PrerecordedSpeech::eType>(
+                tts_capabilities_so[1].asInt()));
+  EXPECT_EQ(hmi_apis::Common_PrerecordedSpeech::LISTEN_JINGLE,
+            static_cast<hmi_apis::Common_PrerecordedSpeech::eType>(
+                tts_capabilities_so[2].asInt()));
+  EXPECT_EQ(hmi_apis::Common_PrerecordedSpeech::POSITIVE_JINGLE,
+            static_cast<hmi_apis::Common_PrerecordedSpeech::eType>(
+                tts_capabilities_so[3].asInt()));
+  EXPECT_EQ(hmi_apis::Common_PrerecordedSpeech::NEGATIVE_JINGLE,
+            static_cast<hmi_apis::Common_PrerecordedSpeech::eType>(
+                tts_capabilities_so[4].asInt()));
+}
+
 }  // namespace application_manager_test
 }  // namespace components
 }  // namespace test


### PR DESCRIPTION
Fixes [Jira link](https://adc.luxoft.com/jira/browse/FORDTCN-5842)

This PR is **[ready]** for review.

**Reproduction Steps**
1. Value of HMICapabilitiesCacheFile parameter is defined (hmi_capabilities_cache.json) in smartDeviceLink.ini file
2. HMI capability cash file (hmi_capabilities_cache.json) exists on file system
3. All HMI Capabilities (VR/TTS/RC/UI etc) are presented in hmi_capabilities_cache.json
4. SDL and HMI are started
5. Mobile sends RegisterAppInterface request to SDL

**Testing Plan**
Testing with ATF and UT

**Summary**
Added enum for correct convert and saving prerecordedSpeechCapabilities

**!! Can be merge only after [PR with refactor hmi_capabilities_test](https://github.com/LuxoftSDL/sdl_core/pull/17)**

**CLA**
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
