### PR TITLE
Processing OnSystemCapabilityUpdated with video stream capabilities

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.h
@@ -87,6 +87,8 @@ class OnBCSystemCapabilityUpdatedNotificationFromHMI
   ProcessSystemDisplayCapabilitiesResult ProcessSystemDisplayCapabilities(
       const smart_objects::SmartObject& display_capabilities);
 
+  void RemoveAppIdFromNotification();
+
   DISALLOW_COPY_AND_ASSIGN(OnBCSystemCapabilityUpdatedNotificationFromHMI);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
@@ -193,11 +193,13 @@ void GetSystemCapabilityRequest::Run() {
       if ((*message_)[app_mngr::strings::msg_params][strings::subscribe]
               .asBool() == true) {
         LOG4CXX_DEBUG(logger_,
-                      "Subscribe to system capability: " << response_type);
+                      "Subscribe to system capability: "
+                          << response_type << " for app_id: " << app->app_id());
         ext.SubscribeTo(response_type);
       } else {
         LOG4CXX_DEBUG(logger_,
-                      "Unsubscribe from system capability: " << response_type);
+                      "Unsubscribe from system capability: "
+                          << response_type << " for app_id: " << app->app_id());
         ext.UnsubscribeFrom(response_type);
       }
     }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
@@ -80,13 +80,13 @@ void OnSystemCapabilityUpdatedNotification::Run() {
       break;
     }
     case mobile_apis::SystemCapabilityType::VIDEO_STREAMING:
-      if (hmi_capabilities_.video_streaming_capability()) {
-        msg_params[strings::system_capability]
-                  [strings::video_streaming_capability] =
-                      *hmi_capabilities_.video_streaming_capability();
-      } else {
-        return;
+      if ((*message_)[strings::msg_params].keyExists(strings::app_id)) {
+        (*message_)[strings::params][strings::connection_key] =
+            (*message_)[strings::msg_params][strings::app_id];
+        (*message_)[strings::msg_params].erase(strings::app_id);
+        SendNotification();
       }
+      return;
       break;
     case mobile_apis::SystemCapabilityType::APP_SERVICES: {
       auto all_services =
@@ -191,51 +191,55 @@ void OnSystemCapabilityUpdatedNotification::Run() {
 
   for (; applications.end() != app_it; ++app_it) {
     const ApplicationSharedPtr app = *app_it;
-    if (system_capability_type ==
-            mobile_apis::SystemCapabilityType::REMOTE_CONTROL &&
-        !app->is_remote_control_supported()) {
-      LOG4CXX_WARN(
-          logger_,
-          "App with connection key: "
-              << app->app_id()
-              << " was subcribed to REMOTE_CONTROL system capabilities, but "
-                 "does not have RC permissions. Unsubscribing");
-      auto& ext = SystemCapabilityAppExtension::ExtractExtension(*app);
-      ext.UnsubscribeFrom(system_capability_type);
-      continue;
-    }
 
-    if (mobile_apis::SystemCapabilityType::DISPLAYS == system_capability_type) {
-      LOG4CXX_DEBUG(logger_, "Using common display capabilities");
-      auto capabilities = hmi_capabilities_.system_display_capabilities();
-      if (app->is_resuming() && app->is_app_data_resumption_allowed()) {
-        LOG4CXX_DEBUG(logger_,
-                      "Application "
-                          << app->app_id()
-                          << " is resuming. Providing cached capabilities");
-        auto display_caps =
-            app->display_capabilities_builder().display_capabilities();
-        capabilities = display_caps;
-      } else if (app->display_capabilities()) {
-        LOG4CXX_DEBUG(logger_,
-                      "Application " << app->app_id()
-                                     << " has specific display capabilities");
-        const WindowID window_id =
-            msg_params[strings::system_capability]
-                      [strings::display_capabilities][0]
-                      [strings::window_capabilities][0][strings::window_id]
-                          .asInt();
-        capabilities = app->display_capabilities(window_id);
-      }
+    switch (system_capability_type) {
+      case mobile_apis::SystemCapabilityType::REMOTE_CONTROL: {
+        if (!app->is_remote_control_supported()) {
+          LOG4CXX_WARN(logger_,
+                       "App with connection key: "
+                           << app->app_id()
+                           << " was subcribed to REMOTE_CONTROL system "
+                              "capabilities, but "
+                              "does not have RC permissions. Unsubscribing");
+          auto& ext = SystemCapabilityAppExtension::ExtractExtension(*app);
+          ext.UnsubscribeFrom(system_capability_type);
+        }
+      } break;
 
-      if (!capabilities) {
-        LOG4CXX_WARN(logger_,
-                     "No available display capabilities for sending. Skipping");
-        continue;
-      }
+      case mobile_apis::SystemCapabilityType::DISPLAYS: {
+        LOG4CXX_DEBUG(logger_, "Using common display capabilities");
+        auto capabilities = hmi_capabilities_.system_display_capabilities();
+        if (app->is_resuming() && app->is_app_data_resumption_allowed()) {
+          LOG4CXX_DEBUG(logger_,
+                        "Application "
+                            << app->app_id()
+                            << " is resuming. Providing cached capabilities");
+          auto display_caps =
+              app->display_capabilities_builder().display_capabilities();
+          capabilities = display_caps;
+        } else if (app->display_capabilities()) {
+          LOG4CXX_DEBUG(logger_,
+                        "Application " << app->app_id()
+                                       << " has specific display capabilities");
+          const WindowID window_id =
+              msg_params[strings::system_capability]
+                        [strings::display_capabilities][0]
+                        [strings::window_capabilities][0][strings::window_id]
+                            .asInt();
+          capabilities = app->display_capabilities(window_id);
+        }
 
-      msg_params[strings::system_capability][strings::display_capabilities] =
-          *capabilities;
+        if (!capabilities) {
+          LOG4CXX_WARN(
+              logger_,
+              "No available display capabilities for sending. Skipping");
+          continue;
+        }
+
+        msg_params[strings::system_capability][strings::display_capabilities] =
+            *capabilities;
+      } break;
+      default: {}
     }
 
     LOG4CXX_INFO(logger_,
@@ -245,7 +249,7 @@ void OnSystemCapabilityUpdatedNotification::Run() {
     (*message_)[strings::params][strings::connection_key] = app->app_id();
     SendNotification();
   }
-}
+}  // namespace mobile
 
 }  // namespace mobile
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
@@ -81,9 +81,6 @@ void OnSystemCapabilityUpdatedNotification::Run() {
     }
     case mobile_apis::SystemCapabilityType::VIDEO_STREAMING:
       if ((*message_)[strings::msg_params].keyExists(strings::app_id)) {
-        (*message_)[strings::params][strings::connection_key] =
-            (*message_)[strings::msg_params][strings::app_id];
-        (*message_)[strings::msg_params].erase(strings::app_id);
         SendNotification();
       }
       return;
@@ -249,7 +246,7 @@ void OnSystemCapabilityUpdatedNotification::Run() {
     (*message_)[strings::params][strings::connection_key] = app->app_id();
     SendNotification();
   }
-}  // namespace mobile
+}
 
 }  // namespace mobile
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
@@ -33,6 +33,8 @@
 #include "hmi/on_bc_system_capability_updated_notification_from_hmi.h"
 
 #include "application_manager/commands/commands_test.h"
