### PR TITLE
Impl/ut for wep app in resuming mode

### DIFF
--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -88,7 +88,10 @@ void StateControllerImpl::SetRegularState(ApplicationSharedPtr app,
     return;
   }
 
-  if (app->is_resuming() && !IsResumptionAllowed(app, state)) {
+  const bool app_is_resuming = app->is_resuming();
+  const bool is_resumption_allowed = IsResumptionAllowed(app, state);
+
+  if (app_is_resuming && !is_resumption_allowed) {
     return;
   }
 
@@ -478,9 +481,12 @@ bool StateControllerImpl::IsResumptionAllowed(ApplicationSharedPtr app,
     return false;
   }
 
+  const bool is_navi_app = app->is_navi();
+  const bool is_mob_projection_app = app->mobile_projection_enabled();
+  const bool is_wep_app = app->webengine_projection_enabled();
+
   if (IsTempStateActive(HmiState::StateID::STATE_ID_EMBEDDED_NAVI) &&
-      (app->is_navi() || app->mobile_projection_enabled() ||
-       app->webengine_projection_enabled())) {
+      (is_navi_app || is_mob_projection_app || is_wep_app)) {
     LOG4CXX_DEBUG(logger_,
                   "Resumption for navi and projection apps is not allowed. "
                       << "EMBEDDED_NAVI event is active");

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -131,6 +131,8 @@ struct HmiStatesIDComparator {
 #define NOT_VC false
 #define NAVI true
 #define NOT_NAVI false
+#define WEP true
+#define NOT_WEP false
 
 enum ApplicationType {
   APP_TYPE_NON_MEDIA,
@@ -692,9 +694,10 @@ class StateControllerImplTest : public ::testing::Test {
       NiceMock<application_manager_test::MockApplication>** app_mock,
       uint32_t app_id,
       uint32_t hmi_app_id,
-      bool media,
-      bool navi,
-      bool vc) {
+      const bool media,
+      const bool navi,
+      const bool vc,
+      const bool wep) {
     *app_mock = new NiceMock<application_manager_test::MockApplication>;
 
     Mock::AllowLeak(*app_mock);  // WorkAround for googletest bug
@@ -704,6 +707,8 @@ class StateControllerImplTest : public ::testing::Test {
     ON_CALL(**app_mock, hmi_app_id()).WillByDefault(Return(hmi_app_id));
     ON_CALL(**app_mock, is_media_application()).WillByDefault(Return(media));
     ON_CALL(**app_mock, is_navi()).WillByDefault(Return(navi));
+    ON_CALL(**app_mock, webengine_projection_enabled())
+        .WillByDefault(Return(wep));
     ON_CALL(**app_mock, is_voice_communication_supported())
         .WillByDefault(Return(vc));
     ON_CALL(**app_mock, IsAudioApplication())
@@ -908,57 +913,71 @@ class StateControllerImplTest : public ::testing::Test {
                                simple_hmi_app_id_,
                                NOT_MEDIA,
                                NOT_NAVI,
-                               NOT_VC);
+                               NOT_VC,
+                               NOT_WEP);
     media_app_ = ConfigureApp(&media_app_ptr_,
                               media_app_id_,
                               media_hmi_app_id_,
                               MEDIA,
                               NOT_NAVI,
-                              NOT_VC);
+                              NOT_VC,
+                              NOT_WEP);
     navi_app_ = ConfigureApp(&navi_app_ptr_,
                              navi_app_id_,
                              navi_hmi_app_id_,
                              NOT_MEDIA,
                              NAVI,
-                             NOT_VC);
-    vc_app_ = ConfigureApp(
-        &vc_app_ptr_, vc_app_id_, vc_hmi_app_id_, NOT_MEDIA, NOT_NAVI, VC);
+                             NOT_VC,
+                             NOT_WEP);
+    vc_app_ = ConfigureApp(&vc_app_ptr_,
+                           vc_app_id_,
+                           vc_hmi_app_id_,
+                           NOT_MEDIA,
+                           NOT_NAVI,
+                           VC,
+                           NOT_WEP);
     media_navi_app_ = ConfigureApp(&media_navi_app_ptr_,
                                    media_navi_app_id_,
                                    media_navi_hmi_app_id_,
                                    MEDIA,
                                    NAVI,
-                                   NOT_VC);
+                                   NOT_VC,
+                                   NOT_WEP);
     media_vc_app_ = ConfigureApp(&media_vc_app_ptr_,
                                  media_vc_app_id_,
                                  media_vc_hmi_app_id_,
                                  MEDIA,
                                  NOT_NAVI,
-                                 VC);
+                                 VC,
+                                 NOT_WEP);
     navi_vc_app_ = ConfigureApp(&navi_vc_app_ptr_,
                                 navi_vc_app_id_,
                                 navi_vc_hmi_app_id_,
                                 NOT_MEDIA,
                                 NAVI,
-                                VC);
+                                VC,
+                                NOT_WEP);
     media_navi_vc_app_ = ConfigureApp(&media_navi_vc_app_ptr_,
                                       media_navi_vc_app_id_,
                                       media_navi_vc_hmi_app_id_,
                                       MEDIA,
                                       NAVI,
-                                      VC);
+                                      VC,
+                                      NOT_WEP);
     media_wep_app_ = ConfigureApp(&media_wep_app_ptr_,
                                   media_wep_app_id_,
                                   media_wep_app_hmi_app_id_,
                                   MEDIA,
                                   NOT_NAVI,
-                                  NOT_VC);
+                                  NOT_VC,
+                                  WEP);
     non_media_wep_app_ = ConfigureApp(&non_media_wep_app_ptr_,
                                       non_media_wep_app_id_,
                                       non_media_wep_app_hmi_app_id_,
                                       NOT_MEDIA,
                                       NOT_NAVI,
-                                      NOT_VC);
+                                      NOT_VC,
+                                      WEP);
 
     applications_list_[simple_app_] = simple_app_ptr_;
     applications_list_[media_app_] = media_app_ptr_;
