### PR TITLE
Removed functional where SDL sets the wersCountryCode to LocalPT

### DIFF
--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -425,8 +425,6 @@ struct ConsumerFriendlyMessages : CompositeType {
 struct ModuleMeta : CompositeType {
  public:
   Optional<String<0, 250> > ccpu_version;
-  Optional<String<0, 250> > language;
-  Optional<String<0, 250> > wers_country_code;
   Optional<Integer<uint32_t, 0, ODO_MAX> > pt_exchanged_at_odometer_x;
   Optional<Integer<uint16_t, 0, 65535> > pt_exchanged_x_days_after_epoch;
   Optional<Integer<uint16_t, 0, 65535> > ignition_cycles_since_last_exchange;

--- a/src/components/policy/policy_regular/include/policy/pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/pt_representation.h
@@ -155,9 +155,7 @@ class PTRepresentation {
    * @brief Records information about head unit system to PT
    * @return bool Success of operation
    */
-  virtual bool SetMetaInfo(const std::string& ccpu_version,
-                           const std::string& wers_country_code,
-                           const std::string& language) = 0;
+  virtual bool SetMetaInfo(const std::string& ccpu_version) = 0;
 
   /**
    * @brief Get allowed number of notifications

--- a/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
@@ -89,9 +89,7 @@ class SQLPTRepresentation : public virtual PTRepresentation {
                          StringArray* nicknames = NULL,
                          StringArray* app_hmi_types = NULL);
   bool GetFunctionalGroupings(policy_table::FunctionalGroupings& groups);
-  bool SetMetaInfo(const std::string& ccpu_version,
-                   const std::string& wers_country_code,
-                   const std::string& language);
+  bool SetMetaInfo(const std::string& ccpu_version);
 #ifdef BUILD_TESTS
   uint32_t open_counter() {
     return open_counter_;

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1345,10 +1345,7 @@ void CacheManager::PersistData() {
             app_id, is_revoked, is_default_policy, is_predata_policy);
         is_revoked = false;
 
-        backup_->SetMetaInfo(
-            *(*copy_pt.policy_table.module_meta).ccpu_version,
-            *(*copy_pt.policy_table.module_meta).wers_country_code,
-            *(*copy_pt.policy_table.module_meta).language);
+        backup_->SetMetaInfo(*(*copy_pt.policy_table.module_meta).ccpu_version);
       }
 
       // In case of extended policy the meta info should be backuped as well.
@@ -1494,8 +1491,6 @@ bool CacheManager::SetMetaInfo(const std::string& ccpu_version,
   rpc::Optional<policy_table::ModuleMeta>& module_meta =
       pt_->policy_table.module_meta;
   *(module_meta->ccpu_version) = ccpu_version;
-  *(module_meta->wers_country_code) = wers_country_code;
-  *(module_meta->language) = language;
   // We have to set preloaded flag as false in policy table on any response
   // of GetSystemInfo (SDLAQ-CRS-2365)
   *(pt_->policy_table.module_config.preloaded_pt) = false;

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -1270,8 +1270,6 @@ ModuleMeta::~ModuleMeta() {}
 ModuleMeta::ModuleMeta(const Json::Value* value__)
     : CompositeType(InitHelper(value__, &Json::Value::isObject))
     , ccpu_version(impl::ValueMember(value__, "ccpu_version"))
-    , language(impl::ValueMember(value__, "language"))
-    , wers_country_code(impl::ValueMember(value__, "wers_country_code"))
     , pt_exchanged_at_odometer_x(
           impl::ValueMember(value__, "pt_exchanged_at_odometer_x"))
     , pt_exchanged_x_days_after_epoch(
@@ -1282,8 +1280,6 @@ ModuleMeta::ModuleMeta(const Json::Value* value__)
 Json::Value ModuleMeta::ToJsonValue() const {
   Json::Value result__(Json::objectValue);
   impl::WriteJsonField("ccpu_version", ccpu_version, &result__);
-  impl::WriteJsonField("language", language, &result__);
-  impl::WriteJsonField("wers_country_code", wers_country_code, &result__);
   impl::WriteJsonField(
       "pt_exchanged_at_odometer_x", pt_exchanged_at_odometer_x, &result__);
   impl::WriteJsonField("pt_exchanged_x_days_after_epoch",
@@ -1300,12 +1296,6 @@ bool ModuleMeta::is_valid() const {
     return initialization_state__ == kInitialized && Validate();
   }
   if (!ccpu_version.is_valid()) {
-    return false;
-  }
-  if (!language.is_valid()) {
-    return false;
-  }
-  if (!wers_country_code.is_valid()) {
     return false;
   }
   if (!pt_exchanged_at_odometer_x.is_valid()) {
@@ -1328,13 +1318,6 @@ bool ModuleMeta::struct_empty() const {
   if (ccpu_version.is_initialized()) {
     return false;
   }
-  if (language.is_initialized()) {
-    return false;
-  }
-
-  if (wers_country_code.is_initialized()) {
-    return false;
-  }
   if (pt_exchanged_at_odometer_x.is_initialized()) {
     return false;
   }
@@ -1355,13 +1338,6 @@ void ModuleMeta::ReportErrors(rpc::ValidationReport* report__) const {
   if (!ccpu_version.is_valid()) {
     ccpu_version.ReportErrors(&report__->ReportSubobject("ccpu_version"));
   }
-  if (!language.is_valid()) {
-    language.ReportErrors(&report__->ReportSubobject("language"));
-  }
-  if (!wers_country_code.is_valid()) {
-    wers_country_code.ReportErrors(
-        &report__->ReportSubobject("wers_country_code"));
-  }
   if (!pt_exchanged_at_odometer_x.is_valid()) {
     pt_exchanged_at_odometer_x.ReportErrors(
         &report__->ReportSubobject("pt_exchanged_at_odometer_x"));
@@ -1379,8 +1355,6 @@ void ModuleMeta::ReportErrors(rpc::ValidationReport* report__) const {
 void ModuleMeta::SetPolicyTableType(PolicyTableType pt_type) {
   CompositeType::SetPolicyTableType(pt_type);
   ccpu_version.SetPolicyTableType(pt_type);
-  language.SetPolicyTableType(pt_type);
-  wers_country_code.SetPolicyTableType(pt_type);
   pt_exchanged_at_odometer_x.SetPolicyTableType(pt_type);
   pt_exchanged_x_days_after_epoch.SetPolicyTableType(pt_type);
   ignition_cycles_since_last_exchange.SetPolicyTableType(pt_type);

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -57,8 +57,6 @@ const std::string kCreateSchema =
     "); "
     "CREATE TABLE IF NOT EXISTS `module_meta`( "
     "  `ccpu_version` VARCHAR(45), "
-    "  `language` VARCHAR(45), "
-    "  `wers_country_code` VARCHAR(45), "
     "  `pt_exchanged_at_odometer_x` INTEGER NOT NULL DEFAULT 0, "
     "  `pt_exchanged_x_days_after_epoch` INTEGER NOT NULL DEFAULT 0, "
     "  `ignition_cycles_since_last_exchange` INTEGER NOT NULL DEFAULT 0, "
@@ -1053,6 +1051,6 @@ const std::string kSelectModuleMeta = "SELECT* FROM `module_meta`";
 
 const std::string kUpdateMetaParams =
     "UPDATE `module_meta` SET "
-    "`ccpu_version` = ?, `language` = ?, `wers_country_code` = ? ";
+    "`ccpu_version` = ? ";
 }  // namespace sql_pt
 }  // namespace policy

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -477,11 +477,9 @@ void SQLPTRepresentation::GatherModuleMeta(
   utils::dbms::SQLQuery query(db());
   if (query.Prepare(sql_pt::kSelectModuleMeta) && query.Next()) {
     *meta->ccpu_version = query.GetString(0);
-    *meta->language = query.GetString(1);
-    *meta->wers_country_code = query.GetString(2);
-    *meta->pt_exchanged_at_odometer_x = query.GetInteger(3);
-    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(4);
-    *meta->ignition_cycles_since_last_exchange = query.GetInteger(5);
+    *meta->pt_exchanged_at_odometer_x = query.GetInteger(1);
+    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(2);
+    *meta->ignition_cycles_since_last_exchange = query.GetInteger(3);
   }
 }
 
@@ -696,9 +694,7 @@ bool SQLPTRepresentation::GatherConsumerFriendlyMessages(
   return true;
 }
 
-bool SQLPTRepresentation::SetMetaInfo(const std::string& ccpu_version,
-                                      const std::string& wers_country_code,
-                                      const std::string& language) {
+bool SQLPTRepresentation::SetMetaInfo(const std::string& ccpu_version) {
   LOG4CXX_AUTO_TRACE(logger_);
   utils::dbms::SQLQuery query(db());
   if (!query.Prepare(sql_pt::kUpdateMetaParams)) {
@@ -707,8 +703,6 @@ bool SQLPTRepresentation::SetMetaInfo(const std::string& ccpu_version,
   }
 
   query.Bind(0, ccpu_version);
-  query.Bind(1, wers_country_code);
-  query.Bind(2, language);
 
   if (!query.Exec() || !query.Reset()) {
     LOG4CXX_WARN(logger_, "Incorrect insert to module meta.");
@@ -1421,11 +1415,9 @@ bool SQLPTRepresentation::SaveModuleMeta(const policy_table::ModuleMeta& meta) {
   const int64_t odometer = *(meta.pt_exchanged_at_odometer_x);
 
   query.Bind(0, *(meta.ccpu_version));
-  query.Bind(1, *(meta.language));
-  query.Bind(2, *(meta.wers_country_code));
-  query.Bind(3, odometer);
-  query.Bind(4, *(meta.pt_exchanged_x_days_after_epoch));
-  query.Bind(5, *(meta.ignition_cycles_since_last_exchange));
+  query.Bind(1, odometer);
+  query.Bind(2, *(meta.pt_exchanged_x_days_after_epoch));
+  query.Bind(3, *(meta.ignition_cycles_since_last_exchange));
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Incorrect update for module_meta.");


### PR DESCRIPTION
Fix for [5843](https://adc.luxoft.com/jira/browse/FORDTCN-5841)

### Summary
Removed functional where SDL sets the wersCountryCode parameter in 'ignition_cycles_since_last_exchange' section of LocalPT (policy_regular build)

This code was added by me in this [commit](https://github.com/LuxoftSDL/sdl_core/commit/309671f16072568421cf22f57d7747b78331f938) but because it is not used and leads to failed some script - I removed it. 
