### PR TITLE
Fix problem with subscription on way points during resumption

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -617,20 +617,32 @@ class MessageHelper {
                                   bool available,
                                   ApplicationManager& app_mngr);
 
-  /*
+  /**
+   * @deprecated Deprecated in favor of method CreateMessageWithFunctionID
    * @brief Sends notification to HMI to stop audioPathThru
    *
    * @param connection_key  Application connection key
    *
    * @return TRUE on SUCCES otherwise return FALSE
    */
-  static bool SendStopAudioPathThru(ApplicationManager& app_mngr);
+  DEPRECATED static bool SendStopAudioPathThru(ApplicationManager& app_mngr);
 
   /**
+   * @deprecated Deprecated in favor of method CreateMessageWithFunctionID
    * @brief Sends UnsubscribeWayPoints request
    * @return true if UnsubscribedWayPoints is send otherwise false
    */
-  static bool SendUnsubscribedWayPoints(ApplicationManager& app_mngr);
+  DEPRECATED static bool SendUnsubscribedWayPoints(
+      ApplicationManager& app_mngr);
+
+  /**
+   * @brief Creates message to HMI to send corresponding command
+   * @param function_id Function ID of corresponding command
+   * @return Shared pointer to smart object with received function ID and other
+   * parameters, which are needed for creation message to HMI
+   */
+  static smart_objects::SmartObjectSPtr CreateMessageWithFunctionID(
+      ApplicationManager& app_mngr, hmi_apis::FunctionID::eType function_id);
 
   static smart_objects::SmartObjectSPtr CreateNegativeResponse(
       uint32_t connection_key,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3215,13 +3215,6 @@ void ApplicationManagerImpl::UnregisterApplication(
 
   GetAppServiceManager().UnpublishServices(app_id);
 
-  if (IsAppSubscribedForWayPoints(app_id)) {
-    UnsubscribeAppFromWayPoints(app_id);
-    if (!IsAnyAppSubscribedForWayPoints()) {
-      LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
-      MessageHelper::SendUnsubscribedWayPoints(*this);
-    }
-  }
   EndNaviServices(app_id);
 
   {
@@ -3295,6 +3288,16 @@ void ApplicationManagerImpl::UnregisterApplication(
       resume_controller().SaveApplication(app_to_remove);
     } else {
       resume_controller().RemoveApplicationFromSaved(app_to_remove);
+    }
+
+    if (IsAppSubscribedForWayPoints(app_id)) {
+      UnsubscribeAppFromWayPoints(app_id);
+      if (!IsAnyAppSubscribedForWayPoints()) {
+        LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
+        auto message = MessageHelper::CreateMessageWithFunctionID(
+            *this, hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints);
+        GetRPCService().ManageHMICommand(message);
+      }
     }
 
     (hmi_capabilities_->get_hmi_language_handler())

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3332,8 +3332,11 @@ void ApplicationManagerImpl::UnregisterApplication(
   if (EndAudioPassThru(app_id)) {
     // May be better to put this code in MessageHelper?
     StopAudioPassThru(app_id);
-    MessageHelper::SendStopAudioPathThru(*this);
+    auto message = MessageHelper::CreateMessageWithFunctionID(
+        *this, hmi_apis::FunctionID::UI_EndAudioPassThru);
+    GetRPCService().ManageHMICommand(message);
   }
+
   auto on_app_unregistered =
       [app_to_remove](plugin_manager::RPCPlugin& plugin) {
         plugin.OnApplicationEvent(plugin_manager::kApplicationUnregistered,

--- a/src/components/application_manager/src/helpers/application_helper.cc
+++ b/src/components/application_manager/src/helpers/application_helper.cc
@@ -11,7 +11,9 @@ void DeleteWayPoints(ApplicationSharedPtr app,
                      ApplicationManager& app_manager) {
   app_manager.UnsubscribeAppFromWayPoints(app);
   if (!app_manager.IsAnyAppSubscribedForWayPoints()) {
-    MessageHelper::SendUnsubscribedWayPoints(app_manager);
+    auto message = MessageHelper::CreateMessageWithFunctionID(
+        app_manager, hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints);
+    app_manager.GetRPCService().ManageHMICommand(message);
   }
 }
 

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2524,6 +2524,17 @@ bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
   return app_mngr.GetRPCService().ManageHMICommand(result);
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageWithFunctionID(
+    ApplicationManager& app_mngr, hmi_apis::FunctionID::eType function_id) {
+  LOG4CXX_TRACE(logger_, "MessageHelper::CreateMessageWithFunctionID");
+
+  smart_objects::SmartObjectSPtr result = CreateMessageForHMI(
+      hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
+
+  (*result)[strings::params][strings::function_id] = function_id;
+  return result;
+}
+
 void MessageHelper::SendPolicySnapshotNotification(
     uint32_t connection_key,
     const std::string& snapshot_file_path,

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -914,6 +914,10 @@ void ResumeCtrlImpl::AddWayPointsSubscription(
         saved_app[strings::subscribed_for_way_points];
     if (true == subscribed_for_way_points_so.asBool()) {
       application_manager_.SubscribeAppForWayPoints(application);
+      auto message = MessageHelper::CreateMessageWithFunctionID(
+          application_manager_,
+          hmi_apis::FunctionID::Navigation_SubscribeWayPoints);
+      application_manager_.GetRPCService().ManageHMICommand(message);
     }
   }
 }

--- a/src/components/application_manager/test/application_helper_test.cc
+++ b/src/components/application_manager/test/application_helper_test.cc
@@ -204,7 +204,14 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectAppDataReset) {
   EXPECT_TRUE(NULL != file_ptr);
   EXPECT_TRUE(file_ptr->file_name == filename);
 
+  smart_objects::SmartObjectSPtr message_to_hmi;
+  EXPECT_CALL(*mock_message_helper_,
+              CreateMessageWithFunctionID(
+                  _, hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints))
+      .WillOnce(Return(message_to_hmi));
+
   // Act
+
   application_manager::DeleteApplicationData(app_impl_, app_manager_impl_);
   EXPECT_FALSE(NULL != app_impl_->FindCommand(cmd_id));
   EXPECT_FALSE(NULL != app_impl_->FindSubMenu(menu_id));
@@ -243,7 +250,11 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectHMICleanupRequests) {
   app_impl_->AddChoiceSet(choice_set_id, cmd[strings::msg_params]);
   app_impl_->SubscribeToButton(mobile_apis::ButtonName::AC);
 
-  EXPECT_CALL(*mock_message_helper_, SendUnsubscribedWayPoints(_));
+  smart_objects::SmartObjectSPtr message_to_hmi;
+  EXPECT_CALL(*mock_message_helper_,
+              CreateMessageWithFunctionID(
+                  _, hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints))
+      .WillOnce(Return(message_to_hmi));
 
   EXPECT_CALL(*mock_message_helper_, SendDeleteCommandRequest(_, _, _));
 

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -252,7 +252,6 @@ class MockMessageHelper {
                                      const uint32_t correlation_id,
                                      uint32_t connection_key));
   MOCK_METHOD0(vehicle_data, const VehicleData&());
-  MOCK_METHOD1(SendStopAudioPathThru, bool(ApplicationManager& app_mngr));
   MOCK_METHOD1(StringifiedFunctionID,
                std::string(const mobile_apis::FunctionID::eType function_id));
   MOCK_METHOD2(SendUIChangeRegistrationRequestToHMI,
@@ -282,8 +281,10 @@ class MockMessageHelper {
                     const std::string& urlSchema,
                     const std::string& packageName,
                     ApplicationManager& app_man));
-  MOCK_METHOD1(SendUnsubscribedWayPoints, bool(ApplicationManager& app_mngr));
-
+  MOCK_METHOD2(
+      CreateMessageWithFunctionID,
+      smart_objects::SmartObjectSPtr(ApplicationManager& app_mngr,
+                                     hmi_apis::FunctionID::eType function_id));
   MOCK_METHOD2(SendQueryApps,
                void(const uint32_t connection_key,
                     ApplicationManager& app_man));

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -457,11 +457,6 @@ const VehicleData& MessageHelper::vehicle_data() {
   return MockMessageHelper::message_helper_mock()->vehicle_data();
 }
 
-bool MessageHelper::SendStopAudioPathThru(ApplicationManager& app_mngr) {
-  return MockMessageHelper::message_helper_mock()->SendStopAudioPathThru(
-      app_mngr);
-}
-
 std::string MessageHelper::StringifiedFunctionID(
     const mobile_apis::FunctionID::eType function_id) {
   return MockMessageHelper::message_helper_mock()->StringifiedFunctionID(
@@ -517,9 +512,10 @@ void MessageHelper::SendLaunchApp(const uint32_t connection_key,
       connection_key, urlSchema, packageName, app_man);
 }
 
-bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
-  return MockMessageHelper::message_helper_mock()->SendUnsubscribedWayPoints(
-      app_mngr);
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageWithFunctionID(
+    ApplicationManager& app_mngr, hmi_apis::FunctionID::eType function_id) {
+  return MockMessageHelper::message_helper_mock()->CreateMessageWithFunctionID(
+      app_mngr, function_id);
 }
 
 void MessageHelper::SendQueryApps(const uint32_t connection_key,


### PR DESCRIPTION
Fixes [#2460](https://github.com/smartdevicelink/sdl_core/issues/2460)

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This pull request is intended to fix problem with subscription on way points during resumption, when SDL does not send SubscribeWayPoints request to HMI in case of resumption. This problem is caused by absence of functionality, which may ensure the sending corresponding command to HMI during resumption.

MessageHelper class is responsible for creation messages to HMI in similar situations, and already has two in fact duplicate methods with identical functionality (SendUnsubscribedWayPoints and SendStopAudioPathThru). There is a possibility to add another duplicate method like SendSubscribedWayPoints, but better solution may be implementation one shared method for creation such type of messages (with any function ID, depending of situation).

That's why in this pull request CreateMessageWithFunctionID method is added to MessageHelper class, and methods SendUnsubscribedWayPoints and SendStopAudioPathThru are replaced by CreateMessageWithFunctionID method in all places, where they were used. Also call of CreateMessageWithFunctionID is added to method AddWayPointsSubscription of ResumeCtrlImpl class to solve problem, mentioned in corresponding issue.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