+#include "sdl_rpc_plugin/extensions/system_capability_app_extension.h"
+
 #include "gtest/gtest.h"
 
 namespace test {
@@ -47,8 +49,10 @@ using ::testing::Return;
 
 typedef std::shared_ptr<OnBCSystemCapabilityUpdatedNotificationFromHMI>
     OnBCSystemCapabilityUpdatedNotificationFromHMIPtr;
+typedef mobile_apis::SystemCapabilityType::eType SystemCapabilityType;
 
 namespace strings = application_manager::strings;
+
 namespace {
 const uint32_t kAppId = 1u;
 }  // namespace
@@ -88,6 +92,27 @@ MATCHER(CheckMessageToMobileWithoutAppId, "") {
 
 MATCHER_P(CheckDisplayCapabilitiesNotChanged, display_capability, "") {
   return display_capability == arg;
+}
+
+MATCHER_P2(CheckVideoStreamingCapability,
+           system_capability_type,
+           video_streaming_capability,
+           "") {
+  const mobile_apis::SystemCapabilityType::eType received_sys_cap_type =
+      static_cast<mobile_apis::SystemCapabilityType::eType>(
+          (*arg)[strings::msg_params][strings::system_capability]
+                [strings::system_capability_type]
+                    .asInt());
+
+  const bool system_capability_type_matched =
+      received_sys_cap_type == system_capability_type;
+
+  const bool video_capability_matched =
+      video_streaming_capability ==
+      (*arg)[strings::msg_params][strings::system_capability]
+            [strings::video_streaming_capability];
+
+  return system_capability_type_matched && video_capability_matched;
 }
 
 class OnBCSystemCapabilityUpdatedNotificationFromHMITest
@@ -181,6 +206,135 @@ TEST_F(
   ASSERT_TRUE(command_->Init());
   EXPECT_CALL(mock_hmi_capabilities_, set_video_streaming_capability(_))
       .Times(0);
+  command_->Run();
+}
+
+TEST_F(OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+       Run_VideoStreamingCapability_AppIdIsAbsent_NotificationIgnored) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+       Run_VideoStreamingCapability_AppNotRegistered_NotificationIgnored) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  ApplicationSharedPtr app;  // Empty application shared pointer
+
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(app));
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+       Run_VideoStreamingCapability_AppNotSubsribed_NotificationIgnored) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
+
+  // By default system capability extensiob is not subsribed to the
+  // VIDEO_STREAMING
+  std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
+      system_capability_app_extension(
+          std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
+              sdl_rpc_plugin, *mock_app_));
+
+  ON_CALL(*mock_app_,
+          QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::
+                             SystemCapabilityAppExtensionUID))
+      .WillByDefault(Return(system_capability_app_extension));
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(
+    OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+    Run_VideoStreamingCapability_AppIsSubsribed_VideoCapabilityIsAbsent_NotificationIgnored) {
+  const mobile_apis::SystemCapabilityType::eType system_capability_type =
+      mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] = system_capability_type;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
+  std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
+      system_capability_app_extension(
+          std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
+              sdl_rpc_plugin, *mock_app_));
+  system_capability_app_extension->SubscribeTo(system_capability_type);
+
+  ON_CALL(*mock_app_,
+          QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::
+                             SystemCapabilityAppExtensionUID))
+      .WillByDefault(Return(system_capability_app_extension));
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(
+    OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+    Run_VideoStreamingCapability_AppIsSubsribed_VideoCapabilityExists_NotificationForwarded) {
+  const mobile_apis::SystemCapabilityType::eType system_capability_type =
+      mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] = system_capability_type;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [strings::video_streaming_capability] =
+                 new smart_objects::SmartObject(
+                     smart_objects::SmartType::SmartType_Map);
+
+  auto& video_streaming_capability =
+      (*message_)[am::strings::msg_params][strings::system_capability]
+                 [strings::video_streaming_capability];
+
+  FillVideoStreamingCapability(video_streaming_capability);
+
+  sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
+  std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
+      system_capability_app_extension(
+          std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
+              sdl_rpc_plugin, *mock_app_));
+  system_capability_app_extension->SubscribeTo(system_capability_type);
+
+  ON_CALL(*mock_app_,
+          QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::
+                             SystemCapabilityAppExtensionUID))
+      .WillByDefault(Return(system_capability_app_extension));
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  CheckVideoStreamingCapability(system_capability_type,
+                                                video_streaming_capability),
+                  _));
+
+  ASSERT_TRUE(command_->Init());
   command_->Run();
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
@@ -246,12 +246,11 @@ TEST_F(OnBCSystemCapabilityUpdatedNotificationFromHMITest,
 
   sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
 
-  // By default system capability extensiob is not subsribed to the
+  // By default system capability extension is not subsribed to the
   // VIDEO_STREAMING
-  std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
-      system_capability_app_extension(
-          std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
-              sdl_rpc_plugin, *mock_app_));
+  auto system_capability_app_extension =
+      std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
+          sdl_rpc_plugin, *mock_app_);
 
   ON_CALL(*mock_app_,
           QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
@@ -63,6 +63,12 @@ MATCHER_P(CheckDisplayCapabilities, display_capabilities, "") {
                [strings::display_capabilities];
 }
 
+MATCHER_P(CheckVideoStreamCapability, video_streaming_capability, "") {
+  return video_streaming_capability ==
+         (*arg)[strings::msg_params][strings::system_capability]
+               [strings::video_streaming_capability];
+}
+
 class OnSystemCapabilityUpdatedNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  protected:
@@ -224,6 +230,43 @@ TEST_F(
 
   ON_CALL(app_mngr_, applications()).WillByDefault(Return(apps_data));
   EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnSystemCapabilityUpdatedNotificationTest,
+       Run_VideoSteamingCapability_AppIdIsAbsent_NotSendMessageToMobile) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, false)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnSystemCapabilityUpdatedNotificationTest,
+       Run_VideoSteamingCapability_AppIdExistsInMessage_SendMessageToMobile) {
+  (*message_)[strings::msg_params][strings::system_capability]
+             [strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+  (*message_)[strings::msg_params][strings::app_id] = kAppId;
+  (*message_)[strings::msg_params][strings::system_capability]
+             [strings::video_streaming_capability] =
+                 new smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  auto& video_streaming_capability =
+      (*message_)[strings::msg_params][strings::system_capability]
+                 [strings::video_streaming_capability];
+
+  FillVideoStreamingCapability(video_streaming_capability);
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      SendMessageToMobile(
+          CheckVideoStreamCapability(video_streaming_capability), false));
 
   ASSERT_TRUE(command_->Init());
   command_->Run();


### PR DESCRIPTION
Fixes [FORDTCN-7048](https://adc.luxoft.com/jira/browse/FORDTCN-7048)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR providing the next changes for the `OnSystemCapabilityupdated` notification:
- In the case when the notification from HMI contains an application id, it should be forwarded to the mobile application only if it has been subscribed on it, otherwise the notification should be ignored.
- In the case when the notification from HMI contains an application id, it should be ignored.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
