### PR TITLE
Saved audioPassThruCapabilities like array to hmi_capabilities_cache_file

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1800,10 +1800,13 @@ void HMICapabilitiesImpl::PrepareUiJsonValueForSaving(
           (*audio_pass_thru_capabilities_so)[i];
       const auto audio_pass_thru_capabilities =
           std::make_shared<smart_objects::SmartObject>(element);
+      Json::Value out_audio_pass_thru;
       save_hmi_capability_field_to_json(strings::audio_pass_thru_capabilities,
                                         schema,
                                         audio_pass_thru_capabilities,
-                                        out_node);
+                                        out_audio_pass_thru);
+      out_node[strings::audio_pass_thru_capabilities][Json::ArrayIndex(i)] =
+          out_audio_pass_thru[strings::audio_pass_thru_capabilities];
     }
   }
 

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -1219,11 +1219,14 @@ TEST_F(HMICapabilitiesTest, PrepareJsonValueForSaving_Success) {
 
   Json::Value root_node;
   utils::JsonReader reader;
-  EXPECT_TRUE(reader.parse(content_after_update, &root_node));
+  ASSERT_TRUE(reader.parse(content_after_update, &root_node));
 
   for (size_t i = 0; i < interfaces_name.size(); ++i) {
     EXPECT_TRUE(static_cast<bool>(root_node[interfaces_name[i]]));
   }
+  EXPECT_TRUE(
+      root_node[hmi_interface::ui][strings::audio_pass_thru_capabilities]
+          .isArray());
 }
 
 TEST_F(HMICapabilitiesTest,


### PR DESCRIPTION
Fix for [5843](https://adc.luxoft.com/jira/browse/FORDTCN-5843)

### Summary
Persists audioPassThruCapabilitiesList to  HMI Capabilities cache file like array.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
