### PR TITLE
Fix/0190 fix widget support

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -334,19 +334,6 @@ RegisterAppInterfaceRequest::ApplicationDataShouldBeResumed(
     return mobile_apis::Result::RESUME_FAILED;
   }
 
-  // In case application exist in resumption we need to send resumeVrgrammars
-  const bool is_app_saved_in_resumption = resumer.IsApplicationSaved(
-      application->policy_app_id(), application->mac_address());
-
-  // If app is in resuming state
-  // DisplayCapabilitiesBuilder has to collect all the information
-  // from incoming HMI notifications and send only one notification
-  // to mobile app, even if hash does not match, which means that app data
-  // will not be resumed, notification should be sent for default window as
-  // it will be resumed in any case
-  if (resumption || is_app_saved_in_resumption) {
-    resumer.StartWaitingForDisplayCapabilitiesUpdate(application);
-  }
   if (!resumer.CheckApplicationHash(application, hash_id)) {
     LOG4CXX_WARN(logger_, "Hash from RAI does not match to saved resume data.");
     add_info = "Hash from RAI does not match to saved resume data.";
@@ -364,6 +351,21 @@ RegisterAppInterfaceRequest::ApplicationDataShouldBeResumed(
     application->set_is_resuming(true);
     result_code_ = mobile_apis::Result::SUCCESS;
   }
+
+  // In case application exist in resumption we need to send resumeVrgrammars
+  const bool is_app_saved_in_resumption = resumer.IsApplicationSaved(
+      application->policy_app_id(), application->mac_address());
+
+  // If app is in resuming state
+  // DisplayCapabilitiesBuilder has to collect all the information
+  // from incoming HMI notifications and send only one notification
+  // to mobile app, even if hash does not match, which means that app data
+  // will not be resumed, notification should be sent for default window as
+  // it will be resumed in any case
+  if (resumption || is_app_saved_in_resumption) {
+    resumer.StartWaitingForDisplayCapabilitiesUpdate(application);
+  }
+
   return result_code_;
 }
 

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -545,7 +545,6 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
     const std::string& saved_hash = saved_app[strings::hash_id].asString();
     result = saved_hash == hash ? RestoreApplicationData(application, callback)
                                 : false;
-    AddToResumptionTimerQueue(application->app_id());
   }
   return result;
 }

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -537,13 +537,6 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
                           << " received hash = " << hash);
   application->set_is_resuming(true);
 
-  if (!application->is_cloud_app()) {
-    // Default HMI Level is already set before resumption in
-    // ApplicationManager::OnApplicationRegistered, and handling low bandwidth
-    // transports doesn't apply to cloud apps, so this step can be skipped for
-    // such apps
-    SetupDefaultHMILevel(application);
-  }
   smart_objects::SmartObject saved_app;
   const std::string& device_mac = application->mac_address();
   bool result = resumption_storage_->GetSavedApplication(


### PR DESCRIPTION
Fixes #[6992](https://adc.luxoft.com/jira/browse/FORDTCN-6992)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fix regression defects, related to fails of following scripts:

./test_scripts/WidgetSupport/Resumption/001_Resumption_CreateWindow_IGN_OFF_ON_Cycle.lua

./test_scripts/WidgetSupport/Resumption/002_Resumption_CreateWindow_Unexpected_Disconnect.lua

./test_scripts/WidgetSupport/Resumption/003_Resumption_CreateWindows_3_Widgets_IGN_OFF_ON_Cycle.lua

./test_scripts/WidgetSupport/Resumption/004_Resumption_CreateWindow_2_App_Unexpected_Disconnect.lua

./test_scripts/WidgetSupport/Resumption/005_Resumption_CreateWindows_3_Widgets_Unexpected_Disconnect_error_HMI_response.lua


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
