### PR TITLE
Add check for result codes from HMI IsReady response

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -137,7 +137,7 @@ void RCCommandRequest::Run() {
     LOG4CXX_WARN(logger_, "HMI interface RC is not available");
     SendResponse(false,
                  mobile_apis::Result::UNSUPPORTED_RESOURCE,
-                 "Remote control is not supported by system");
+                 "RC is not supported by system");
     return;
   }
   LOG4CXX_TRACE(logger_, "RC interface is available!");

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -153,7 +153,7 @@ void UnsubscribeVehicleDataRequest::Run() {
   if (0 == unsubscribed_items) {
     SendResponse(false,
                  mobile_apis::Result::IGNORED,
-                 "Was not subscribed on any VehicleData.",
+                 "Some provided VehicleData was not subscribed.",
                  &response_params_);
     return;
   }

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -92,13 +92,13 @@ const std::string CreateInfoForUnsupportedResult(
       return "UI is not supported by system";
     }
     case (HmiInterfaces::InterfaceID::HMI_INTERFACE_Navigation): {
-      return "Navi is not supported by system";
+      return "Navigation is not supported by system";
     }
     case (HmiInterfaces::InterfaceID::HMI_INTERFACE_VehicleInfo): {
       return "VehicleInfo is not supported by system";
     }
     case (HmiInterfaces::InterfaceID::HMI_INTERFACE_RC): {
-      return "Remote control is not supported by system";
+      return "RC is not supported by system";
     }
     default:
 #ifdef ENABLE_LOG

--- a/src/components/application_manager/src/commands/request_to_hmi.cc
+++ b/src/components/application_manager/src/commands/request_to_hmi.cc
@@ -85,6 +85,12 @@ bool ChangeInterfaceState(ApplicationManager& application_manager,
     return is_available;
   }
 
+  if (response_from_hmi[strings::params].keyExists(strings::error_msg)) {
+    application_manager.hmi_interfaces().SetInterfaceState(
+        interface, HmiInterfaces::STATE_NOT_AVAILABLE);
+    return false;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Fixes #[1384](https://github.com/smartdevicelink/sdl_core/issues/1384) and #3205

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This pull request is intended to fix issue with incorrect determination of interface availability, when HMI sends IsReady response. Corresponding to requirements, message with any error result code and "available" = "true" is equal to "available" = "false", when interface is set as unavailable. That's why check of result codes from IsReady response is added to ChangeInterfaceState method, also minor changes are added to corresponding requests for processing RPC to align their responses to requirements.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
