### PR TITLE
Fix problem with sending onAppInterfaceUnregistered notification during execution of UnregisterAppInterface request

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unregister_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unregister_app_interface_request.cc
@@ -49,11 +49,6 @@ void UnregisterAppInterfaceRequest::Run() {
     return;
   }
 
-  rpc_service_.ManageMobileCommand(
-      MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
-          connection_key(),
-          mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM),
-      SOURCE_SDL);
   application_manager_.EndNaviServices(connection_key());
   application_manager_.UnregisterApplication(connection_key(),
                                              mobile_apis::Result::SUCCESS);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unregister_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unregister_app_interface_request_test.cc
@@ -85,19 +85,8 @@ TEST_F(UnregisterAppInterfaceRequestTest, Run_SUCCESS) {
   MockAppPtr mock_app(CreateMockApp());
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillRepeatedly(Return(mock_app));
-
-  const mobile_apis::AppInterfaceUnregisteredReason::eType kUnregisterReason =
-      mobile_apis::AppInterfaceUnregisteredReason::INVALID_ENUM;
-
-  MessageSharedPtr dummy_msg(CreateMessage());
-  EXPECT_CALL(mock_message_helper_,
-              GetOnAppInterfaceUnregisteredNotificationToMobile(
-                  kConnectionKey, kUnregisterReason))
-      .WillOnce(Return(dummy_msg));
   {
     ::testing::InSequence sequence;
-
-    EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(dummy_msg, _));
 
     EXPECT_CALL(app_mngr_,
                 UnregisterApplication(


### PR DESCRIPTION
Fixes #[1178](https://github.com/SmartDeviceLink/sdl_core/issues/1178)

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Corresponding unit test is updated

### Summary
This pull request is intended to fix issue with sending onAppInterfaceUnregistered notification during execution of UnregisterAppInterface request. Root cause of this issue is a sending OnAppInterfaceUnregistered notification with invalid unregistration reason in method UnregisterAppInterfaceRequest::Run().
That's why this notification was removed from UnregisterAppInterfaceRequest::Run() method and corresponding unit test.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
