### PR TITLE
Fix OnSCU notification on app registration

### DIFF
--- a/src/components/application_manager/include/application_manager/display_capabilities_builder.h
+++ b/src/components/application_manager/include/application_manager/display_capabilities_builder.h
@@ -68,6 +68,16 @@ class DisplayCapabilitiesBuilder {
       const smart_objects::SmartObject& display_capabilities);
 
   /**
+   * @brief IsWaitingForWindowCapabilities checks wheter builder is waiting for
+   * a capabilities notification for at least one window or not
+   * @param incoming_display_capabilities capabilities to analyze
+   * @return true if builder is waiting for capabilities for at least one
+   * window, otherwise returns false
+   */
+  bool IsWaitingForWindowCapabilities(
+      const smart_objects::SmartObject& incoming_display_capabilities);
+
+  /**
    * @brief ResetDisplayCapabilities resets stored notification
    */
   void ResetDisplayCapabilities();
@@ -85,6 +95,12 @@ class DisplayCapabilitiesBuilder {
   const smart_objects::SmartObjectSPtr display_capabilities() const;
 
  private:
+  /**
+   * @brief InvokeCallbackFunction invokes callback function if all required
+   * criterias met
+   */
+  void InvokeCallbackFunction();
+
   smart_objects::SmartObjectSPtr display_capabilities_;
   typedef std::set<WindowID> WindowIDsToResume;
   WindowIDsToResume window_ids_to_resume_;

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -320,8 +320,15 @@ class ResumeCtrl {
   virtual int32_t GetSavedAppHmiLevel(const std::string& app_id,
                                       const std::string& device_id) const = 0;
 
+  /**
+   * @brief StartWaitingForDisplayCapabilitiesUpdate add application to
+   * capabilities builder waitlist
+   * @param application application to add
+   * @param is_resume_app flag to check whether app data should be resumed or
+   * not
+   */
   virtual void StartWaitingForDisplayCapabilitiesUpdate(
-      app_mngr::ApplicationSharedPtr application) = 0;
+      app_mngr::ApplicationSharedPtr application, const bool is_resume_app) = 0;
 
   virtual time_t LaunchTime() const = 0;
 

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -315,7 +315,8 @@ class ResumeCtrlImpl : public ResumeCtrl,
                               const std::string& device_id) const OVERRIDE;
 
   void StartWaitingForDisplayCapabilitiesUpdate(
-      app_mngr::ApplicationSharedPtr application) OVERRIDE;
+      app_mngr::ApplicationSharedPtr application,
+      const bool is_resume_app) OVERRIDE;
 
   /**
    * @brief geter for launch_time_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.cc
@@ -87,10 +87,11 @@ OnBCSystemCapabilityUpdatedNotificationFromHMI::
   (*message_)[strings::params][strings::connection_key] =
       (*message_)[strings::msg_params][strings::app_id];
   (*message_)[strings::msg_params].erase(strings::app_id);
-  if (app->is_resuming() && app->is_app_data_resumption_allowed()) {
-    LOG4CXX_DEBUG(logger_, "Application is resuming");
-    app->display_capabilities_builder().UpdateDisplayCapabilities(
-        display_capabilities);
+
+  auto& builder = app->display_capabilities_builder();
+  if (builder.IsWaitingForWindowCapabilities(display_capabilities)) {
+    LOG4CXX_DEBUG(logger_, "Application is waiting for capabilities");
+    builder.UpdateDisplayCapabilities(display_capabilities);
     return ProcessSystemDisplayCapabilitiesResult::CAPABILITIES_CACHED;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -355,20 +355,6 @@ bool RegisterAppInterfaceRequest::ApplicationDataShouldBeResumed(
   application->set_app_data_resumption_allowance(true);
   application->set_is_resuming(true);
 
-  // In case application exist in resumption we need to send resumeVrgrammars
-  const bool is_app_saved_in_resumption = resumer.IsApplicationSaved(
-      application->policy_app_id(), application->mac_address());
-
-  // If app is in resuming state
-  // DisplayCapabilitiesBuilder has to collect all the information
-  // from incoming HMI notifications and send only one notification
-  // to mobile app, even if hash does not match, which means that app data
-  // will not be resumed, notification should be sent for default window as
-  // it will be resumed in any case
-  if (resumption || is_app_saved_in_resumption) {
-    resumer.StartWaitingForDisplayCapabilitiesUpdate(application);
-  }
-
   return true;
 }
 
@@ -502,6 +488,11 @@ void FinishSendingRegisterAppInterfaceToMobile(
   // Default HMI level should be set before any permissions validation, since
   // it relies on HMI level.
   app_manager.OnApplicationRegistered(application);
+
+  // Once HMI level is set we can safely forward system capabilities for the
+  // main window and it won't be blocked by policies
+  application->display_capabilities_builder().StopWaitingForWindow(
+      mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
 
   if (notify_upd_manager) {
     (*notify_upd_manager)();
@@ -740,6 +731,17 @@ void RegisterAppInterfaceRequest::Run() {
 
   std::string add_info;
   const auto is_resumption_required = ApplicationDataShouldBeResumed(add_info);
+
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  // DisplayCapabilitiesBuilder has to collect all the information
+  // from incoming HMI notifications and send only one notification
+  // to mobile app, even if hash does not match, which means that app data
+  // will not be resumed, notification should be sent for default window as
+  // it will be resumed in any case
+  resume_ctrl.StartWaitingForDisplayCapabilitiesUpdate(application,
+                                                       is_resumption_required);
+
   SendOnAppRegisteredNotificationToHMI(
       application, is_resumption_required && !is_resumption_failed_);
 
@@ -758,7 +760,6 @@ void RegisterAppInterfaceRequest::Run() {
         connection_key(), correlation_id(), 0);
     sleep(1);
 
-    auto& resume_ctrl = application_manager_.resume_controller();
     const auto& msg_params = (*message_)[strings::msg_params];
     const auto& hash_id = msg_params[strings::hash_id].asString();
     LOG4CXX_WARN(logger_, "Start Data Resumption");

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -772,7 +772,7 @@ bool ResumeCtrlImpl::RestoreApplicationData(ApplicationSharedPtr application,
 }
 
 void ResumeCtrlImpl::StartWaitingForDisplayCapabilitiesUpdate(
-    app_mngr::ApplicationSharedPtr application) {
+    app_mngr::ApplicationSharedPtr application, const bool is_resume_app) {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject saved_app(smart_objects::SmartType_Map);
   resumption_storage_->GetSavedApplication(
@@ -786,7 +786,7 @@ void ResumeCtrlImpl::StartWaitingForDisplayCapabilitiesUpdate(
   auto& builder = application->display_capabilities_builder();
 
   smart_objects::SmartObject windows_info(smart_objects::SmartType_Null);
-  if (saved_app.keyExists(strings::windows_info)) {
+  if (is_resume_app && saved_app.keyExists(strings::windows_info)) {
     windows_info = saved_app[strings::windows_info];
   }
   builder.InitBuilder(resume_callback, windows_info);

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -114,8 +114,9 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_METHOD1(RestoreWidgetsHMIState,
                void(const smart_objects::SmartObject& response_message));
 
-  MOCK_METHOD1(StartWaitingForDisplayCapabilitiesUpdate,
-               void(application_manager::ApplicationSharedPtr application));
+  MOCK_METHOD2(StartWaitingForDisplayCapabilitiesUpdate,
+               void(application_manager::ApplicationSharedPtr application,
+                    const bool is_resume_app));
 
 #ifdef BUILD_TESTS
   MOCK_METHOD1(set_resumption_storage,


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF scripts

### Summary
There was an issue with OnSCU notification on app registration observed for the main window. This notification can't be sent
to mobile app too early because state controller did not set initial default HMI level for it so policy manager just rejects
this notification on attempt to send it upon registration.
To avoid that issue, mandatory capabilities caching has been added for main window on app registration. SDL will additionaly
postpone capabilities for all other windows in case of resumption. SDL will stop waiting for capabilities notification once HMI level
of application was set. If SDL receives onSCU notification during app registration and it is the only window to wait then SDL will
send notification right after `OnHmiStatus`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
