### PR TITLE
Fix VR.AddCommand error response handling

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -336,8 +336,6 @@ class MessageHelper {
                                    ApplicationManager& app_mngr);
   static void SendShowConstantTBTRequestToHMI(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_man);
-  static void SendAddCommandRequestToHMI(ApplicationConstSharedPtr app,
-                                         ApplicationManager& app_man);
   static smart_objects::SmartObjectList CreateAddCommandRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
@@ -351,11 +349,6 @@ class MessageHelper {
    */
   static void SendUIChangeRegistrationRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
-  static void SendAddVRCommandToHMI(
-      uint32_t cmd_id,
-      const smart_objects::SmartObject& vr_commands,
-      const uint32_t app_id,
-      ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateAddVRCommandToHMI(
       uint32_t cmd_id,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -354,16 +354,17 @@ ApplicationSharedPtr ApplicationManagerImpl::get_full_or_limited_application()
   return FindApp(accessor, FullOrLimitedAppPredicate);
 }
 
-bool LimitedAppPredicate(const ApplicationSharedPtr app) {
-  return app ? app->hmi_level(mobile_api::PredefinedWindows::DEFAULT_WINDOW) ==
-                   mobile_api::HMILevel::HMI_LIMITED
+bool LimitedMediaAppPredicate(const ApplicationSharedPtr app) {
+  return app ? (app->is_media_application() &&
+                app->hmi_level(mobile_api::PredefinedWindows::DEFAULT_WINDOW) ==
+                    mobile_api::HMILevel::HMI_LIMITED)
              : false;
 }
 
 ApplicationSharedPtr ApplicationManagerImpl::get_limited_media_application()
     const {
   DataAccessor<ApplicationSet> accessor = applications();
-  return FindApp(accessor, LimitedAppPredicate);
+  return FindApp(accessor, LimitedMediaAppPredicate);
 }
 
 bool LimitedNaviAppPredicate(const ApplicationSharedPtr app) {

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1544,20 +1544,6 @@ void MessageHelper::SendShowConstantTBTRequestToHMI(
   }
 }
 
-void MessageHelper::SendAddCommandRequestToHMI(ApplicationConstSharedPtr app,
-                                               ApplicationManager& app_man) {
-  if (!app) {
-    return;
-  }
-  smart_objects::SmartObjectList requests =
-      CreateAddCommandRequestToHMI(app, app_man);
-  for (smart_objects::SmartObjectList::iterator it = requests.begin();
-       it != requests.end();
-       ++it) {
-    DCHECK(app_man.GetRPCService().ManageHMICommand(*it));
-  }
-}
-
 smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
     ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
   smart_objects::SmartObjectList requests;
@@ -1574,42 +1560,44 @@ smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
     if ((*i->second).keyExists(strings::menu_params)) {
       smart_objects::SmartObjectSPtr ui_command = CreateMessageForHMI(
           hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
-      if (!ui_command) {
-        return requests;
+      if (ui_command) {
+        (*ui_command)[strings::params][strings::function_id] =
+            static_cast<int>(hmi_apis::FunctionID::UI_AddCommand);
+
+        smart_objects::SmartObject msg_params =
+            smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+        if ((*i->second).keyExists(strings::cmd_id)) {
+          msg_params[strings::cmd_id] = (*i->second)[strings::cmd_id].asUInt();
+        } else {
+          LOG4CXX_ERROR(logger_, "Command ID is missing.");
+          continue;
+        }
+        msg_params[strings::menu_params] = (*i->second)[strings::menu_params];
+        msg_params[strings::app_id] = app->app_id();
+
+        if (((*i->second).keyExists(strings::cmd_icon)) &&
+            (0 < (*i->second)[strings::cmd_icon][strings::value].length())) {
+          msg_params[strings::cmd_icon] = (*i->second)[strings::cmd_icon];
+          msg_params[strings::cmd_icon][strings::value] =
+              (*i->second)[strings::cmd_icon][strings::value].asString();
+        }
+        (*ui_command)[strings::msg_params] = msg_params;
+        requests.push_back(ui_command);
       }
-
-      (*ui_command)[strings::params][strings::function_id] =
-          static_cast<int>(hmi_apis::FunctionID::UI_AddCommand);
-
-      smart_objects::SmartObject msg_params =
-          smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-      if ((*i->second).keyExists(strings::cmd_id)) {
-        msg_params[strings::cmd_id] = (*i->second)[strings::cmd_id].asUInt();
-      } else {
-        LOG4CXX_ERROR(logger_, "Command ID is missing.");
-        continue;
-      }
-      msg_params[strings::menu_params] = (*i->second)[strings::menu_params];
-      msg_params[strings::app_id] = app->app_id();
-
-      if (((*i->second).keyExists(strings::cmd_icon)) &&
-          (0 < (*i->second)[strings::cmd_icon][strings::value].length())) {
-        msg_params[strings::cmd_icon] = (*i->second)[strings::cmd_icon];
-        msg_params[strings::cmd_icon][strings::value] =
-            (*i->second)[strings::cmd_icon][strings::value].asString();
-      }
-      (*ui_command)[strings::msg_params] = msg_params;
-      requests.push_back(ui_command);
     }
 
     // VR Interface
     if ((*i->second).keyExists(strings::vr_commands) &&
         (*i->second).keyExists(strings::cmd_id)) {
-      SendAddVRCommandToHMI((*i->second)[strings::cmd_id].asUInt(),
-                            (*i->second)[strings::vr_commands],
-                            app->app_id(),
-                            app_mngr);
+      auto vr_command =
+          CreateAddVRCommandToHMI((*i->second)[strings::cmd_id].asUInt(),
+                                  (*i->second)[strings::vr_commands],
+                                  app->app_id(),
+                                  app_mngr);
+      if (vr_command) {
+        requests.push_back(vr_command);
+      }
     }
   }
   return requests;
@@ -1706,16 +1694,6 @@ void MessageHelper::SendUIChangeRegistrationRequestToHMI(
       app_mngr.GetRPCService().ManageHMICommand(ui_command);
     }
   }
-}
-
-void MessageHelper::SendAddVRCommandToHMI(
-    const uint32_t cmd_id,
-    const smart_objects::SmartObject& vr_commands,
-    const uint32_t app_id,
-    ApplicationManager& app_mngr) {
-  smart_objects::SmartObjectSPtr request =
-      CreateAddVRCommandToHMI(cmd_id, vr_commands, app_id, app_mngr);
-  DCHECK(app_mngr.GetRPCService().ManageHMICommand(request));
 }
 
 smart_objects::SmartObjectSPtr MessageHelper::CreateAddVRCommandToHMI(

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -613,6 +613,8 @@ void ResumptionDataProcessor::DeleteChoicesets(
 
   auto choices = application->choice_set_map().GetData();
   for (auto& choice : choices) {
+    MessageHelper::SendDeleteChoiceSetRequest(
+        choice.second, application, application_manager_);
     application->RemoveChoiceSet(choice.first);
   }
 }


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
The issue was that resumption data processor did not subscribe to `VR.AddCommand` requests sent to HMI and as a result, ignored them and proceed with resumption.
Also fixed sending of `VR.DeleteCommand` for a choice sets in case of rollback.
Also fixed HMI level resumption for app in case another media app is in LIMITED.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
