### PR TITLE
Fix/0190 fix subscriptions on vehicle data

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -106,12 +106,6 @@ class RegisterAppInterfaceRequest
       policy::StatusNotifier status_notifier,
       const std::string& add_info);
 
-  void SendDriverDistractionAndIconUrlNotifications(
-      const uint32_t connection_key, app_mngr::ApplicationSharedPtr app);
-
-  smart_objects::SmartObjectSPtr GetLockScreenIconUrlNotification(
-      const uint32_t connection_key, app_mngr::ApplicationSharedPtr app);
-
   /**
    * @brief SendChangeRegistration send ChangeRegistration on HMI
    * @param function_id interface specific ChangeRegistration

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -106,6 +106,9 @@ class RegisterAppInterfaceRequest
       policy::StatusNotifier status_notifier,
       const std::string& add_info);
 
+  void SendDriverDistractionAndIconUrlNotifications(
+      const uint32_t connection_key, app_mngr::ApplicationSharedPtr app);
+
   smart_objects::SmartObjectSPtr GetLockScreenIconUrlNotification(
       const uint32_t connection_key, app_mngr::ApplicationSharedPtr app);
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -66,9 +66,6 @@ class VehicleInfoPendingResumptionHandler
       std::set<std::string>& subscriptions,
       std::set<std::string>& successful_subscriptions);
 
-  std::set<std::string> GetExtensionSubscriptions(
-      VehicleInfoAppExtension& extension);
-
   smart_objects::SmartObjectSPtr CreateSubscribeRequestToHMI(
       const std::set<std::string>& subscriptions);
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -103,7 +103,7 @@ void VehicleInfoPendingResumptionHandler::ClearPendingResumptionRequests() {
     freezed_resumptions_.pop();
 
     std::set<std::string> subscriptions =
-        GetExtensionSubscriptions(freezed_resumption.ext);
+        freezed_resumption.ext.Subscriptions();
 
     auto request = CreateSubscribeRequestToHMI(subscriptions);
     const uint32_t cid =
@@ -163,8 +163,7 @@ void VehicleInfoPendingResumptionHandler::on_event(
   freezed_resumptions_.pop();
   resumption::Subscriber subscriber = freezed_resumption.subscriber;
 
-  std::set<std::string> subscriptions =
-      GetExtensionSubscriptions(freezed_resumption.ext);
+  std::set<std::string> subscriptions = freezed_resumption.ext.Subscriptions();
 
   if (!IsResumptionResultSuccessful(subscription_results)) {
     LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is NOT successful");
@@ -243,7 +242,7 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
   VehicleInfoAppExtension& ext =
       dynamic_cast<VehicleInfoAppExtension&>(extension);
 
-  std::set<std::string> subscriptions = GetExtensionSubscriptions(ext);
+  std::set<std::string> subscriptions = ext.Subscriptions();
 
   smart_objects::SmartObjectSPtr request =
       CreateSubscribeRequestToHMI(subscriptions);
@@ -278,19 +277,6 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     ResumptionAwaitingHandling frozen_res(app.app_id(), ext, subscriber);
     freezed_resumptions_.push(frozen_res);
   }
-}
-
-std::set<std::string>
-VehicleInfoPendingResumptionHandler::GetExtensionSubscriptions(
-    VehicleInfoAppExtension& extension) {
-  std::set<std::string> subscriptions;
-  for (auto& ivi : application_manager::MessageHelper::vehicle_data()) {
-    const auto it = extension.Subscriptions().find(ivi.first);
-    if (extension.Subscriptions().end() != it) {
-      subscriptions.insert(ivi.first);
-    }
-  }
-  return subscriptions;
 }
 
 smart_objects::SmartObjectSPtr

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -160,22 +160,6 @@ void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
   application_manager_->GetRPCService().ManageHMICommand(message);
 }
 
-bool IsOtherAppAlreadySubscribedFor(
-    const std::string& ivi_name,
-    const application_manager::ApplicationManager& app_mngr,
-    const uint32_t current_app_id) {
-  auto applications = app_mngr.applications();
-
-  for (auto& app : applications.GetData()) {
-    auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-    if (ext.isSubscribedToVehicleInfo(ivi_name) &&
-        (app->app_id() != current_app_id)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 void VehicleInfoPlugin::ProcessResumptionSubscription(
     application_manager::Application& app,
     VehicleInfoAppExtension& ext,


### PR DESCRIPTION
Fixes #[6993](https://adc.luxoft.com/jira/browse/FORDTCN-6993)

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Summary

Fix regression defects from ATF_VF4 jobs:

./test_scripts/API/VehicleData/GenericNetworkSignalData/011_Subscription_resumption_for_VDitems_ign_off.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/033_Subscription_resumption_for_VDitems_2_apps_ign_off.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/032_Subscription_resumption_for_VDitems_2_apps_unexpected_disconnect.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/010_Subscription_resumption_for_VDitems_unexpected_disconnect.lua

./test_scripts/API/VehicleData/GenericNetworkSignalData/036_6_Subscribtion_after_removing_several_VD_from_permissions.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/036_3_Subscribtion_after_removing_VD_from_permissions_2_subscriptions_to_custom_data_and_rpc_spec.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/036_7_Subscribtion_after_removing_and_adding_VD_from_permissions.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/036_5_Subscribtion_after_removing_VD_from_permissions_from_2_apps.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/036_4_Subscribtion_after_removing_VD_from_permissions_from_1_app_2_apps.lua
./test_scripts/API/VehicleData/GenericNetworkSignalData/036_2_Subscribtion_after_removing_VD_from_permissions_2_subscriptions_to_custom_data.lua

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