@@ -1641,10 +1660,15 @@ TEST_F(StateControllerImplTest,
   am::ApplicationSharedPtr app_moved_to_full;
   NiceMock<application_manager_test::MockApplication>* app_moved_to_full_mock;
 
-  app_in_full =
-      ConfigureApp(&app_in_full_mock, 1761, 15685, NOT_MEDIA, NOT_NAVI, NOT_VC);
-  app_moved_to_full = ConfigureApp(
-      &app_moved_to_full_mock, 1796, 30093, NOT_MEDIA, NOT_NAVI, NOT_VC);
+  app_in_full = ConfigureApp(
+      &app_in_full_mock, 1761, 15685, NOT_MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
+  app_moved_to_full = ConfigureApp(&app_moved_to_full_mock,
+                                   1796,
+                                   30093,
+                                   NOT_MEDIA,
+                                   NOT_NAVI,
+                                   NOT_VC,
+                                   NOT_WEP);
 
   InsertApplication(app_in_full);
   InsertApplication(app_moved_to_full);
@@ -1718,12 +1742,12 @@ TEST_F(StateControllerImplTest,
   namespace HMILevel = mobile_apis::HMILevel;
   namespace SystemContext = mobile_apis::SystemContext;
   NiceMock<application_manager_test::MockApplication>* app_in_full_mock;
-  am::ApplicationSharedPtr app_in_full =
-      ConfigureApp(&app_in_full_mock, 1761, 15685, MEDIA, NOT_NAVI, NOT_VC);
+  am::ApplicationSharedPtr app_in_full = ConfigureApp(
+      &app_in_full_mock, 1761, 15685, MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   NiceMock<application_manager_test::MockApplication>* app_moved_to_full_mock;
   am::ApplicationSharedPtr app_moved_to_full = ConfigureApp(
-      &app_moved_to_full_mock, 1796, 30093, MEDIA, NOT_NAVI, NOT_VC);
+      &app_moved_to_full_mock, 1796, 30093, MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   InsertApplication(app_in_full);
   InsertApplication(app_moved_to_full);
@@ -1745,12 +1769,12 @@ TEST_F(StateControllerImplTest,
   namespace SystemContext = mobile_apis::SystemContext;
 
   NiceMock<application_manager_test::MockApplication>* app_in_limited_mock;
-  am::ApplicationSharedPtr app_in_limited =
-      ConfigureApp(&app_in_limited_mock, 1761, 15685, NOT_MEDIA, NAVI, NOT_VC);
+  am::ApplicationSharedPtr app_in_limited = ConfigureApp(
+      &app_in_limited_mock, 1761, 15685, NOT_MEDIA, NAVI, NOT_VC, NOT_WEP);
 
   NiceMock<application_manager_test::MockApplication>* app_moved_to_full_mock;
-  am::ApplicationSharedPtr app_moved_to_full =
-      ConfigureApp(&app_moved_to_full_mock, 1796, 30093, NOT_MEDIA, NAVI, VC);
+  am::ApplicationSharedPtr app_moved_to_full = ConfigureApp(
+      &app_moved_to_full_mock, 1796, 30093, NOT_MEDIA, NAVI, VC, NOT_WEP);
 
   InsertApplication(app_in_limited);
   InsertApplication(app_moved_to_full);
@@ -1771,13 +1795,19 @@ TEST_F(StateControllerImplTest,
   namespace HMILevel = mobile_apis::HMILevel;
   namespace SystemContext = mobile_apis::SystemContext;
   NiceMock<application_manager_test::MockApplication>* app_in_limited_mock;
-  am::ApplicationSharedPtr app_in_limited =
-      ConfigureApp(&app_in_limited_mock, 1761, 15685, NOT_MEDIA, NOT_NAVI, VC);
+  am::ApplicationSharedPtr app_in_limited = ConfigureApp(
+      &app_in_limited_mock, 1761, 15685, NOT_MEDIA, NOT_NAVI, VC, NOT_WEP);
 
   NiceMock<application_manager_test::MockApplication>*
       app_moved_to_limited_mock;
-  am::ApplicationSharedPtr app_moved_to_limited = ConfigureApp(
-      &app_moved_to_limited_mock, 1796, 30093, NOT_MEDIA, NOT_NAVI, VC);
+  am::ApplicationSharedPtr app_moved_to_limited =
+      ConfigureApp(&app_moved_to_limited_mock,
+                   1796,
+                   30093,
+                   NOT_MEDIA,
+                   NOT_NAVI,
+                   VC,
+                   NOT_WEP);
 
   InsertApplication(app_in_limited);
   InsertApplication(app_moved_to_limited);
@@ -1926,16 +1956,22 @@ TEST_F(StateControllerImplTest,
   namespace SystemContext = mobile_apis::SystemContext;
 
   NiceMock<application_manager_test::MockApplication>* app_moved_to_full_mock;
-  am::ApplicationSharedPtr app_moved_to_full = ConfigureApp(
-      &app_moved_to_full_mock, 1761, 15685, NOT_MEDIA, NOT_NAVI, NOT_VC);
+  am::ApplicationSharedPtr app_moved_to_full =
+      ConfigureApp(&app_moved_to_full_mock,
+                   1761,
+                   15685,
+                   NOT_MEDIA,
+                   NOT_NAVI,
+                   NOT_VC,
+                   NOT_WEP);
 
   am::ApplicationSharedPtr limited_app = media_app_;
   NiceMock<application_manager_test::MockApplication>* limited_app_mock =
       media_app_ptr_;
 
   NiceMock<application_manager_test::MockApplication>* full_app_mock;
-  am::ApplicationSharedPtr full_app =
-      ConfigureApp(&full_app_mock, 1796, 30093, NOT_MEDIA, NOT_NAVI, NOT_VC);
+  am::ApplicationSharedPtr full_app = ConfigureApp(
+      &full_app_mock, 1796, 30093, NOT_MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   InsertApplication(app_moved_to_full);
   InsertApplication(limited_app);
@@ -1965,15 +2001,15 @@ TEST_F(
 
   NiceMock<application_manager_test::MockApplication>* app_moved_to_full_mock;
   am::ApplicationSharedPtr app_moved_to_full = ConfigureApp(
-      &app_moved_to_full_mock, 1761, 15685, MEDIA, NOT_NAVI, NOT_VC);
+      &app_moved_to_full_mock, 1761, 15685, MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   NiceMock<application_manager_test::MockApplication>* limited_app_mock;
-  am::ApplicationSharedPtr limited_app =
-      ConfigureApp(&limited_app_mock, 1762, 17559, MEDIA, NOT_NAVI, NOT_VC);
+  am::ApplicationSharedPtr limited_app = ConfigureApp(
+      &limited_app_mock, 1762, 17559, MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   NiceMock<application_manager_test::MockApplication>* full_app_mock;
-  am::ApplicationSharedPtr full_app =
-      ConfigureApp(&full_app_mock, 1796, 30093, NOT_MEDIA, NOT_NAVI, NOT_VC);
+  am::ApplicationSharedPtr full_app = ConfigureApp(
+      &full_app_mock, 1796, 30093, NOT_MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   InsertApplication(app_moved_to_full);
   InsertApplication(limited_app);
@@ -2003,15 +2039,15 @@ TEST_F(
 
   NiceMock<application_manager_test::MockApplication>* app_moved_to_full_mock;
   am::ApplicationSharedPtr app_moved_to_full = ConfigureApp(
-      &app_moved_to_full_mock, 1761, 15685, MEDIA, NOT_NAVI, NOT_VC);
+      &app_moved_to_full_mock, 1761, 15685, MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   NiceMock<application_manager_test::MockApplication>* limited_app_mock;
-  am::ApplicationSharedPtr limited_app =
-      ConfigureApp(&limited_app_mock, 1762, 17559, MEDIA, NOT_NAVI, NOT_VC);
+  am::ApplicationSharedPtr limited_app = ConfigureApp(
+      &limited_app_mock, 1762, 17559, MEDIA, NOT_NAVI, NOT_VC, NOT_WEP);
 
   NiceMock<application_manager_test::MockApplication>* full_app_mock;
-  am::ApplicationSharedPtr full_app =
-      ConfigureApp(&full_app_mock, 1796, 30093, NOT_MEDIA, NAVI, NOT_VC);
+  am::ApplicationSharedPtr full_app = ConfigureApp(
+      &full_app_mock, 1796, 30093, NOT_MEDIA, NAVI, NOT_VC, NOT_WEP);
 
   InsertApplication(app_moved_to_full);
   InsertApplication(limited_app);
@@ -3426,6 +3462,29 @@ TEST_F(
   const bool send_activate_app = true;
   state_ctrl_->SetRegularState(
       media_app_, kDefaultWindowId, new_state, send_activate_app);
+}
+
+TEST_F(
+    StateControllerImplTest,
+    SetRegularState_WEPAppIsInResumingModeEmbeddedNaviIsActive_HmiStateIsNotChanged) {
+  am::event_engine::Event embedded_navi_event(
+      hmi_apis::FunctionID::BasicCommunication_OnEventChanged);
+  smart_objects::SmartObject message;
+  message[am::strings::msg_params][am::hmi_notification::is_active] = true;
+  message[am::strings::msg_params][am::hmi_notification::event_name] =
+      hmi_apis::Common_EventTypes::EMBEDDED_NAVI;
+  embedded_navi_event.set_smart_object(message);
+  state_ctrl_->on_event(embedded_navi_event);
+
+  EXPECT_CALL(*media_wep_app_ptr_, is_resuming())
+      .Times(2)
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*media_wep_app_ptr_, SetRegularState(_, _)).Times(0);
+
+  const auto new_state = FullAudibleState();
+  const bool send_activate_app = true;
+  state_ctrl_->SetRegularState(
+      media_wep_app_, kDefaultWindowId, new_state, send_activate_app);
 }
 
 TEST_F(StateControllerImplTest,


### PR DESCRIPTION
Implements UT for #[0273](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0273-webengine-projection-mode.md)

[JIRA](https://adc.luxoft.com/jira/browse/FORDTCN-6225)

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
N/A

### Summary
Added unit test case for HMI state check when Webengine Projection application is in resuming mode 
and embedded navigation is active.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
