### PR TITLE
Fix LIMITED-LIMITED HMI level conflict resolution

### DIFF
--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -402,7 +402,11 @@ void StateControllerImpl::HmiLevelConflictResolver::operator()(
           result_audio_state,
           mobile_apis::AudioStreamingState::AUDIBLE,
           mobile_apis::AudioStreamingState::ATTENUATED)) {
-    result_hmi_level = mobile_apis::HMILevel::HMI_LIMITED;
+    result_hmi_level =
+        mobile_apis::PredefinedWindows::DEFAULT_WINDOW == window_id_ &&
+                applied_->IsFullscreen()
+            ? mobile_apis::HMILevel::HMI_LIMITED
+            : to_resolve_hmi_level;
   } else {
     result_hmi_level = mobile_apis::HMILevel::HMI_BACKGROUND;
   }


### PR DESCRIPTION
Fixes #7092(https://adc.luxoft.com/jira/browse/FORDTCN-7092)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
There was noticed an issue with the conflict resolution when 1st app has been resumed to FULL and the 2nd app is being resumed to LIMITED. In that case state controller wrongly resolves HMI level of 1st application to LIMITED however it is still can be in FULL. The logic of conflict resolution has been updated to prevent this. Now, state controller will additionally verify HMI level of resumed application vs conflicting application, so if the 2nd app was resumed NOT to FULL then 1st app will keep its current HMI level as this is not considered to be a conflict.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
