### PR TITLE
Increase UT coverage for persisting hmi capabilities

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_request_test.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hmi/vi_get_vehicle_type_request.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/commands/request_to_hmi.h"
+#include "application_manager/smart_object_keys.h"
+#include "smart_objects/smart_object.h"
+#include "vehicle_info_plugin/commands/vi_command_request_test.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace hmi_commands_test {
+namespace vi_get_vehicle_type_request {
+
+namespace am = ::application_manager;
+namespace strings = ::application_manager::strings;
+using am::commands::CommandImpl;
+using ::testing::_;
+using vehicle_info_plugin::commands::VIGetVehicleTypeRequest;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const std::string kStrNumber = "123";
+}  // namespace
+
+class VIGetVehicleTypeRequestTest
+    : public VICommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  MessageSharedPtr CreateCommandMsg() {
+    auto command_msg = CreateMessage(smart_objects::SmartType_Map);
+    (*command_msg)[am::strings::msg_params][am::strings::number] = kStrNumber;
+    (*command_msg)[am::strings::params][am::strings::connection_key] =
+        kConnectionKey;
+    return command_msg;
+  }
+};
+
+TEST_F(VIGetVehicleTypeRequestTest, RUN_SendRequest_SUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  auto command = CreateCommandVI<VIGetVehicleTypeRequest>(command_msg);
+
+  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+
+  EXPECT_EQ(CommandImpl::hmi_protocol_type_,
+            (*command_msg)[strings::params][strings::protocol_type].asInt());
+  EXPECT_EQ(CommandImpl::protocol_version_,
+            (*command_msg)[strings::params][strings::protocol_version].asInt());
+}
+
+TEST_F(VIGetVehicleTypeRequestTest, onTimeOut_VIGetVehicleTypeUpdated) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
+  auto command(CreateCommandVI<VIGetVehicleTypeRequest>(command_msg));
+
+  EXPECT_CALL(mock_hmi_capabilities_,
+              UpdateRequestsRequiredForCapabilities(
+                  hmi_apis::FunctionID::VehicleInfo_GetVehicleType));
+  ASSERT_TRUE(command->Init());
+
+  command->Run();
+  command->onTimeOut();
+}
+
+}  // namespace vi_get_vehicle_type_request
+}  // namespace hmi_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_request_test.cc
@@ -87,7 +87,9 @@ TEST_F(VIGetVehicleTypeRequestTest, RUN_SendRequest_SUCCESS) {
             (*command_msg)[strings::params][strings::protocol_version].asInt());
 }
 
-TEST_F(VIGetVehicleTypeRequestTest, onTimeOut_VIGetVehicleTypeUpdated) {
+TEST_F(
+    VIGetVehicleTypeRequestTest,
+    onTimeOut_VIGetVehicleTypeRequestTimeoutExpired_UpdateRequestsRequiredForVIGetVehicleType) {
   MessageSharedPtr command_msg = CreateCommandMsg();
   auto command(CreateCommandVI<VIGetVehicleTypeRequest>(command_msg));
 

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -269,6 +269,18 @@ class ApplicationManagerImplTest
     ASSERT_TRUE(mock_app_ptr_.get());
   }
 
+  void SetUpRequestForInterfacesAvailabilityExpectation(
+      hmi_apis::FunctionID::eType function_id) {
+    smart_objects::SmartObject sm_object(smart_objects::SmartType_Map);
+    sm_object[strings::params][strings::function_id] =
+        static_cast<int>(function_id);
+    smart_objects::SmartObjectSPtr sptr =
+        std::make_shared<smart_objects::SmartObject>(sm_object);
+
+    ON_CALL(*mock_message_helper_, CreateModuleInfoSO(function_id, _))
+        .WillByDefault(Return(sptr));
+  }
+
   application_manager::commands::MessageSharedPtr CreateCloseAppMessage() {
     using namespace application_manager;
 
@@ -350,6 +362,13 @@ class ApplicationManagerImplTest
   std::shared_ptr<NiceMock<usage_statistics_test::MockStatisticsManager> >
       mock_statistics_manager_;
 };
+
+MATCHER_P(HMIResultCodeIs, result_code, "") {
+  return result_code == static_cast<hmi_apis::FunctionID::eType>(
+                            (*arg)[application_manager::strings::params]
+                                  [application_manager::strings::function_id]
+                                      .asInt());
+}
 
 INSTANTIATE_TEST_CASE_P(
     ProcessServiceStatusUpdate_REQUEST_ACCEPTED,
@@ -2026,6 +2045,40 @@ TEST_F(ApplicationManagerImplTest, AddAndRemoveQueryAppDevice_SUCCESS) {
   EXPECT_TRUE(app_manager_impl_->IsAppsQueriedFrom(device_handle));
   app_manager_impl_->RemoveDevice(device_handle);
   EXPECT_FALSE(app_manager_impl_->IsAppsQueriedFrom(device_handle));
+}
+
+TEST_F(
+    ApplicationManagerImplTest,
+    RequestForInterfacesAvailability_AllRequestsWillBeSuccessfullyRequested) {
+  std::vector<hmi_apis::FunctionID::eType> expected_requests{
+      hmi_apis::FunctionID::VehicleInfo_IsReady,
+      hmi_apis::FunctionID::VR_IsReady,
+      hmi_apis::FunctionID::TTS_IsReady,
+      hmi_apis::FunctionID::UI_IsReady,
+      hmi_apis::FunctionID::RC_IsReady};
+
+  for (auto request : expected_requests) {
+    SetUpRequestForInterfacesAvailabilityExpectation(request);
+  }
+
+  EXPECT_CALL(
+      *mock_rpc_service_,
+      ManageHMICommand(
+          HMIResultCodeIs(hmi_apis::FunctionID::VehicleInfo_IsReady), _));
+  EXPECT_CALL(
+      *mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::VR_IsReady), _));
+  EXPECT_CALL(
+      *mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::TTS_IsReady), _));
+  EXPECT_CALL(
+      *mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::UI_IsReady), _));
+  EXPECT_CALL(
+      *mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::RC_IsReady), _));
+
+  app_manager_impl_->RequestForInterfacesAvailability();
 }
 
 }  // namespace application_manager_test

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -269,7 +269,7 @@ class ApplicationManagerImplTest
     ASSERT_TRUE(mock_app_ptr_.get());
   }
 
