### PR TITLE
Suspend response to RAI requests until HMI has responded to all the HMI capabilities

### DIFF
--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1676,7 +1676,7 @@ void HMICapabilitiesImpl::OnSoftwareVersionReceived(
 
   if (MatchesCCPUVersion(ccpu_version)) {
     LOG4CXX_DEBUG(logger_, "Software version not changed");
-    app_mngr_.SetHMICooperating(true);
+    CheckPendingRequestsRequiredForCapabilities();
     app_mngr_.RequestForInterfacesAvailability();
     return;
   }


### PR DESCRIPTION
[Jira Task](https://adc.luxoft.com/jira/browse/FORDTCN-6161)
This PR is **[ready]** for review.

### Summary

#### Pre-condition
Received GetSystemInfoResponse with ccpu_version 

#### Cases: 
1. If local ccpu_version matches with received ccpu_version from HMI, and cache exist SDL Core should respond all pending RAI requests, this is possible if set the hmi_cooperating to true.
2. If local ccpu_version matches with received ccpu_version from HMI, and cache does't exist, SDL Core should not respond all holded RAI requests, before will be processed required requests for capabilitiesit's. It's mean that hmi_cooperating need to be false until required requests will be  proccesed.
