### PR TITLE
Fix/after web view app registration rejected unable to register other app

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -1023,7 +1023,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
       (*response_to_mobile)[am::strings::msg_params][am::strings::result_code]
           .asUInt());
 
-  EXPECT_EQ(mobile_apis::Result::REJECTED, result_code);
+  EXPECT_EQ(mobile_apis::Result::DISALLOWED, result_code);
 }
 
 TEST_F(RegisterAppInterfaceRequestTest,
@@ -1060,7 +1060,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
   const auto result_code = static_cast<mobile_apis::Result::eType>(
       (*response_to_mobile)[am::strings::msg_params][am::strings::result_code]
           .asUInt());
-  EXPECT_EQ(mobile_apis::Result::REJECTED, result_code);
+  EXPECT_EQ(mobile_apis::Result::DISALLOWED, result_code);
 }
 
 TEST_F(RegisterAppInterfaceRequestTest,
@@ -1093,7 +1093,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
       (*response_to_mobile)[am::strings::msg_params][am::strings::result_code]
           .asUInt());
 
-  EXPECT_EQ(mobile_apis::Result::REJECTED, result_code);
+  EXPECT_EQ(mobile_apis::Result::DISALLOWED, result_code);
 }
 
 }  // namespace register_app_interface_request

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -1605,6 +1605,7 @@ void ConnectionHandlerImpl::CloseConnectionSessions(
 }
 
 void ConnectionHandlerImpl::SendEndService(uint32_t key, uint8_t service_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (protocol_handler_) {
     uint32_t connection_handle = 0;
     uint8_t session_id = 0;

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -650,6 +650,7 @@ void ProtocolHandlerImpl::SendEndServicePrivate(int32_t primary_connection_id,
 
 void ProtocolHandlerImpl::SendEndSession(int32_t connection_id,
                                          uint8_t session_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
   // A session is always associated with a primary connection ID
   SendEndServicePrivate(
       connection_id, connection_id, session_id, SERVICE_TYPE_RPC);
@@ -659,6 +660,7 @@ void ProtocolHandlerImpl::SendEndService(int32_t primary_connection_id,
                                          int32_t connection_id,
                                          uint8_t session_id,
                                          uint8_t service_type) {
+  LOG4CXX_AUTO_TRACE(logger_);
   SendEndServicePrivate(
       primary_connection_id, connection_id, session_id, service_type);
 }

--- a/src/components/transport_manager/src/cloud/websocket_client_connection.cc
+++ b/src/components/transport_manager/src/cloud/websocket_client_connection.cc
@@ -284,6 +284,7 @@ TransportAdapter::Error WebsocketClientConnection::Disconnect() {
 }
 
 void WebsocketClientConnection::Shutdown() {
+  LOG4CXX_AUTO_TRACE(logger_);
   shutdown_ = true;
 
   if (thread_delegate_) {

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -521,6 +521,7 @@ DeviceSptr TransportAdapterImpl::GetWebEngineDevice() const {
 }
 
 DeviceSptr TransportAdapterImpl::AddDevice(DeviceSptr device) {
+  LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_TRACE(logger_, "enter. device: " << device);
   DeviceSptr existing_device;
   bool same_device_found = false;
@@ -530,7 +531,7 @@ DeviceSptr TransportAdapterImpl::AddDevice(DeviceSptr device) {
     existing_device = i->second;
     if (device->IsSameAs(existing_device.get())) {
       same_device_found = true;
-      LOG4CXX_DEBUG(logger_, "device " << device << "already exists");
+      LOG4CXX_DEBUG(logger_, "Device " << device << " already exists");
       break;
     }
   }
@@ -539,7 +540,7 @@ DeviceSptr TransportAdapterImpl::AddDevice(DeviceSptr device) {
   }
   devices_mutex_.Release();
   if (same_device_found) {
-    LOG4CXX_TRACE(logger_, "exit with TRUE. Condition: same_device_found");
+    LOG4CXX_TRACE(logger_, "Exit with TRUE. Condition: same_device_found");
     return existing_device;
   } else {
     device->set_connection_status(ConnectionStatus::PENDING);
@@ -677,6 +678,7 @@ void TransportAdapterImpl::ConnectionCreated(
     ConnectionSPtr connection,
     const DeviceUID& device_id,
     const ApplicationHandle& app_handle) {
+  LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_TRACE(logger_,
                 "enter connection:" << connection
                                     << ", device_id: " << &device_id
@@ -692,6 +694,7 @@ void TransportAdapterImpl::ConnectionCreated(
 
 void TransportAdapterImpl::DeviceDisconnected(
     const DeviceUID& device_handle, const DisconnectDeviceError& error) {
+  LOG4CXX_AUTO_TRACE(logger_);
   const DeviceUID device_uid = device_handle;
   LOG4CXX_TRACE(
       logger_,
@@ -730,6 +733,7 @@ void TransportAdapterImpl::DeviceDisconnected(
 
 bool TransportAdapterImpl::IsSingleApplication(
     const DeviceUID& device_uid, const ApplicationHandle& app_uid) {
+  LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoReadLock locker(connections_lock_);
   for (ConnectionMap::const_iterator it = connections_.begin();
        it != connections_.end();
@@ -749,6 +753,7 @@ bool TransportAdapterImpl::IsSingleApplication(
 
 void TransportAdapterImpl::DisconnectDone(const DeviceUID& device_handle,
                                           const ApplicationHandle& app_handle) {
+  LOG4CXX_AUTO_TRACE(logger_);
   const DeviceUID device_uid = device_handle;
   const ApplicationHandle app_uid = app_handle;
   LOG4CXX_TRACE(
@@ -775,6 +780,7 @@ void TransportAdapterImpl::DisconnectDone(const DeviceUID& device_handle,
   RemoveConnection(device_uid, app_uid);
 
   if (device_disconnected) {
+    LOG4CXX_DEBUG(logger_, "Removing device...");
     RemoveDevice(device_uid);
   }
 
@@ -1026,6 +1032,7 @@ void TransportAdapterImpl::RemoveFinalizedConnection(
 
 void TransportAdapterImpl::RemoveConnection(
     const DeviceUID& device_id, const ApplicationHandle& app_handle) {
+  LOG4CXX_AUTO_TRACE(logger_);
   ConnectionSPtr connection;
   connections_lock_.AcquireForWriting();
   ConnectionMap::const_iterator it =
@@ -1071,6 +1078,7 @@ ApplicationList TransportAdapterImpl::GetApplicationList(
 
 void TransportAdapterImpl::ConnectionFinished(
     const DeviceUID& device_id, const ApplicationHandle& app_handle) {
+  LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_TRACE(
       logger_,
       "enter. device_id: " << &device_id << ", app_handle: " << &app_handle);
@@ -1088,6 +1096,7 @@ void TransportAdapterImpl::ConnectionAborted(
     const DeviceUID& device_id,
     const ApplicationHandle& app_handle,
     const CommunicationError& error) {
+  LOG4CXX_AUTO_TRACE(logger_);
   ConnectionFinished(device_id, app_handle);
   for (TransportAdapterListenerList::iterator it = listeners_.begin();
        it != listeners_.end();
@@ -1192,6 +1201,7 @@ bool TransportAdapterImpl::ToBeAutoConnected(DeviceSptr device) const {
 }
 
 bool TransportAdapterImpl::ToBeAutoDisconnected(DeviceSptr device) const {
+  LOG4CXX_AUTO_TRACE(logger_);
   return true;
 }
 

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_listener_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_listener_impl.cc
@@ -203,6 +203,7 @@ void TransportAdapterListenerImpl::OnDisconnectDone(
     const TransportAdapter* adapter,
     const DeviceUID& device,
     const ApplicationHandle& app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
   LOG4CXX_TRACE(logger_,
                 "enter. adapter: " << adapter << ", device: " << &device
                                    << ", application_id: " << &app_id);
@@ -245,7 +246,9 @@ void TransportAdapterListenerImpl::OnDisconnectFailed(
 }
 
 void TransportAdapterListenerImpl::OnDisconnectDeviceDone(
-    const TransportAdapter* adapter, const DeviceUID& device) {}
+    const TransportAdapter* adapter, const DeviceUID& device) {
+  LOG4CXX_AUTO_TRACE(logger_);
+}
 
 void TransportAdapterListenerImpl::OnDisconnectDeviceFailed(
     const TransportAdapter* adapter,

--- a/src/components/transport_manager/src/websocket_server/websocket_connection.cc
+++ b/src/components/transport_manager/src/websocket_server/websocket_connection.cc
@@ -100,6 +100,12 @@ WebSocketConnection<Session>::~WebSocketConnection() {
 template <typename Session>
 void WebSocketConnection<Session>::OnError() {
   LOG4CXX_AUTO_TRACE(wsc_logger_);
+
+  if (IsShuttingDown()) {
+    LOG4CXX_DEBUG(wsc_logger_, "Session is shutting down...");
+    return;
+  }
+
   Message message_ptr;
   while (message_queue_.pop(message_ptr)) {
     DataSendFailed(message_ptr);


### PR DESCRIPTION
Partially Fixes [Jira](https://adc.luxoft.com/jira/browse/FORDTCN-6040)

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF test scripts

### Summary

 - Added check to OnError callback function to avoid connection abort when the session is being shutdown intentionally.

 - Replaced inappropriate result code `REJECTED` by `DISALLLOWED` when `WEB_VIEW` app is disallowed to be registered when `WEB_VIEW` app hmi type is not allowed for the specified app.

- Changed some variables naming in order to avoid confusing when differentiating app hmi types in RAI message and app hmi types form policy DB.

- Added logging in missed places

- Updated UT to used correct result code



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
