### PR TITLE
Fix/fix sdl crash on resumption request timeout

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -75,6 +75,8 @@ class VehicleInfoPendingResumptionHandler
   void ClearPendingResumptionRequests() OVERRIDE;
 
  private:
+  void ClearPendingRequestsMap();
+
   struct ResumptionAwaitingHandling {
     const uint32_t app_id;
     VehicleInfoAppExtension& ext;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -79,17 +79,24 @@ void VehicleInfoPendingResumptionHandler::RemoveSucessfulSubscriptions(
   }
 }
 
+void VehicleInfoPendingResumptionHandler::ClearPendingRequestsMap() {
+  using namespace application_manager;
+
+  for (auto const& it : pending_requests_) {
+    const hmi_apis::FunctionID::eType timed_out_pending_request_fid =
+        static_cast<hmi_apis::FunctionID::eType>(
+            it.second[strings::params][strings::function_id].asInt());
+    unsubscribe_from_event(timed_out_pending_request_fid);
+  }
+
+  pending_requests_.clear();
+}
+
 void VehicleInfoPendingResumptionHandler::ClearPendingResumptionRequests() {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace application_manager;
-  const hmi_apis::FunctionID::eType timed_out_pending_request_fid =
-      static_cast<hmi_apis::FunctionID::eType>(
-          pending_requests_.begin()
-              ->second[strings::params][strings::function_id]
-              .asInt());
-  unsubscribe_from_event(timed_out_pending_request_fid);
-  pending_requests_.clear();
 
+  ClearPendingRequestsMap();
   if (!freezed_resumptions_.empty()) {
     ResumptionAwaitingHandling freezed_resumption =
         freezed_resumptions_.front();

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -193,9 +193,18 @@ void ResumptionDataProcessor::HandleOnTimeOut(
   }
   if (app && app->is_resuming()) {
     LOG4CXX_DEBUG(logger_, "Unsubscribing from event: " << function_id);
-    auto callback = register_callbacks_[app_id];
-    callback(mobile_apis::Result::RESUME_FAILED, "Data resumption failed");
     unsubscribe_from_event(function_id);
+
+    auto it = register_callbacks_.find(app_id);
+    if (it == register_callbacks_.end()) {
+      LOG4CXX_WARN(logger_, "Callback for app_id: " << app_id << " not found");
+
+      return;
+    }
+
+    auto callback = it->second;
+    callback(mobile_apis::Result::RESUME_FAILED, "Data resumption failed");
+
     RevertRestoredData(application_manager_.application(app_id));
   }
 }


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
There was noticed two different crashes:
1. Crash happened when at least two resumption related requests are timed out. In that case `ResumptionDataProcessor` class works in the unexpected way - when first timeout is happening and `HandleOnTimeOut` invoked, callback execution is fine, revert sequence if fine and callback has been removed from map. However, when the second timeout is happening, processor is trying to get the same callback using the same app_id, however this callback is already deleted. Instead of that, processor default-constructs a new instance of callback and tries to call that uninitialized function which causes an SDL crash with `bad_function_call` exception. Was fixed by adding check that a valid callback for current app_id is exist.
2. Crash happened when processor was trying to deallocate `VehicleInfoPendingResumptionHandler` object on SDL shutdown. Issue is happening due to access to map `pending_requests_` by `begin()` call without any check that map is empty. So in case if map was empty and `begin()` was called on it this causes an undefined behavior like an entire object corruption and a core crash on attempt to deallocate it. Was fixed by iterating over the map instead of direct access.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
