### PR TITLE
Add methods to acquire/release internal collection lock.

### DIFF
--- a/src/components/application_manager/include/application_manager/request_info.h
+++ b/src/components/application_manager/include/application_manager/request_info.h
@@ -48,7 +48,7 @@ namespace application_manager {
 
 namespace request_controller {
 
-/*
+/**
  * @brief Typedef for active mobile request
  *
  */
@@ -174,7 +174,7 @@ typedef std::set<RequestInfoPtr, RequestInfoTimeComparator>
 typedef std::set<RequestInfoPtr, RequestInfoHashComparator>
     HashSortedRequestInfoSet;
 
-/*
+/**
  * @brief RequestInfoSet provides uniue requests bu corralation_id and app_id
  *
  */
@@ -185,14 +185,19 @@ class RequestInfoSet {
    */
   ~RequestInfoSet();
 
-  /*
+  /**
+   * @brief Default constructor
+   */
+  RequestInfoSet();
+
+  /**
    * @brief Add requests into colletion by log(n) time
    * @param request_info - request to add
    * @return false is request with the same app_id and correlation_id exist
    */
   bool Add(RequestInfoPtr request_info);
 
-  /*
+  /**
    * @brief Find requests int colletion by log(n) time
    * @param connection_key - connection_key of request
    * @param correlation_id - correlation_id of request
@@ -201,45 +206,55 @@ class RequestInfoSet {
   RequestInfoPtr Find(const uint32_t connection_key,
                       const uint32_t correlation_id) const;
 
-  /*
+  /**
    * @brief Get request with smalest end_time_
    * @return founded request or shared_ptr with NULL
    */
   RequestInfoPtr Front();
 
-  /*
+  /**
    * @brief Get request with smalest end_time_ != 0
    * @return founded request or shared_ptr with NULL
    */
   RequestInfoPtr FrontWithNotNullTimeout();
 
-  /*
+  /**
    * @brief Erase request from colletion by log(n) time
    * @param request_info - request to erase
    * @return true if Erase succes, otherwise return false
    */
   bool RemoveRequest(const RequestInfoPtr request_info);
 
-  /*
+  /**
    * @brief Erase request from colletion by connection_key
    * @param connection_key - connection_key of requests to erase
    * @return count of erased requests
    */
   uint32_t RemoveByConnectionKey(uint32_t connection_key);
 
-  /*
+  /**
    * @brief Erase all mobile requests from controller
    * @return count of erased requests
    */
   uint32_t RemoveMobileRequests();
 
-  /*
+  /**
    * @return count of requestd in collections
    */
   const size_t Size();
 
+  /**
+   * @brief Locks info sets using internal lock
+   */
+  void LockInfoSet();
+
+  /**
+   * @brief Unlocks info sets using internal lock
+   */
+  void UnlockInfoSet();
+
  private:
-  /*
+  /**
    * @brief Comparator of connection key for std::find_if function
    */
   struct AppIdCompararator {
@@ -255,21 +270,21 @@ class RequestInfoSet {
 
   bool Erase(const RequestInfoPtr request_info);
 
-  /*
+  /**
    * @brief Erase requests from collection if filter allows
    * @param filter - filtering predicate
    * @return count of erased requests
    */
   uint32_t RemoveRequests(const RequestInfoSet::AppIdCompararator& filter);
 
-  /*
+  /**
    * @brief Debug function, will raise assert if set sizes are noit equal
    */
   inline void CheckSetSizes();
   TimeSortedRequestInfoSet time_sorted_pending_requests_;
   HashSortedRequestInfoSet hash_sorted_pending_requests_;
 
-  mutable sync_primitives::Lock pending_requests_lock_;
+  mutable sync_primitives::RecursiveLock pending_requests_lock_;
 };
 
 /**
@@ -305,6 +320,5 @@ struct TimeScale {
 };
 
 }  //  namespace request_controller
-
 }  //  namespace application_manager
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_REQUEST_INFO_H_

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -30,12 +30,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "utils/logger.h"
-
+#include "application_manager/request_controller_impl.h"
 #include "application_manager/commands/command_request_impl.h"
 #include "application_manager/commands/request_to_hmi.h"
-#include "application_manager/request_controller_impl.h"
 
+#include "utils/logger.h"
+#include "utils/scope_guard.h"
 #include "utils/timer_task_impl.h"
 
 namespace application_manager {
@@ -281,6 +281,10 @@ void RequestControllerImpl::TerminateRequest(const uint32_t correlation_id,
     }
   }
 
+  waiting_for_response_.LockInfoSet();
+  utils::ScopeGuard guard = utils::MakeObjGuard(waiting_for_response_,
+                                                &RequestInfoSet::UnlockInfoSet);
+
   RequestInfoPtr request =
       waiting_for_response_.Find(connection_key, correlation_id);
   if (!request) {
@@ -300,6 +304,9 @@ void RequestControllerImpl::TerminateRequest(const uint32_t correlation_id,
   } else {
     SDL_LOG_WARN("Request was not terminated");
   }
+  waiting_for_response_.UnlockInfoSet();
+  guard.Dismiss();
+
   NotifyTimer();
 }
 
@@ -383,12 +390,19 @@ void RequestControllerImpl::UpdateRequestTimeout(const uint32_t app_id,
       "New_timeout is NULL. RequestCtrl will "
       "not manage this request any more");
 
+  waiting_for_response_.LockInfoSet();
+  utils::ScopeGuard guard = utils::MakeObjGuard(waiting_for_response_,
+                                                &RequestInfoSet::UnlockInfoSet);
+
   RequestInfoPtr request_info =
       waiting_for_response_.Find(app_id, correlation_id);
   if (request_info) {
     waiting_for_response_.RemoveRequest(request_info);
     request_info->updateTimeOut(new_timeout);
     waiting_for_response_.Add(request_info);
+    waiting_for_response_.UnlockInfoSet();
+    guard.Dismiss();
+
     NotifyTimer();
     SDL_LOG_INFO("Timeout updated for "
                  << " app_id: " << app_id << " correlation_id: "
@@ -424,9 +438,15 @@ void RequestControllerImpl::TimeoutThread() {
       "ENTER Waiting fore response count: " << waiting_for_response_.Size());
   sync_primitives::AutoLock auto_lock(timer_lock);
   while (!timer_stop_flag_) {
+    waiting_for_response_.LockInfoSet();
+    utils::ScopeGuard guard = utils::MakeObjGuard(
+        waiting_for_response_, &RequestInfoSet::UnlockInfoSet);
+
     RequestInfoPtr probably_expired =
         waiting_for_response_.FrontWithNotNullTimeout();
     if (!probably_expired) {
+      waiting_for_response_.UnlockInfoSet();
+      guard.Dismiss();
       timer_condition_.Wait(auto_lock);
       continue;
     }
@@ -445,6 +465,8 @@ void RequestControllerImpl::TimeoutThread() {
         const uint32_t msecs =
             static_cast<uint32_t>(date_time::getmSecs(end_time - current_time));
         SDL_LOG_DEBUG("Sleep for " << msecs << " millisecs");
+        waiting_for_response_.UnlockInfoSet();
+        guard.Dismiss();
         timer_condition_.WaitFor(auto_lock, msecs);
       }
       continue;

--- a/src/components/application_manager/src/request_info.cc
+++ b/src/components/application_manager/src/request_info.cc
@@ -36,6 +36,7 @@
 #include "application_manager/request_info.h"
 
 #include <algorithm>
+
 namespace application_manager {
 
 namespace request_controller {
@@ -124,6 +125,8 @@ RequestInfoSet::~RequestInfoSet() {
     it = time_sorted_pending_requests_.begin();
   }
 }
+
+RequestInfoSet::RequestInfoSet() : pending_requests_lock_() {}
 
 bool RequestInfoSet::Add(RequestInfoPtr request_info) {
   DCHECK_OR_RETURN(request_info, false);
@@ -266,6 +269,14 @@ const size_t RequestInfoSet::Size() {
   sync_primitives::AutoLock lock(pending_requests_lock_);
   CheckSetSizes();
   return time_sorted_pending_requests_.size();
+}
+
+void RequestInfoSet::LockInfoSet() {
+  pending_requests_lock_.Acquire();
+}
+
+void RequestInfoSet::UnlockInfoSet() {
+  pending_requests_lock_.Release();
 }
 
 void RequestInfoSet::CheckSetSizes() {


### PR DESCRIPTION
Relates to the Luxoft Jira issue https://adc.luxoft.com/jira/browse/FORDTCN-6602

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
In some cases request controller must hold this internal lock to avoid possible data races in Find-Remove sequences. Added scope guards to unlock internal lock when it is not needed automatically.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)