### PR TITLE
Fix filtering of empty structures for vehicle data

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -985,6 +985,12 @@ class MessageHelper {
   static smart_objects::SmartObjectSPtr CreateDisplayCapabilityUpdateToMobile(
       const smart_objects::SmartObject& system_capabilities, Application& app);
 
+  /**
+   * @brief Recursively removes empty parameters of composite type from message
+   * @param msg_params smart object containing message params
+   */
+  static void RemoveEmptyMessageParams(smart_objects::SmartObject& msg_params);
+
  private:
   /**
    * @brief Allows to fill SO according to the  current permissions.

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
@@ -162,6 +162,8 @@ void GetVehicleDataRequest::on_event(const event_engine::Event& event) {
           }
         }
 
+        MessageHelper::RemoveEmptyMessageParams(message[strings::msg_params]);
+
         if (message[strings::msg_params].empty() &&
             hmi_apis::Common_Result::DATA_NOT_AVAILABLE != result_code) {
           response_info = "Failed to retrieve data from vehicle";

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/on_vehicle_data_notification.cc
@@ -68,6 +68,8 @@ void OnVehicleDataNotification::Run() {
   custom_vehicle_data_manager_.CreateMobileMessageParams(
       (*message_)[strings::msg_params]);
 
+  MessageHelper::RemoveEmptyMessageParams((*message_)[strings::msg_params]);
+
   const auto& param_names = (*message_)[strings::msg_params].enumerate();
   for (const auto& name : param_names) {
     LOG4CXX_DEBUG(logger_, "vehicle_data name: " << name);


### PR DESCRIPTION
Fixes #3368

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Current PR contains a new function for MessageHelper to filter empty structures from vehicle data response messages (OnVehicleData, GetVehicleData)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)