### PR TITLE
Fix failed Unit tests for OnSystemCapabilityUpdatedNotification

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
@@ -236,12 +236,12 @@ TEST_F(
 }
 
 TEST_F(OnSystemCapabilityUpdatedNotificationTest,
-       Run_VideoSteamingCapability_AppIdIsAbsent_NotSendMessageToMobile) {
+       Run_VideoSteamingCapability_AppIdIsAbsent_SendMessageToMobile) {
   (*message_)[am::strings::msg_params][strings::system_capability]
              [am::strings::system_capability_type] =
                  mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
 
-  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, false)).Times(0);
+  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(message_, false));
 
   ASSERT_TRUE(command_->Init());
   command_->Run();


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Fix failed Unit test which ckeck the case when an application id is absent in the incoming message. According to the current implementation, the OnBCSystemCapabilityUpdatedNotificationFromHMI has the same check, so in this notification it is redundant check.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
