### PR TITLE
Widgets data resumption error handling

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -1087,6 +1087,19 @@ class MessageHelper {
   static smart_objects::SmartObjectSPtr CreateDisplayCapabilityUpdateToMobile(
       const smart_objects::SmartObject& system_capabilities, Application& app);
 
+  /**
+   * @brief CreateUIDeleteWindowRequestToHMI creates request to delete specified
+   * window
+   * @param application reference to related application
+   * @param app_mngr reference to application manager instance
+   * @param window_id id of window to delete
+   * @return shared ptr to request SO
+   */
+  static smart_objects::SmartObjectSPtr CreateUIDeleteWindowRequestToHMI(
+      ApplicationSharedPtr application,
+      ApplicationManager& app_mngr,
+      const WindowID window_id);
+
  private:
   /**
    * @brief Allows to fill SO according to the  current permissions.

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -684,6 +684,20 @@ class MessageHelper {
       int32_t result_code);
 
   /**
+   * @brief Creates negative response message from HMI using provided params
+   * @param function_id id of function
+   * @param correlation_id correlation id
+   * @param result_code result code
+   * @param info info message
+   * @return pointer to created message
+   */
+  static smart_objects::SmartObjectSPtr CreateNegativeResponseFromHmi(
+      const int32_t function_id,
+      const uint32_t correlation_id,
+      const int32_t result_code,
+      const std::string& info);
+
+  /**
    * @brief Get the full file path of an app file
    *
    * @param file_name The relative path of an application file

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -89,13 +89,6 @@ class ResumeCtrl {
       application_manager::ApplicationSharedPtr application) = 0;
 
   /**
-   * @brief Restore widgets HMI level on the resumption response from HMI
-   * @param response_message smart_object with HMI message
-   */
-  virtual void RestoreWidgetsHMIState(
-      const smart_objects::SmartObject& response_message) = 0;
-
-  /**
    * @brief Set application HMI Level as stored in policy
    * @param application is application witch HMI Level is need to setup
    * @return true if success, otherwise return false
@@ -116,16 +109,6 @@ class ResumeCtrl {
       application_manager::ApplicationSharedPtr application,
       const mobile_apis::HMILevel::eType hmi_level,
       bool check_policy = true) = 0;
-
-  /**
-   * @brief RestoreAppWidgets add widgets for the application
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   * @return the number of widget windows to be resumed
-   */
-  virtual size_t RestoreAppWidgets(
-      application_manager::ApplicationSharedPtr application,
-      const smart_objects::SmartObject& saved_app) = 0;
 
   /**
    * @brief Remove application from list of saved applications

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -57,8 +57,7 @@ namespace resumption {
  * @brief Contains logic for storage/restore data of applications.
  */
 
-class ResumeCtrlImpl : public ResumeCtrl,
-                       public app_mngr::event_engine::EventObserver {
+class ResumeCtrlImpl : public ResumeCtrl {
  public:
   /**
    * @brief allows to create ResumeCtrlImpl object
@@ -69,12 +68,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @brief allows to destroy ResumeCtrlImpl object
    */
   ~ResumeCtrlImpl();
-
-  /**
-   * @brief Event, that raised if application get resumption response from HMI
-   * @param event : event object, that contains smart_object with HMI message
-   */
-  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Save all applications info to the file system
@@ -93,9 +86,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return true if success, otherwise return false
    */
   bool RestoreAppHMIState(app_mngr::ApplicationSharedPtr application) OVERRIDE;
-
-  void RestoreWidgetsHMIState(
-      const smart_objects::SmartObject& response_message) OVERRIDE;
 
   /**
    * @brief Set application HMI Level as stored in policy
@@ -117,15 +107,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
   bool SetAppHMIState(app_mngr::ApplicationSharedPtr application,
                       const mobile_apis::HMILevel::eType hmi_level,
                       bool check_policy = true) OVERRIDE;
-
-  /**
-   * @brief RestoreAppWidgets add widgets for the application
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  size_t RestoreAppWidgets(
-      application_manager::ApplicationSharedPtr application,
-      const smart_objects::SmartObject& saved_app) OVERRIDE;
 
   /**
    * @brief Remove application from list of saved applications
@@ -486,21 +467,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @param ign_off_time - igition off time
    */
   void SetLastIgnOffTime(time_t ign_off_time);
-
-  /**
-   * @brief Process specified HMI request
-   * @param request Request to process
-   * @param use_events Process request events or not flag
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ProcessHMIRequest(smart_objects::SmartObjectSPtr request = NULL,
-                         bool use_events = false);
-
-  /**
-   * @brief Process list of HMI requests using ProcessHMIRequest method
-   * @param requests List of requests to process
-   */
-  void ProcessHMIRequests(const smart_objects::SmartObjectList& requests);
 
   void InsertToTimerQueue(uint32_t app_id, uint32_t time_stamp);
 

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -103,6 +103,16 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
 
  private:
   /**
+   * @brief Processes response message from HMI
+   * @param response reference to response message
+   * @param function_id function id of response
+   * @param corr_id correlation id of response
+   */
+  void ProcessResponseFromHMI(const smart_objects::SmartObject& response,
+                              const hmi_apis::FunctionID::eType function_id,
+                              const int32_t corr_id);
+
+  /**
    * @brief Revert the data to the state before Resumption
    * @param shared ptr to application
    */

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -140,6 +140,14 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
                 const smart_objects::SmartObject& saved_app);
 
   /**
+   * @brief AddWindows allows to add widget windows for the application
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddWindows(app_mngr::ApplicationSharedPtr application,
+                  const smart_objects::SmartObject& saved_app);
+
+  /**
    * @brief Deleting files that have been resumed
    * @param shared ptr to application
    */
@@ -253,6 +261,12 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   void DeleteWayPointsSubscription(app_mngr::ApplicationSharedPtr application);
 
   /**
+   * @brief Deletting subscription for CreateWindow have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteWindowsSubscriptions(app_mngr::ApplicationSharedPtr application);
+
+  /**
    * @brief Get button subscriptions that need to be resumed.
    * Since some subscriptions can be set by default during
    * app registration, this function is needed to discard subscriptions
@@ -272,6 +286,15 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   void CheckVehicleDataResponse(const smart_objects::SmartObject& request,
                                 const smart_objects::SmartObject& response,
                                 ApplicationResumptionStatus& status);
+
+  /**
+   * @brief Checks whether CreateWindow response successful or not and handles
+   * it
+   * @param request reference to request SO
+   * @param response reference to response SO
+   */
+  void CheckCreateWindowResponse(const smart_objects::SmartObject& request,
+                                 const smart_objects::SmartObject& response);
 
   /**
    * @brief Determines whether application has saved data, including

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -116,19 +116,19 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   void WaitForResponse(const int32_t app_id, const ResumptionRequest& request);
 
   /**
-   * @brief Process specified HMI request
-   * @param request Request to process
-   * @param use_events Process request events or not flag
+   * @brief Process specified HMI message
+   * @param request Message to process
+   * @param use_events flag to specify should message events be processed or not
    * @return TRUE on success, otherwise FALSE
    */
-  void ProcessHMIRequest(smart_objects::SmartObjectSPtr request,
-                         bool subscribe_on_response);
+  void ProcessMessageToHMI(smart_objects::SmartObjectSPtr request,
+                           bool subscribe_on_response);
 
   /**
-   * @brief Process list of HMI requests using ProcessHMIRequest method
-   * @param requests List of requests to process
+   * @brief Process list of HMI messages using ProcessHMIRequest method
+   * @param messages List of messages to process
    */
-  void ProcessHMIRequests(const smart_objects::SmartObjectList& requests);
+  void ProcessMessagesToHMI(const smart_objects::SmartObjectList& messages);
 
   /**
    * @brief AddFiles allows to add files for the application
@@ -277,11 +277,11 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
       app_mngr::ApplicationSharedPtr application) const;
 
   /**
-   * @brief Determines whether request is successful
+   * @brief Determines whether response is successful
    * judging from result code received from HMI
    * @param response from HMI with request's result code
    */
-  bool IsRequestSuccessful(const smart_objects::SmartObject& response) const;
+  bool IsResponseSuccessful(const smart_objects::SmartObject& response) const;
 
   void CheckVehicleDataResponse(const smart_objects::SmartObject& request,
                                 const smart_objects::SmartObject& response,
@@ -293,8 +293,9 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
    * @param request reference to request SO
    * @param response reference to response SO
    */
-  void CheckCreateWindowResponse(const smart_objects::SmartObject& request,
-                                 const smart_objects::SmartObject& response);
+  void CheckCreateWindowResponse(
+      const smart_objects::SmartObject& request,
+      const smart_objects::SmartObject& response) const;
 
   /**
    * @brief Determines whether application has saved data, including

--- a/src/components/application_manager/include/application_manager/state_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/state_controller_impl.h
@@ -126,6 +126,10 @@ class StateControllerImpl : public event_engine::EventObserver,
   void ActivateDefaultWindow(ApplicationSharedPtr app) OVERRIDE;
   void ExitDefaultWindow(ApplicationSharedPtr app) OVERRIDE;
 
+  void ResumePostponedWindows(const uint32_t app_id) OVERRIDE;
+
+  void DropPostponedWindows(const uint32_t app_id) OVERRIDE;
+
  private:
   int64_t RequestHMIStateChange(ApplicationConstSharedPtr app,
                                 hmi_apis::Common_HMILevel::eType level,
@@ -426,6 +430,11 @@ class StateControllerImpl : public event_engine::EventObserver,
   StateIDList active_states_;
   mutable sync_primitives::Lock active_states_lock_;
   std::map<uint32_t, HmiStatePtr> waiting_for_response_;
+
+  typedef std::pair<WindowID, HmiStatePtr> WindowStatePair;
+  typedef std::list<WindowStatePair> WindowStatePairs;
+  std::map<uint32_t, WindowStatePairs> postponed_app_widgets_;
+
   ApplicationManager& app_mngr_;
 };
 }  // namespace application_manager

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_create_window_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_create_window_request.h
@@ -55,6 +55,8 @@ class UICreateWindowRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() FINAL;
 
+  void onTimeOut() FINAL;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UICreateWindowRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_create_window_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_create_window_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void UICreateWindowRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UICreateWindowRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -408,20 +408,27 @@ smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::display_capabilities(
     return display_capabilities_;
   }
 
+  smart_objects::SmartObject result_window_caps(
+      smart_objects::SmartType::SmartType_Map);
+
   const auto window_caps =
       (*display_capabilities_)[0][strings::window_capabilities].asArray();
-  auto find_res =
-      std::find_if(window_caps->begin(),
-                   window_caps->end(),
-                   [&window_id](const smart_objects::SmartObject& element) {
-                     if (window_id == element[strings::window_id].asInt()) {
-                       return true;
-                     }
+  if (window_caps) {
+    auto find_res =
+        std::find_if(window_caps->begin(),
+                     window_caps->end(),
+                     [&window_id](const smart_objects::SmartObject& element) {
+                       if (window_id == element[strings::window_id].asInt()) {
+                         return true;
+                       }
 
-                     return false;
-                   });
+                       return false;
+                     });
 
-  DCHECK(find_res != window_caps->end());
+    if (find_res != window_caps->end()) {
+      result_window_caps = *find_res;
+    }
+  }
 
   auto result_display_caps = std::make_shared<smart_objects::SmartObject>(
       smart_objects::SmartType_Array);
@@ -434,7 +441,8 @@ smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::display_capabilities(
     (*result_display_caps)[0][key] = (*display_capabilities_)[0][key];
   }
 
-  (*result_display_caps)[0][strings::window_capabilities][0] = *find_res;
+  (*result_display_caps)[0][strings::window_capabilities][0] =
+      result_window_caps;
 
   return result_display_caps;
 }

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -402,15 +402,14 @@ smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::display_capabilities(
     const WindowID window_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  auto result_display_caps = std::make_shared<smart_objects::SmartObject>(
-      smart_objects::SmartType_Array);
-  const auto window_caps =
-      (*display_capabilities_)[0][strings::window_capabilities].asArray();
-  if (!window_caps) {
+  if (!display_capabilities_) {
     LOG4CXX_WARN(logger_, "Current window capabilities are empty");
     // SDL still needs to retreive display capabilities
     return display_capabilities_;
   }
+
+  const auto window_caps =
+      (*display_capabilities_)[0][strings::window_capabilities].asArray();
   auto find_res =
       std::find_if(window_caps->begin(),
                    window_caps->end(),
@@ -423,6 +422,10 @@ smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::display_capabilities(
                    });
 
   DCHECK(find_res != window_caps->end());
+
+  auto result_display_caps = std::make_shared<smart_objects::SmartObject>(
+      smart_objects::SmartType_Array);
+
   const auto disp_caps_keys = (*display_capabilities_)[0].enumerate();
   for (const auto& key : disp_caps_keys) {
     if (strings::window_capabilities == key) {
@@ -629,6 +632,12 @@ void DynamicApplicationDataImpl::set_display_capabilities(
 void DynamicApplicationDataImpl::remove_window_capability(
     const WindowID window_id) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!display_capabilities_) {
+    LOG4CXX_ERROR(logger_,
+                  "Application display capabilities are not available");
+    return;
+  }
 
   auto window_capabilities =
       (*display_capabilities_)[0][strings::window_capabilities].asArray();

--- a/src/components/application_manager/src/display_capabilities_builder.cc
+++ b/src/components/application_manager/src/display_capabilities_builder.cc
@@ -164,13 +164,15 @@ void DisplayCapabilitiesBuilder::ResetDisplayCapabilities() {
     auto* cur_window_caps_ptr =
         (*display_capabilities_)[0][strings::window_capabilities].asArray();
     if (cur_window_caps_ptr) {
-      std::remove_if(cur_window_caps_ptr->begin(),
-                     cur_window_caps_ptr->end(),
-                     [](const smart_objects::SmartObject& item) {
-                       return item.keyExists(strings::window_id) &&
-                              item[strings::window_id].asInt() !=
-                                  kDefaultWindowID;
-                     });
+      for (auto it = cur_window_caps_ptr->begin();
+           it != cur_window_caps_ptr->end();) {
+        if ((*it).keyExists(strings::window_id) &&
+            (*it)[strings::window_id].asInt() != kDefaultWindowID) {
+          it = cur_window_caps_ptr->erase(it);
+        } else {
+          ++it;
+        }
+      }
     }
   }
 }

--- a/src/components/application_manager/src/display_capabilities_builder.cc
+++ b/src/components/application_manager/src/display_capabilities_builder.cc
@@ -161,17 +161,15 @@ void DisplayCapabilitiesBuilder::ResetDisplayCapabilities() {
   }
 
   if (display_capabilities_) {
-    auto cur_window_caps =
+    auto* cur_window_caps_ptr =
         (*display_capabilities_)[0][strings::window_capabilities].asArray();
-    if (cur_window_caps) {
-      std::remove_if(cur_window_caps->begin(),
-                     cur_window_caps->end(),
+    if (cur_window_caps_ptr) {
+      std::remove_if(cur_window_caps_ptr->begin(),
+                     cur_window_caps_ptr->end(),
                      [](const smart_objects::SmartObject& item) {
-                       const WindowID window_id =
-                           item.keyExists(strings::window_id)
-                               ? item[strings::window_id].asInt()
-                               : kDefaultWindowID;
-                       return kDefaultWindowID != window_id;
+                       return item.keyExists(strings::window_id) &&
+                              item[strings::window_id].asInt() !=
+                                  kDefaultWindowID;
                      });
     }
   }

--- a/src/components/application_manager/src/display_capabilities_builder.cc
+++ b/src/components/application_manager/src/display_capabilities_builder.cc
@@ -29,8 +29,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include "application_manager/display_capabilities_builder.h"
+
+#include <algorithm>
+
 #include "application_manager/message_helper.h"
 #include "application_manager/smart_object_keys.h"
 namespace application_manager {
@@ -152,7 +154,27 @@ bool DisplayCapabilitiesBuilder::IsWaitingForWindowCapabilities(
 void DisplayCapabilitiesBuilder::ResetDisplayCapabilities() {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(display_capabilities_lock_);
-  display_capabilities_.reset();
+  for (auto& window_id : window_ids_to_resume_) {
+    if (kDefaultWindowID != window_id) {
+      window_ids_to_resume_.erase(window_id);
+    }
+  }
+
+  if (display_capabilities_) {
+    auto cur_window_caps =
+        (*display_capabilities_)[0][strings::window_capabilities].asArray();
+    if (cur_window_caps) {
+      std::remove_if(cur_window_caps->begin(),
+                     cur_window_caps->end(),
+                     [](const smart_objects::SmartObject& item) {
+                       const WindowID window_id =
+                           item.keyExists(strings::window_id)
+                               ? item[strings::window_id].asInt()
+                               : kDefaultWindowID;
+                       return kDefaultWindowID != window_id;
+                     });
+    }
+  }
 }
 
 void DisplayCapabilitiesBuilder::StopWaitingForWindow(

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1777,7 +1777,34 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateUICreateWindowRequestToHMI(
         window_info[strings::duplicate_updates_from_window_id].asInt();
   }
 
-  msg_params[strings::app_id] = application->hmi_app_id();
+  msg_params[strings::app_id] = application->app_id();
+
+  (*ui_request)[strings::msg_params] = msg_params;
+
+  return ui_request;
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateUIDeleteWindowRequestToHMI(
+    ApplicationSharedPtr application,
+    ApplicationManager& app_mngr,
+    const WindowID window_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto ui_request = CreateMessageForHMI(hmi_apis::messageType::request,
+                                        app_mngr.GetNextHMICorrelationID());
+
+  (*ui_request)[strings::params][strings::function_id] =
+      static_cast<int>(hmi_apis::FunctionID::UI_DeleteWindow);
+
+  (*ui_request)[strings::correlation_id] =
+      (*ui_request)[strings::params][strings::correlation_id];
+  (*ui_request)[strings::function_id] =
+      (*ui_request)[strings::params][strings::function_id];
+
+  smart_objects::SmartObject msg_params(
+      smart_objects::SmartObject(smart_objects::SmartType_Map));
+
+  msg_params[strings::window_id] = window_id;
+  msg_params[strings::app_id] = application->app_id();
 
   (*ui_request)[strings::msg_params] = msg_params;
 

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2467,6 +2467,30 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponse(
   return std::make_shared<smart_objects::SmartObject>(response_data);
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponseFromHmi(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const int32_t result_code,
+    const std::string& info) {
+  smart_objects::SmartObjectSPtr message =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  (*message)[strings::params][strings::function_id] = function_id;
+  (*message)[strings::params][strings::protocol_type] =
+      commands::CommandImpl::hmi_protocol_type_;
+  (*message)[strings::params][strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  (*message)[strings::params][strings::correlation_id] = correlation_id;
+
+  (*message)[strings::params][strings::message_type] =
+      MessageType::kErrorResponse;
+  (*message)[strings::params][hmi_response::code] = result_code;
+  (*message)[strings::params][strings::error_msg] = info;
+
+  return message;
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateOnServiceUpdateNotification(
     const hmi_apis::Common_ServiceType::eType service_type,
     const hmi_apis::Common_ServiceEvent::eType service_event,

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -231,7 +231,6 @@ void ResumeCtrlImpl::ProcessSystemCapabilityUpdated(
 
   application_manager_.GetRPCService().ManageMobileCommand(
       notification, commands::Command::SOURCE_SDL);
-  app.set_is_resuming(false);
 }
 
 bool ResumeCtrlImpl::SetupDefaultHMILevel(ApplicationSharedPtr application) {

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -443,20 +443,15 @@ void ResumptionDataProcessor::ProcessHMIRequest(
   }
 }
 
-void ResumptionDataProcessor::ProcessHMIRequests(
-    const smart_objects::SmartObjectList& requests) {
+void ResumptionDataProcessor::ProcessMessagesToHMI(
+    const smart_objects::SmartObjectList& messages) {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (requests.empty()) {
-    LOG4CXX_DEBUG(logger_, "requests list is empty");
-    return;
-  }
-
-  for (const auto& it : requests) {
-    const bool is_request =
+  for (const auto& message : messages) {
+    const bool is_request_message =
         application_manager::MessageType::kRequest ==
-        (*it)[strings::params][strings::message_type].asInt();
+        (*message)[strings::params][strings::message_type].asInt();
 
-    ProcessHMIRequest(it, is_request);
+    ProcessMessageToHMI(message, is_request_message);
   }
 }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -452,7 +452,11 @@ void ResumptionDataProcessor::ProcessHMIRequests(
   }
 
   for (const auto& it : requests) {
-    ProcessHMIRequest(it, true);  // subscribe_on_response = true
+    const bool is_request =
+        application_manager::MessageType::kRequest ==
+        (*it)[strings::params][strings::message_type].asInt();
+
+    ProcessHMIRequest(it, is_request);
   }
 }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -917,6 +917,11 @@ void ResumptionDataProcessor::DeleteWindowsSubscriptions(
         application, application_manager_, window_id);
     const bool subscribe_on_request_events = false;
     ProcessMessageToHMI(delete_request, subscribe_on_request_events);
+
+    application->RemoveWindowInfo(window_id);
+    application->RemoveHMIState(window_id,
+                                app_mngr::HmiState::StateID::STATE_ID_REGULAR);
+    application->remove_window_capability(window_id);
   }
 }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -355,12 +355,14 @@ void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
   if (successful_resumption) {
     LOG4CXX_DEBUG(logger_, "Resumption for app " << app_id << " successful");
     callback(mobile_apis::Result::SUCCESS, "Data resumption succesful");
+    application_manager_.state_controller().ResumePostponedWindows(app_id);
   }
 
   if (!successful_resumption) {
     LOG4CXX_ERROR(logger_, "Resumption for app " << app_id << " failed");
     callback(mobile_apis::Result::RESUME_FAILED, "Data resumption failed");
     RevertRestoredData(application_manager_.application(app_id));
+    application_manager_.state_controller().DropPostponedWindows(app_id);
   }
 
   resumption_status_lock_.AcquireForWriting();

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -107,13 +107,6 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
                     bool check_policy));
   MOCK_CONST_METHOD0(LaunchTime, time_t());
 
-  MOCK_METHOD2(RestoreAppWidgets,
-               size_t(app_mngr::ApplicationSharedPtr application,
-                      const smart_objects::SmartObject& saved_app));
-
-  MOCK_METHOD1(RestoreWidgetsHMIState,
-               void(const smart_objects::SmartObject& response_message));
-
   MOCK_METHOD2(StartWaitingForDisplayCapabilitiesUpdate,
                void(application_manager::ApplicationSharedPtr application,
                     const bool is_resume_app));

--- a/src/components/include/application_manager/state_controller.h
+++ b/src/components/include/application_manager/state_controller.h
@@ -223,6 +223,20 @@ class StateController {
    * @param app pointer to application to be exited
    */
   virtual void ExitDefaultWindow(ApplicationSharedPtr app) = 0;
+
+  /**
+   * @brief ResumePostponedWindows resumes adding of all postponed windows for a
+   * specified application, if exists
+   * @param app_id id of application to check
+   */
+  virtual void ResumePostponedWindows(const uint32_t app_id) = 0;
+
+  /**
+   * @brief DropPostponedWindows drops all postponed windows for a specified
+   * application, if exists
+   * @param app_id id of application to check
+   */
+  virtual void DropPostponedWindows(const uint32_t app_id) = 0;
 };
 
 }  // namespace application_manager


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
- Add logic of CreateWindow resumption into processor class
- Remove unused functions from resumption controller
- Add widget windows postponing logic to state controller
- Fix waiting for non-request messages in processor
- Fix capabilities reset for widgets

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
