### PR TITLE
SDL should reject creation of widgets that duplicate main window for apps having active web view template

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1209,6 +1209,12 @@ class ApplicationManagerImpl
   const std::string AppHMITypeToString(
       mobile_apis::AppHMIType::eType type) const;
 
+  mobile_apis::PredefinedLayout::eType StringToScreenPredefinedLayout(
+      const std::string& str) const OVERRIDE;
+
+  std::string ScreenPredefinedLayoutToString(
+      const mobile_apis::PredefinedLayout::eType& type) const OVERRIDE;
+
   /**
    * @brief Method compares arrays of app HMI type
    * @param from_policy contains app HMI type from policy

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
@@ -171,7 +171,7 @@ void CreateWindowRequest::Run() {
         mobile_apis::PredefinedWindows::DEFAULT_WINDOW;
 
     if (default_window_id == duplicate_updates_from_window_id) {
-      const std::string current_stringified_layout =
+      const auto current_stringified_layout =
           application->window_layout(default_window_id);
       const auto current_app_layout =
           application_manager_.StringToScreenPredefinedLayout(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
@@ -166,6 +166,25 @@ void CreateWindowRequest::Run() {
         (*message_)[strings::msg_params]
                    [strings::duplicate_updates_from_window_id]
                        .asInt();
+
+    const auto default_window_id =
+        mobile_apis::PredefinedWindows::DEFAULT_WINDOW;
+
+    if (default_window_id == duplicate_updates_from_window_id) {
+      const std::string current_stringified_layout =
+          application->window_layout(default_window_id);
+      const auto current_app_layout =
+          application_manager_.StringToScreenPredefinedLayout(
+              current_stringified_layout);
+      if (mobile_apis::PredefinedLayout::WEB_VIEW == current_app_layout) {
+        LOG4CXX_ERROR(logger_,
+                      "MAIN window has active template WEB_VIEW. Option: "
+                      "duplicate from main window is not allowed");
+        SendResponse(false, mobile_apis::Result::REJECTED);
+        return;
+      }
+    }
+
     if (!application->WindowIdExists(duplicate_updates_from_window_id)) {
       LOG4CXX_ERROR(logger_,
                     "Window with id #" << duplicate_updates_from_window_id

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -486,7 +486,7 @@ void RegisterAppInterfaceRequest::Run() {
         }
         case mobile_apis::AppHMIType::WEB_VIEW: {
           application->set_webengine_projection_enabled(true);
-          const std::string default_webview_layout =
+          const auto default_webview_layout =
               application_manager_.ScreenPredefinedLayoutToString(
                   mobile_apis::PredefinedLayout::WEB_VIEW);
           application->set_window_layout(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -486,6 +486,12 @@ void RegisterAppInterfaceRequest::Run() {
         }
         case mobile_apis::AppHMIType::WEB_VIEW: {
           application->set_webengine_projection_enabled(true);
+          const std::string default_webview_layout =
+              application_manager_.ScreenPredefinedLayoutToString(
+                  mobile_apis::PredefinedLayout::WEB_VIEW);
+          application->set_window_layout(
+              mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
+              default_webview_layout);
           break;
         }
         default: {}

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_window_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_window_request_test.cc
@@ -293,6 +293,80 @@ TEST_F(
   command->Run();
 }
 
+TEST_F(
+    CreateWindowRequestTest,
+    Run_DuplicateUpdatesFromMainWindowWithActiveWebViewTemplate_ExpectRejectedCreateWindow) {
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::UI_CreateWindow),
+                       Command::CommandSource::SOURCE_SDL_TO_HMI))
+      .Times(0);
+
+  const auto mobile_result_code = mobile_apis::Result::REJECTED;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(CheckMessageToMobile(mobile_result_code, false),
+                          Command::CommandSource::SOURCE_SDL))
+      .WillOnce(Return(true));
+
+  const auto default_window_id = mobile_apis::PredefinedWindows::DEFAULT_WINDOW;
+  ON_CALL(*mock_app_, WindowIdExists(kTestWindowId))
+      .WillByDefault(Return(false));
+  ON_CALL(*mock_app_, WindowIdExists(default_window_id))
+      .WillByDefault(Return(true));
+  ON_CALL(*mock_app_, name()).WillByDefault(ReturnRef(kAppName));
+  const std::string web_view_layout{"WEB_VIEW"};
+  ON_CALL(*mock_app_, window_layout(default_window_id))
+      .WillByDefault(Return(web_view_layout));
+  ON_CALL(*mock_app_, GetWindowNames())
+      .WillByDefault(Return(std::vector<std::string>()));
+
+  ON_CALL(app_mngr_, StringToScreenPredefinedLayout(web_view_layout))
+      .WillByDefault(Return(mobile_apis::PredefinedLayout::WEB_VIEW));
+
+  auto msg = CreateMsgParams();
+  auto& msg_params = (*msg)[am::strings::msg_params];
+  msg_params[am::strings::window_id] = kTestWindowId;
+  msg_params[am::strings::duplicate_updates_from_window_id] = default_window_id;
+  msg_params[am::strings::window_type] = mobile_apis::WindowType::WIDGET;
+
+  auto command = CreateCommand<CreateWindowRequest>(msg);
+  ASSERT_TRUE(command->Init());
+  command->Run();
+}
+
+TEST_F(
+    CreateWindowRequestTest,
+    Run_DuplicateUpdatesFromWidgetWhileMainWindowHasActiveWebViewTemplate_ExpectCreateWindowSentToHMI) {
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::UI_CreateWindow),
+                       Command::CommandSource::SOURCE_SDL_TO_HMI));
+
+  ON_CALL(*mock_app_, WindowIdExists(kDuplicateWindowID))
+      .WillByDefault(Return(true));
+  ON_CALL(*mock_app_, WindowIdExists(kTestWindowId))
+      .WillByDefault(Return(false));
+  ON_CALL(*mock_app_, name()).WillByDefault(ReturnRef(kAppName));
+  const std::string web_view_layout{"WEB_VIEW"};
+  const auto default_window_id = mobile_apis::PredefinedWindows::DEFAULT_WINDOW;
+  ON_CALL(*mock_app_, window_layout(default_window_id))
+      .WillByDefault(Return(web_view_layout));
+  ON_CALL(*mock_app_, GetWindowNames())
+      .WillByDefault(Return(std::vector<std::string>()));
+
+  auto msg = CreateMsgParams();
+  auto& msg_params = (*msg)[am::strings::msg_params];
+  msg_params[am::strings::window_id] = kTestWindowId;
+  msg_params[am::strings::duplicate_updates_from_window_id] =
+      kDuplicateWindowID;
+  msg_params[am::strings::window_type] = mobile_apis::WindowType::WIDGET;
+
+  auto command = CreateCommand<CreateWindowRequest>(msg);
+  ASSERT_TRUE(command->Init());
+  command->Run();
+}
+
 TEST_F(CreateWindowRequestTest,
        Run_WindowNameAppNameAreEqual_ExpectDuplicateNameResponseToMobile) {
   const auto result_code = mobile_apis::Result::DUPLICATE_NAME;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -854,6 +854,14 @@ TEST_F(RegisterAppInterfaceRequestTest,
               ManageMobileCommand(_, am::commands::Command::SOURCE_SDL))
       .Times(2);
   EXPECT_CALL(app_mngr_, SendDriverDistractionState(app));
+  const std::string default_webview_layout{"WEB_VIEW"};
+  EXPECT_CALL(
+      app_mngr_,
+      ScreenPredefinedLayoutToString(mobile_apis::PredefinedLayout::WEB_VIEW))
+      .WillOnce(Return(default_webview_layout));
+  EXPECT_CALL(*mock_app,
+              set_window_layout(mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
+                                default_webview_layout));
 
   ASSERT_TRUE(command_->Init());
   command_->Run();
@@ -878,6 +886,14 @@ TEST_F(RegisterAppInterfaceRequestTest,
       .WillOnce(DoAll(SaveArg<0>(&response_to_mobile), Return(true)))
       .WillOnce(Return(true));
 
+  EXPECT_CALL(
+      app_mngr_,
+      ScreenPredefinedLayoutToString(mobile_apis::PredefinedLayout::WEB_VIEW))
+      .Times(0);
+  EXPECT_CALL(
+      *mock_app,
+      set_window_layout(mobile_apis::PredefinedWindows::DEFAULT_WINDOW, _))
+      .Times(0);
   ASSERT_TRUE(command_->Init());
   command_->Run();
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4202,6 +4202,8 @@ mobile_apis::AppHMIType::eType ApplicationManagerImpl::StringToAppHMIType(
     return mobile_apis::AppHMIType::TESTING;
   } else if ("SYSTEM" == str) {
     return mobile_apis::AppHMIType::SYSTEM;
+  } else if ("WEB_VIEW" == str) {
+    return mobile_apis::AppHMIType::WEB_VIEW;
   } else {
     return mobile_apis::AppHMIType::INVALID_ENUM;
   }
@@ -4235,6 +4237,112 @@ const std::string ApplicationManagerImpl::AppHMITypeToString(
       return "PROJECTION";
     case mobile_apis::AppHMIType::REMOTE_CONTROL:
       return "REMOTE_CONTROL";
+    case mobile_apis::AppHMIType::WEB_VIEW:
+      return "WEB_VIEW";
+    default:
+      return "INVALID_ENUM";
+  }
+}
+
+mobile_apis::PredefinedLayout::eType
+ApplicationManagerImpl::StringToScreenPredefinedLayout(
+    const std::string& str) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using ScreenLayout = mobile_apis::PredefinedLayout::eType;
+  if ("DEFAULT" == str) {
+    return ScreenLayout::DEFAULT;
+  } else if ("MEDIA" == str) {
+    return ScreenLayout::MEDIA;
+  } else if ("NON_MEDIA" == str) {
+    return ScreenLayout::NON_MEDIA;
+  } else if ("ONSCREEN_PRESETS" == str) {
+    return ScreenLayout::ONSCREEN_PRESETS;
+  } else if ("NAV_FULLSCREEN_MAP" == str) {
+    return ScreenLayout::NAV_FULLSCREEN_MAP;
+  } else if ("NAV_LIST" == str) {
+    return ScreenLayout::NAV_LIST;
+  } else if ("NAV_KEYBOARD" == str) {
+    return ScreenLayout::NAV_KEYBOARD;
+  } else if ("GRAPHIC_WITH_TEXT" == str) {
+    return ScreenLayout::GRAPHIC_WITH_TEXT;
+  } else if ("TEXT_WITH_GRAPHIC" == str) {
+    return ScreenLayout::TEXT_WITH_GRAPHIC;
+  } else if ("TILES_ONLY" == str) {
+    return ScreenLayout::TILES_ONLY;
+  } else if ("TEXTBUTTONS_ONLY" == str) {
+    return ScreenLayout::TEXTBUTTONS_ONLY;
+  } else if ("GRAPHIC_WITH_TILES" == str) {
+    return ScreenLayout::GRAPHIC_WITH_TILES;
+  } else if ("TILES_WITH_GRAPHIC" == str) {
+    return ScreenLayout::TILES_WITH_GRAPHIC;
+  } else if ("GRAPHIC_WITH_TEXT_AND_SOFTBUTTONS" == str) {
+    return ScreenLayout::GRAPHIC_WITH_TEXT_AND_SOFTBUTTONS;
+  } else if ("TEXT_AND_SOFTBUTTONS_WITH_GRAPHIC" == str) {
+    return ScreenLayout::TEXT_AND_SOFTBUTTONS_WITH_GRAPHIC;
+  } else if ("GRAPHIC_WITH_TEXTBUTTONS" == str) {
+    return ScreenLayout::GRAPHIC_WITH_TEXTBUTTONS;
+  } else if ("TEXTBUTTONS_WITH_GRAPHIC" == str) {
+    return ScreenLayout::TEXTBUTTONS_WITH_GRAPHIC;
+  } else if ("LARGE_GRAPHIC_WITH_SOFTBUTTONS" == str) {
+    return ScreenLayout::LARGE_GRAPHIC_WITH_SOFTBUTTONS;
+  } else if ("DOUBLE_GRAPHIC_WITH_SOFTBUTTONS" == str) {
+    return ScreenLayout::DOUBLE_GRAPHIC_WITH_SOFTBUTTONS;
+  } else if ("LARGE_GRAPHIC_ONLY" == str) {
+    return ScreenLayout::LARGE_GRAPHIC_ONLY;
+  } else if ("WEB_VIEW" == str) {
+    return ScreenLayout::WEB_VIEW;
+  } else {
+    return ScreenLayout::INVALID_ENUM;
+  }
+}
+
+std::string ApplicationManagerImpl::ScreenPredefinedLayoutToString(
+    const mobile_apis::PredefinedLayout::eType& type) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using ScreenLayout = mobile_apis::PredefinedLayout::eType;
+  switch (type) {
+    case ScreenLayout::DEFAULT:
+      return "DEFAULT";
+    case ScreenLayout::MEDIA:
+      return "MEDIA";
+    case ScreenLayout::NON_MEDIA:
+      return "NON_MEDIA";
+    case ScreenLayout::ONSCREEN_PRESETS:
+      return "ONSCREEN_PRESETS";
+    case ScreenLayout::NAV_FULLSCREEN_MAP:
+      return "NAV_FULLSCREEN_MAP";
+    case ScreenLayout::NAV_LIST:
+      return "NAV_LIST";
+    case ScreenLayout::NAV_KEYBOARD:
+      return "NAV_KEYBOARD";
+    case ScreenLayout::GRAPHIC_WITH_TEXT:
+      return "GRAPHIC_WITH_TEXT";
+    case ScreenLayout::TEXT_WITH_GRAPHIC:
+      return "TEXT_WITH_GRAPHIC";
+    case ScreenLayout::TILES_ONLY:
+      return "TILES_ONLY";
+    case ScreenLayout::TEXTBUTTONS_ONLY:
+      return "TEXTBUTTONS_ONLY";
+    case ScreenLayout::GRAPHIC_WITH_TILES:
+      return "GRAPHIC_WITH_TILES";
+    case ScreenLayout::TILES_WITH_GRAPHIC:
+      return "TILES_WITH_GRAPHIC";
+    case ScreenLayout::GRAPHIC_WITH_TEXT_AND_SOFTBUTTONS:
+      return "GRAPHIC_WITH_TEXT_AND_SOFTBUTTONS";
+    case ScreenLayout::TEXT_AND_SOFTBUTTONS_WITH_GRAPHIC:
+      return "TEXT_AND_SOFTBUTTONS_WITH_GRAPHIC";
+    case ScreenLayout::GRAPHIC_WITH_TEXTBUTTONS:
+      return "GRAPHIC_WITH_TEXTBUTTONS";
+    case ScreenLayout::TEXTBUTTONS_WITH_GRAPHIC:
+      return "TEXTBUTTONS_WITH_GRAPHIC";
+    case ScreenLayout::LARGE_GRAPHIC_WITH_SOFTBUTTONS:
+      return "LARGE_GRAPHIC_WITH_SOFTBUTTONS";
+    case ScreenLayout::DOUBLE_GRAPHIC_WITH_SOFTBUTTONS:
+      return "DOUBLE_GRAPHIC_WITH_SOFTBUTTONS";
+    case ScreenLayout::LARGE_GRAPHIC_ONLY:
+      return "LARGE_GRAPHIC_ONLY";
+    case ScreenLayout::WEB_VIEW:
+      return "WEB_VIEW";
     default:
       return "INVALID_ENUM";
   }

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -186,6 +186,22 @@ class ApplicationManager {
    */
   virtual void RemovePendingApplication(const std::string& policy_app_id) = 0;
 
