### PR TITLE
Remove application id checking the OnSystemCapabilityUpdatedNotification

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
@@ -79,12 +79,10 @@ void OnSystemCapabilityUpdatedNotification::Run() {
       }
       break;
     }
-    case mobile_apis::SystemCapabilityType::VIDEO_STREAMING:
-      if ((*message_)[strings::msg_params].keyExists(strings::app_id)) {
-        SendNotification();
-      }
+    case mobile_apis::SystemCapabilityType::VIDEO_STREAMING: {
+      SendNotification();
       return;
-      break;
+    }
     case mobile_apis::SystemCapabilityType::APP_SERVICES: {
       auto all_services =
           application_manager_.GetAppServiceManager().GetAllServiceRecords();


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Remove redundant app id checking in the OnSystemCapabilityUpdatedNotification. The same check exists in the BCOnSystemCapabilityUpdatedNotification.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