-  void SetUpCreateModuleInfoSOExpectation(
+  void SetExpectationForCreateModuleInfoSO(
       const hmi_apis::FunctionID::eType function_id) {
     smart_objects::SmartObject sm_object(smart_objects::SmartType_Map);
     sm_object[strings::params][strings::function_id] =
@@ -2057,9 +2057,10 @@ TEST_F(
       hmi_apis::FunctionID::RC_IsReady};
 
   for (auto request : expected_requests) {
-    SetUpCreateModuleInfoSOExpectation(request);
+    SetExpectationForCreateModuleInfoSO(request);
     EXPECT_CALL(*mock_rpc_service_,
-                ManageHMICommand(HMIResultCodeIs(request), _));
+                ManageHMICommand(HMIResultCodeIs(request),
+                                 commands::Command::SOURCE_HMI));
   }
 
   app_manager_impl_->RequestForInterfacesAvailability();

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -269,7 +269,7 @@ class ApplicationManagerImplTest
     ASSERT_TRUE(mock_app_ptr_.get());
   }
 
-  void SetUpRequestForInterfacesAvailabilityExpectation(
+  void SetUpCreateModuleInfoSOExpectation(
       const hmi_apis::FunctionID::eType function_id) {
     smart_objects::SmartObject sm_object(smart_objects::SmartType_Map);
     sm_object[strings::params][strings::function_id] =
@@ -2057,25 +2057,10 @@ TEST_F(
       hmi_apis::FunctionID::RC_IsReady};
 
   for (auto request : expected_requests) {
-    SetUpRequestForInterfacesAvailabilityExpectation(request);
+    SetUpCreateModuleInfoSOExpectation(request);
+    EXPECT_CALL(*mock_rpc_service_,
+                ManageHMICommand(HMIResultCodeIs(request), _));
   }
-
-  EXPECT_CALL(
-      *mock_rpc_service_,
-      ManageHMICommand(
-          HMIResultCodeIs(hmi_apis::FunctionID::VehicleInfo_IsReady), _));
-  EXPECT_CALL(
-      *mock_rpc_service_,
-      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::VR_IsReady), _));
-  EXPECT_CALL(
-      *mock_rpc_service_,
-      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::TTS_IsReady), _));
-  EXPECT_CALL(
-      *mock_rpc_service_,
-      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::UI_IsReady), _));
-  EXPECT_CALL(
-      *mock_rpc_service_,
-      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::RC_IsReady), _));
 
   app_manager_impl_->RequestForInterfacesAvailability();
 }

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -270,7 +270,7 @@ class ApplicationManagerImplTest
   }
 
   void SetUpRequestForInterfacesAvailabilityExpectation(
-      hmi_apis::FunctionID::eType function_id) {
+      const hmi_apis::FunctionID::eType function_id) {
     smart_objects::SmartObject sm_object(smart_objects::SmartType_Map);
     sm_object[strings::params][strings::function_id] =
         static_cast<int>(function_id);

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -274,8 +274,7 @@ class ApplicationManagerImplTest
     smart_objects::SmartObject sm_object(smart_objects::SmartType_Map);
     sm_object[strings::params][strings::function_id] =
         static_cast<int>(function_id);
-    smart_objects::SmartObjectSPtr sptr =
-        std::make_shared<smart_objects::SmartObject>(sm_object);
+    auto sptr = std::make_shared<smart_objects::SmartObject>(sm_object);
 
     ON_CALL(*mock_message_helper_, CreateModuleInfoSO(function_id, _))
         .WillByDefault(Return(sptr));

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -1217,7 +1217,7 @@ TEST_F(
   hmi_capabilities_->Init(last_state_wrapper_);
   hmi_capabilities_->set_active_tts_language(hmi_apis::Common_Language::RU_RU);
   const std::vector<std::string> sections_to_update{hmi_response::language};
-  const std::string content_to_save = "{\"TTS\": {\"language\":\"RU_RU\"}}";
+  const std::string content_to_save = "{\"TTS\": {\"language\":\"EN_US\"}}";
 
   CreateFile(kHmiCapabilitiesCacheFile);
   const std::vector<uint8_t> binary_data_to_save(content_to_save.begin(),

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -1209,7 +1209,7 @@ TEST_F(
     HMICapabilitiesTest,
     SaveCachedCapabilitiesToFile_LanguageIsNotTheSameAsPersisted_SaveNewLanguageToCache) {
   SetUpLanguageAndLightCapabilitiesExpectation();
-  std::string new_language = "RU_RU";
+  const std::string new_language = "RU_RU";
   ON_CALL(*(MockMessageHelper::message_helper_mock()),
           CommonLanguageToString(_))
       .WillByDefault(Return(new_language));


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
This PR increase unit tests coverage on persistence HMI capabilities . The commit created as fixup for [commit](https://github.com/LuxoftSDL/sdl_core/commit/b0995be0042cc6ab78f57795906c320ac86da129)