+  /**
+   * @brief Method transforms string to screen PredefinedLayout enum
+   * @param str contains string with screen PredefinedLayout
+   * @return enum PredefinedLayout
+   */
+  virtual mobile_apis::PredefinedLayout::eType StringToScreenPredefinedLayout(
+      const std::string& str) const = 0;
+
+  /**
+   * @brief Returns a string representation of screen PredefinedLayout enum
+   * @param type an enum value of screen PredefinedLayout
+   * @return string representation of the enum value
+   */
+  virtual std::string ScreenPredefinedLayoutToString(
+      const mobile_apis::PredefinedLayout::eType& type) const = 0;
+
   virtual DataAccessor<ReregisterWaitList> reregister_applications() const = 0;
 
   virtual ApplicationSharedPtr application(uint32_t app_id) const = 0;

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -91,6 +91,12 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(RemovePendingApplication,
                void(const std::string& policy_app_id));
   MOCK_CONST_METHOD1(
+      StringToScreenPredefinedLayout,
+      mobile_apis::PredefinedLayout::eType(const std::string& str));
+  MOCK_CONST_METHOD1(
+      ScreenPredefinedLayoutToString,
+      std::string(const mobile_apis::PredefinedLayout::eType& type));
+  MOCK_CONST_METHOD1(
       application, application_manager::ApplicationSharedPtr(uint32_t app_id));
   MOCK_CONST_METHOD0(active_application,
                      application_manager::ApplicationSharedPtr());


### PR DESCRIPTION
Fixes: [0273](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0273-webengine-projection-mode.md)

[JIRA](https://adc.luxoft.com/jira/browse/FORDTCN-5926)

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Unit tests are included in current PR
ATF test scripts will be created afrewards as separate PR.

### Summary
 - Implemented internal SDL setup of default template screen layout for apps registered with AppHMIType "WEB_VIEW"
 - Implemented Widgets rejection while app has active template WEB_VIEW 
 - Added unit test cases for RAI requests and for CreateWindow requests which cover the functionality described above.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
