### PR TITLE
Save pcm_stream_capabilities to the cache

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1829,6 +1829,13 @@ void HMICapabilitiesImpl::PrepareUiJsonValueForSaving(
         strings::system_capabilities, schema, system_capabilities, out_node);
   }
 
+  if (helpers::in_range(sections_to_update, strings::pcm_stream_capabilities)) {
+    save_hmi_capability_field_to_json(strings::pcm_stream_capabilities,
+                                      schema,
+                                      pcm_stream_capabilities(),
+                                      out_node);
+  }
+
   if (helpers::in_range(sections_to_update, hmi_response::language)) {
     out_node[hmi_response::language] =
         MessageHelper::CommonLanguageToString(active_ui_language());


### PR DESCRIPTION
Fix for [5895](https://adc.luxoft.com/jira/browse/FORDTCN-5895)

pcm_stream_capabilities parameter was missed in the HMI API, after adding it (it was done in the scope of [4188](https://adc.luxoft.com/jira/browse/FORDTCN-4188) ) - we also need to add the saving of this parameter to the cache file