### PR TITLE
[Pre-delivery] Feature/0296 possibility to update video streaming capabilities

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/smartdevicelink/jsoncpp.git
 [submodule "tools/rpc_spec"]
 	path = tools/rpc_spec
-	url = https://github.com/smartdevicelink/rpc_spec.git
+	url = https://github.com/LuxoftSDL/rpc_spec.git

--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -311,19 +311,105 @@
                 "dialNumberEnabled": true
             },
             "videoStreamingCapability": {
-                "preferredResolution": {
-                    "resolutionWidth": 800,
-                    "resolutionHeight": 350
+              "preferredResolution": {
+                "resolutionWidth": 800,
+                "resolutionHeight": 380
+              },
+              "maxBitrate": 20000,
+              "supportedFormats": [            
+                {
+                  "protocol": "RAW",
+                  "codec": "H264"
                 },
-                "maxBitrate": 10000,
-                "supportedFormats": [{
-                    "protocol": "RAW",
-                    "codec": "H264"
-                }],
-                "hapticSpatialDataSupported": false,
-                "diagonalScreenSize": 8,
-                "pixelPerInch": 117,
-                "scale": 1
+                {
+                  "protocol": "RTP",
+                  "codec": "H264"
+                },
+                {
+                  "protocol": "RTSP",
+                  "codec": "Theora"
+                },
+                {
+                  "protocol": "RTMP",
+                  "codec": "VP8"
+                },
+                {
+                  "protocol": "WEBM",
+                  "codec": "VP9"
+                }
+              ],
+              "hapticSpatialDataSupported": true,
+              "diagonalScreenSize": 8,
+              "pixelPerInch": 96,
+              "scale": 1,
+              "additionalVideoStreamingCapabilities": [
+                {
+                  "preferredResolution":
+                  {
+                    "resolutionWidth": 800,
+                    "resolutionHeight": 380
+                  },
+                  "hapticSpatialDataSupported": true,
+                  "scale": 1,
+                  "diagonalScreenSize": 8
+                },
+                {
+                  "preferredResolution":
+                  {
+                    "resolutionWidth": 320,
+                    "resolutionHeight": 200
+                  },
+                  "hapticSpatialDataSupported": false,
+                  "diagonalScreenSize": 3
+                },
+                {
+                  "preferredResolution":
+                  {
+                    "resolutionWidth": 480,
+                    "resolutionHeight": 320
+                  },
+                  "hapticSpatialDataSupported": true,
+                  "diagonalScreenSize": 5
+                },
+                {
+                  "preferredResolution":
+                  {
+                    "resolutionWidth": 400,
+                    "resolutionHeight": 380
+                  },
+                  "hapticSpatialDataSupported": true,
+                  "diagonalScreenSize": 4
+                },
+                {
+                  "preferredResolution":
+                  {
+                    "resolutionWidth": 800,
+                    "resolutionHeight": 240
+                  },
+                  "hapticSpatialDataSupported": true,
+                  "diagonalScreenSize": 4
+                },
+                {
+                  "preferredResolution":
+                  {
+                    "resolutionWidth": 800,
+                    "resolutionHeight": 380
+                  },
+                  "hapticSpatialDataSupported": true,
+                  "scale": 1.5,
+                  "diagonalScreenSize": 5
+                },
+                {
+                  "preferredResolution":
+                  {
+                    "resolutionWidth": 800,
+                    "resolutionHeight": 380
+                  },
+                  "hapticSpatialDataSupported": true,
+                  "scale": 2,
+                  "diagonalScreenSize": 4
+                }
+              ]
             }
         }
     },

--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -166,6 +166,13 @@
                             "NONE"
                         ]
                     },
+                    "OnAppCapabilityUpdated": {
+                        "hmi_levels": [
+                            "BACKGROUND",
+                            "FULL",
+                            "LIMITED"
+                        ]
+                    },
                     "OnAppInterfaceUnregistered": {
                         "hmi_levels": [
                             "BACKGROUND",

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -224,6 +224,8 @@ extern const char* policy_type;
 extern const char* property;
 extern const char* displays;
 extern const char* seat_location;
+extern const char* app_capability;
+extern const char* app_capability_type;
 
 // PutFile
 extern const char* sync_file_name;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -475,6 +475,7 @@ extern const char* const haptic_spatial_data_supported;
 extern const char* const diagonal_screen_size;
 extern const char* const pixel_per_inch;
 extern const char* const scale;
+extern const char* const additional_video_streaming_capabilities;
 extern const char* const haptic_rect_data;
 extern const char* const rect;
 extern const char* const x;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
@@ -28,7 +28,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-include_directories(include)
+include_directories(
+  include
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/sdl_rpc_plugin
+)
 
 set (COMMANDS_SOURCE_DIR
   ${CMAKE_CURRENT_SOURCE_DIR}/src/commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/bc_on_app_capability_updated_notification.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/bc_on_app_capability_updated_notification.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_APP_CAPABILITY_UPDATED_NOTIFICATION_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_APP_CAPABILITY_UPDATED_NOTIFICATION_H_
+
+#include "application_manager/commands/notification_to_hmi.h"
+
+namespace sdl_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+class BCOnAppCapabilityUpdatedNotification
+    : public app_mngr::commands::NotificationToHMI {
+ public:
+  BCOnAppCapabilityUpdatedNotification(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  ~BCOnAppCapabilityUpdatedNotification() OVERRIDE;
+
+  void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(BCOnAppCapabilityUpdatedNotification);
+};
+
+}  // namespace commands
+}  // namespace sdl_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_APP_CAPABILITY_UPDATED_NOTIFICATION_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.h
@@ -87,6 +87,18 @@ class OnBCSystemCapabilityUpdatedNotificationFromHMI
   ProcessSystemDisplayCapabilitiesResult ProcessSystemDisplayCapabilities(
       const smart_objects::SmartObject& display_capabilities);
 
+  /**
+   * @brief ProcessVideoStreamingCapability processes provided video
+   * streaming capabilities according to its structure
+   * @param system_capability capabilities to process
+   * @return true if video streaming capabilities have been processed
+   * properly, otherwise returns false
+   */
+  bool ProcessVideoStreamingCapability(
+      const smart_objects::SmartObject& system_capability);
+
+  void RemoveAppIdFromNotification();
+
   DISALLOW_COPY_AND_ASSIGN(OnBCSystemCapabilityUpdatedNotificationFromHMI);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/on_app_capability_updated_notification.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/on_app_capability_updated_notification.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_APP_CAPABILITY_UPDATED_NOTIFICATION_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_APP_CAPABILITY_UPDATED_NOTIFICATION_H_
+
+#include "application_manager/commands/command_notification_from_mobile_impl.h"
+#include "utils/macro.h"
+
+namespace sdl_rpc_plugin {
+namespace commands {
+namespace mobile {
+
+namespace app_mngr = application_manager;
+class OnAppCapabilityUpdatedNotification
+    : public app_mngr::commands::CommandNotificationFromMobileImpl {
+ public:
+  /**
+   * @brief OnAppPermissionChangedNotification class constructor
+   * @param message Incoming SmartObject message
+   * @param application_manager Reference to the instance of the Application
+   *Manager
+   * @param rpc_service Reference to the instance of the RPCService
+   * @param hmi_capabilities Reference to the instance of the HMICapabilities
+   * @param policy_handle Reference to the instance of the PolicyHandler
+   **/
+  OnAppCapabilityUpdatedNotification(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  /**
+   * @brief OnAppPermissionChangedNotification class destructor
+   **/
+  ~OnAppCapabilityUpdatedNotification() OVERRIDE;
+
+  /**
+   * @brief Execute command
+   **/
+  void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnAppCapabilityUpdatedNotification);
+};
+
+}  // namespace mobile
+}  // namespace commands
+}  // namespace sdl_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_APP_CAPABILITY_UPDATED_NOTIFICATION_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/bc_on_app_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/bc_on_app_capability_updated_notification.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/commands/hmi/bc_on_app_capability_updated_notification.h"
+
+namespace sdl_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+BCOnAppCapabilityUpdatedNotification::BCOnAppCapabilityUpdatedNotification(
+    const application_manager::commands::MessageSharedPtr& message,
+    application_manager::ApplicationManager& application_manager,
+    application_manager::rpc_service::RPCService& rpc_service,
+    application_manager::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handle)
+    : NotificationToHMI(message,
+                        application_manager,
+                        rpc_service,
+                        hmi_capabilities,
+                        policy_handle) {}
+
+BCOnAppCapabilityUpdatedNotification::~BCOnAppCapabilityUpdatedNotification() {}
+
+void BCOnAppCapabilityUpdatedNotification::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  SendNotification();
+}
+
+}  // namespace commands
+}  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
@@ -193,11 +193,13 @@ void GetSystemCapabilityRequest::Run() {
       if ((*message_)[app_mngr::strings::msg_params][strings::subscribe]
               .asBool() == true) {
         LOG4CXX_DEBUG(logger_,
-                      "Subscribe to system capability: " << response_type);
+                      "Subscribe to system capability: "
+                          << response_type << " for app_id: " << app->app_id());
         ext.SubscribeTo(response_type);
       } else {
         LOG4CXX_DEBUG(logger_,
-                      "Unsubscribe from system capability: " << response_type);
+                      "Unsubscribe from system capability: "
+                          << response_type << " for app_id: " << app->app_id());
         ext.UnsubscribeFrom(response_type);
       }
     }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_app_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_app_capability_updated_notification.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/commands/mobile/on_app_capability_updated_notification.h"
+
+namespace sdl_rpc_plugin {
+
+namespace commands {
+namespace mobile {
+
+OnAppCapabilityUpdatedNotification::OnAppCapabilityUpdatedNotification(
+    const application_manager::commands::MessageSharedPtr& message,
+    app_mngr::ApplicationManager& application_manager,
+    app_mngr::rpc_service::RPCService& rpc_service,
+    app_mngr::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handle)
+    : CommandNotificationFromMobileImpl(message,
+                                        application_manager,
+                                        rpc_service,
+                                        hmi_capabilities,
+                                        policy_handle) {}
+
+OnAppCapabilityUpdatedNotification::~OnAppCapabilityUpdatedNotification() {}
+
+void OnAppCapabilityUpdatedNotification::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  SendNotificationToHMI(
+      hmi_apis::FunctionID::BasicCommunication_OnAppCapabilityUpdated);
+}
+
+}  // namespace mobile
+}  // namespace commands
+}  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/hmi_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/hmi_command_factory.cc
@@ -171,6 +171,7 @@
 #include "sdl_rpc_plugin/commands/hmi/basic_communication_on_awake_sdl.h"
 #include "sdl_rpc_plugin/commands/hmi/basic_communication_system_request.h"
 #include "sdl_rpc_plugin/commands/hmi/basic_communication_system_response.h"
+#include "sdl_rpc_plugin/commands/hmi/bc_on_app_capability_updated_notification.h"
 #include "sdl_rpc_plugin/commands/hmi/dial_number_request.h"
 #include "sdl_rpc_plugin/commands/hmi/dial_number_response.h"
 #include "sdl_rpc_plugin/commands/hmi/navi_alert_maneuver_request.h"
@@ -922,6 +923,10 @@ CommandCreator& HMICommandFactory::get_creator_factory(
     }
     case hmi_apis::FunctionID::BasicCommunication_OnAppPropertiesChange: {
       return factory.GetCreator<commands::OnAppPropertiesChangeNotification>();
+    }
+    case hmi_apis::FunctionID::BasicCommunication_OnAppCapabilityUpdated: {
+      return factory
+          .GetCreator<commands::BCOnAppCapabilityUpdatedNotification>();
     }
     default: { return factory.GetCreator<InvalidCommand>(); }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
@@ -75,6 +75,7 @@
 #include "sdl_rpc_plugin/commands/mobile/get_way_points_response.h"
 #include "sdl_rpc_plugin/commands/mobile/list_files_request.h"
 #include "sdl_rpc_plugin/commands/mobile/list_files_response.h"
+#include "sdl_rpc_plugin/commands/mobile/on_app_capability_updated_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_app_interface_unregistered_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_audio_pass_thru_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_button_event_notification.h"
@@ -471,6 +472,10 @@ CommandCreator& MobileCommandFactory::get_notification_from_mobile_creator(
     case mobile_apis::FunctionID::OnHMIStatusID: {
       return factory.GetCreator<commands::OnHMIStatusNotificationFromMobile>();
     }
+    case mobile_apis::FunctionID::OnAppCapabilityUpdatedID: {
+      return factory
+          .GetCreator<commands::mobile::OnAppCapabilityUpdatedNotification>();
+    }
     default: {}
   }
   return factory.GetCreator<InvalidCommand>();
@@ -523,10 +528,12 @@ bool MobileCommandFactory::IsAbleToProcess(
     const int32_t function_id,
     const application_manager::commands::Command::CommandSource message_source)
     const {
+  LOG4CXX_AUTO_TRACE(logger_);
   auto id = static_cast<mobile_apis::FunctionID::eType>(function_id);
   return get_command_creator(id, mobile_apis::messageType::INVALID_ENUM)
              .CanBeCreated() ||
-         get_notification_creator(id).CanBeCreated();
+         get_notification_creator(id).CanBeCreated() ||
+         get_notification_from_mobile_creator(id).CanBeCreated();
 }
 
 CommandSharedPtr MobileCommandFactory::CreateCommand(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/bc_on_app_capability_updated_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/bc_on_app_capability_updated_notification_test.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hmi/bc_on_app_capability_updated_notification.h"
+
+#include "application_manager/commands/commands_test.h"
+#include "gtest/gtest.h"
+#include "sdl_rpc_plugin/extensions/system_capability_app_extension.h"
+#include "sdl_rpc_plugin/sdl_rpc_plugin.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace bc_on_app_capability_updated_notification_test {
+
+using sdl_rpc_plugin::commands::BCOnAppCapabilityUpdatedNotification;
+using ::testing::_;
+
+typedef std::shared_ptr<BCOnAppCapabilityUpdatedNotification>
+    BCOnAppCapabilityUpdatedNotificationPtr;
+
+namespace strings = application_manager::strings;
+namespace {
+const uint32_t kConnectionKey = 1u;
+}  // namespace
+
+MATCHER_P(CheckAppCapability, app_capability, "") {
+  return app_capability == (*arg)[strings::msg_params][strings::app_capability];
+}
+
+class BCOnAppCapabilityUpdatedNotificationTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    message_ = CreateMessage();
+    (*message_)[strings::params][strings::connection_key] = kConnectionKey;
+    command_ = CreateCommand<BCOnAppCapabilityUpdatedNotification>(message_);
+    mock_app_ = CreateMockApp();
+  }
+
+  void FillVideoStreamingCapability(
+      smart_objects::SmartObject& video_streaming_capability) {
+    video_streaming_capability[strings::preferred_resolution] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    video_streaming_capability[strings::preferred_resolution]
+                              [strings::resolution_width] = 800;
+    video_streaming_capability[strings::preferred_resolution]
+                              [strings::resolution_height] = 354;
+    video_streaming_capability[strings::max_bitrate] = 10000;
+    video_streaming_capability[strings::supported_formats] =
+        smart_objects::SmartObject(smart_objects::SmartType_Array);
+    video_streaming_capability[strings::supported_formats][0] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    video_streaming_capability[strings::supported_formats][0]
+                              [strings::protocol] =
+                                  hmi_apis::Common_VideoStreamingProtocol::RAW;
+    video_streaming_capability[strings::supported_formats][0][strings::codec] =
+        hmi_apis::Common_VideoStreamingCodec::H264;
+    video_streaming_capability[strings::haptic_spatial_data_supported] = true;
+    video_streaming_capability[strings::diagonal_screen_size] = 7.47;
+    video_streaming_capability[strings::pixel_per_inch] = 117.f;
+    video_streaming_capability[strings::scale] = 1.f;
+  }
+
+  BCOnAppCapabilityUpdatedNotificationPtr command_;
+  MockAppPtr mock_app_;
+  MessageSharedPtr message_;
+};
+
+TEST_F(BCOnAppCapabilityUpdatedNotificationTest, Run_SendMessageToHMI_SUCCESS) {
+  smart_objects::SmartObject app_capability =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  app_capability[strings::app_capability_type] =
+      mobile_apis::AppCapabilityType::VIDEO_STREAMING;
+  app_capability[strings::video_streaming_capability] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  FillVideoStreamingCapability(
+      app_capability[strings::video_streaming_capability]);
+
+  (*message_)[strings::msg_params][strings::app_capability] = app_capability;
+
+  ASSERT_TRUE(command_->Init());
+
+  EXPECT_CALL(mock_rpc_service_,
+              SendMessageToHMI(CheckAppCapability(app_capability)));
+  command_->Run();
+}
+
+}  // namespace bc_on_app_capability_updated_notification_test
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
@@ -67,8 +67,6 @@ MATCHER(CheckMessageToMobile, "") {
         (*arg)[strings::params][strings::connection_key] == kAppId;
   }
 
-  std::cout << is_function_id_matched << " " << app_id_exist << " "
-            << is_connection_key_correct << " " << std::endl;
   return is_function_id_matched && app_id_exist && is_connection_key_correct;
 }
 
@@ -173,28 +171,16 @@ TEST_F(
 
 TEST_F(
     OnBCSystemCapabilityUpdatedNotificationFromHMITest,
-    Run_AppRegisteredWithPresentedAppIdInMessage_SetVideoStreamingCapabilitiesToApp_SendMessageToMobile) {
-  SmartObject video_streaming_capability;
+    Run_SysCapTypeVideoStreaming_CapabilityIsAbsent_DoesntSetInHMICapabilities) {
+  smart_objects::SmartObject system_capability =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
 
-  (*message_)[am::strings::msg_params][strings::system_capability]
-             [am::strings::system_capability_type] =
-                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
-  (*message_)[strings::msg_params][strings::app_id] = kAppId;
-  (*message_)[am::strings::msg_params][strings::system_capability]
-             [strings::video_streaming_capability] = video_streaming_capability;
-
-  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
-
-  EXPECT_CALL(mock_hmi_capabilities_,
-              set_video_streaming_capability(video_streaming_capability));
-  EXPECT_CALL(
-      mock_rpc_service_,
-      ManageMobileCommand(
-          CheckMessageToMobile(),
-          ::application_manager::commands::Command::CommandSource::SOURCE_SDL))
-      .WillOnce(Return(true));
+  system_capability[strings::system_capability_type] =
+      mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
 
   ASSERT_TRUE(command_->Init());
+  EXPECT_CALL(mock_hmi_capabilities_, set_video_streaming_capability(_))
+      .Times(0);
   command_->Run();
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
@@ -33,6 +33,8 @@
 #include "hmi/on_bc_system_capability_updated_notification_from_hmi.h"
 
 #include "application_manager/commands/commands_test.h"
+#include "sdl_rpc_plugin/extensions/system_capability_app_extension.h"
+
 #include "gtest/gtest.h"
 
 namespace test {
@@ -47,8 +49,10 @@ using ::testing::Return;
 
 typedef std::shared_ptr<OnBCSystemCapabilityUpdatedNotificationFromHMI>
     OnBCSystemCapabilityUpdatedNotificationFromHMIPtr;
+typedef mobile_apis::SystemCapabilityType::eType SystemCapabilityType;
 
 namespace strings = application_manager::strings;
+
 namespace {
 const uint32_t kAppId = 1u;
 }  // namespace
@@ -61,11 +65,12 @@ MATCHER(CheckMessageToMobile, "") {
                          (*arg)[strings::params][strings::function_id].asInt());
   const bool app_id_exist =
       (*arg)[strings::msg_params].keyExists(strings::app_id);
-  bool is_connection_key_correct = true;
-  if ((*arg)[strings::msg_params].keyExists(strings::connection_key)) {
-    is_connection_key_correct =
-        (*arg)[strings::params][strings::connection_key] == kAppId;
-  }
+  const bool is_connection_key_correct = [](arg_type arg) {
+    if ((*arg)[strings::msg_params].keyExists(strings::connection_key)) {
+      return (*arg)[strings::params][strings::connection_key] == kAppId;
+    }
+    return false;
+  };
 
   return is_function_id_matched && app_id_exist && is_connection_key_correct;
 }
@@ -78,16 +83,38 @@ MATCHER(CheckMessageToMobileWithoutAppId, "") {
                          (*arg)[strings::params][strings::function_id].asInt());
   const bool app_id_exist =
       (*arg)[strings::msg_params].keyExists(strings::app_id);
-  bool is_connection_key_correct = true;
-  if ((*arg)[strings::msg_params].keyExists(strings::connection_key)) {
-    is_connection_key_correct =
-        (*arg)[strings::params][strings::connection_key] == kAppId;
-  }
+  const bool is_connection_key_correct = [](arg_type arg) {
+    if ((*arg)[strings::msg_params].keyExists(strings::connection_key)) {
+      return (*arg)[strings::params][strings::connection_key] == kAppId;
+    }
+    return false;
+  };
   return is_function_id_matched && !app_id_exist && is_connection_key_correct;
 }
 
 MATCHER_P(CheckDisplayCapabilitiesNotChanged, display_capability, "") {
   return display_capability == arg;
+}
+
+MATCHER_P2(CheckVideoStreamingCapability,
+           system_capability_type,
+           video_streaming_capability,
+           "") {
+  const mobile_apis::SystemCapabilityType::eType received_sys_cap_type =
+      static_cast<mobile_apis::SystemCapabilityType::eType>(
+          (*arg)[strings::msg_params][strings::system_capability]
+                [strings::system_capability_type]
+                    .asInt());
+
+  const bool system_capability_type_matched =
+      received_sys_cap_type == system_capability_type;
+
+  const bool video_capability_matched =
+      video_streaming_capability ==
+      (*arg)[strings::msg_params][strings::system_capability]
+            [strings::video_streaming_capability];
+
+  return system_capability_type_matched && video_capability_matched;
 }
 
 class OnBCSystemCapabilityUpdatedNotificationFromHMITest
@@ -181,6 +208,134 @@ TEST_F(
   ASSERT_TRUE(command_->Init());
   EXPECT_CALL(mock_hmi_capabilities_, set_video_streaming_capability(_))
       .Times(0);
+  command_->Run();
+}
+
+TEST_F(OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+       Run_VideoStreamingCapability_AppIdIsAbsent_NotificationIgnored) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+       Run_VideoStreamingCapability_AppNotRegistered_NotificationIgnored) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  ApplicationSharedPtr app;  // Empty application shared pointer
+
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(app));
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+       Run_VideoStreamingCapability_AppNotSubsribed_NotificationIgnored) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
+
+  // By default system capability extension is not subsribed to the
+  // VIDEO_STREAMING
+  auto system_capability_app_extension =
+      std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
+          sdl_rpc_plugin, *mock_app_);
+
+  ON_CALL(*mock_app_,
+          QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::
+                             SystemCapabilityAppExtensionUID))
+      .WillByDefault(Return(system_capability_app_extension));
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(
+    OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+    Run_VideoStreamingCapability_AppIsSubsribed_VideoCapabilityIsAbsent_NotificationIgnored) {
+  const mobile_apis::SystemCapabilityType::eType system_capability_type =
+      mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] = system_capability_type;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
+  std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
+      system_capability_app_extension(
+          std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
+              sdl_rpc_plugin, *mock_app_));
+  system_capability_app_extension->SubscribeTo(system_capability_type);
+
+  ON_CALL(*mock_app_,
+          QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::
+                             SystemCapabilityAppExtensionUID))
+      .WillByDefault(Return(system_capability_app_extension));
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(
+    OnBCSystemCapabilityUpdatedNotificationFromHMITest,
+    Run_VideoStreamingCapability_AppIsSubsribed_VideoCapabilityExists_NotificationForwarded) {
+  const mobile_apis::SystemCapabilityType::eType system_capability_type =
+      mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] = system_capability_type;
+  (*message_)[am::strings::msg_params][strings::app_id] = kAppId;
+
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [strings::video_streaming_capability] =
+                 new smart_objects::SmartObject(
+                     smart_objects::SmartType::SmartType_Map);
+
+  auto& video_streaming_capability =
+      (*message_)[am::strings::msg_params][strings::system_capability]
+                 [strings::video_streaming_capability];
+
+  FillVideoStreamingCapability(video_streaming_capability);
+
+  sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
+  std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
+      system_capability_app_extension(
+          std::make_shared<sdl_rpc_plugin::SystemCapabilityAppExtension>(
+              sdl_rpc_plugin, *mock_app_));
+  system_capability_app_extension->SubscribeTo(system_capability_type);
+
+  ON_CALL(*mock_app_,
+          QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::
+                             SystemCapabilityAppExtensionUID))
+      .WillByDefault(Return(system_capability_app_extension));
+  ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  CheckVideoStreamingCapability(system_capability_type,
+                                                video_streaming_capability),
+                  _));
+
+  ASSERT_TRUE(command_->Init());
   command_->Run();
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_app_capability_updated_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_app_capability_updated_notification_test.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mobile/on_app_capability_updated_notification.h"
+
+#include "application_manager/commands/commands_test.h"
+#include "gtest/gtest.h"
+#include "sdl_rpc_plugin/extensions/system_capability_app_extension.h"
+#include "sdl_rpc_plugin/sdl_rpc_plugin.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace on_app_capability_updated_notification_test {
+
+using sdl_rpc_plugin::commands::mobile::OnAppCapabilityUpdatedNotification;
+using ::testing::_;
+
+typedef std::shared_ptr<OnAppCapabilityUpdatedNotification>
+    OnAppCapabilityUpdatedNotificationPtr;
+
+namespace strings = application_manager::strings;
+namespace {
+const uint32_t kConnectionKey = 1u;
+}  // namespace
+
+MATCHER_P(CheckAppCapability, app_capability, "") {
+  return app_capability == (*arg)[strings::msg_params][strings::app_capability];
+}
+
+class OnAppCapabilityUpdatedNotificationTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ protected:
+  void SetUp() OVERRIDE {
+    message_ = CreateMessage();
+    (*message_)[strings::params][strings::connection_key] = kConnectionKey;
+    command_ = CreateCommand<OnAppCapabilityUpdatedNotification>(message_);
+    mock_app_ = CreateMockApp();
+  }
+
+  void FillVideoStreamingCapability(
+      smart_objects::SmartObject& video_streaming_capability) {
+    video_streaming_capability[strings::preferred_resolution] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    video_streaming_capability[strings::preferred_resolution]
+                              [strings::resolution_width] = 800;
+    video_streaming_capability[strings::preferred_resolution]
+                              [strings::resolution_height] = 354;
+
+    video_streaming_capability[strings::max_bitrate] = 10000;
+
+    video_streaming_capability[strings::supported_formats] =
+        smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+    video_streaming_capability[strings::supported_formats][0] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+    video_streaming_capability[strings::supported_formats][0]
+                              [strings::protocol] =
+                                  hmi_apis::Common_VideoStreamingProtocol::RAW;
+
+    video_streaming_capability[strings::supported_formats][0][strings::codec] =
+        hmi_apis::Common_VideoStreamingCodec::H264;
+
+    video_streaming_capability[strings::haptic_spatial_data_supported] = true;
+
+    video_streaming_capability[strings::diagonal_screen_size] = 7.47;
+
+    video_streaming_capability[strings::pixel_per_inch] = 117.f;
+
+    video_streaming_capability[strings::scale] = 1.f;
+  }
+
+  OnAppCapabilityUpdatedNotificationPtr command_;
+  MockAppPtr mock_app_;
+  MessageSharedPtr message_;
+};
+
+TEST_F(OnAppCapabilityUpdatedNotificationTest, Run_ManageHMICommand_SUCCESS) {
+  smart_objects::SmartObject app_capability =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  app_capability[strings::app_capability_type] =
+      mobile_apis::AppCapabilityType::VIDEO_STREAMING;
+  app_capability[strings::video_streaming_capability] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  FillVideoStreamingCapability(
+      app_capability[strings::video_streaming_capability]);
+
+  (*message_)[strings::msg_params][strings::app_capability] = app_capability;
+
+  ASSERT_TRUE(command_->Init());
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageHMICommand(CheckAppCapability(app_capability),
+                               app_mngr::commands::Command::SOURCE_SDL_TO_HMI));
+  command_->Run();
+}
+
+}  // namespace on_app_capability_updated_notification_test
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
@@ -63,6 +63,12 @@ MATCHER_P(CheckDisplayCapabilities, display_capabilities, "") {
                [strings::display_capabilities];
 }
 
+MATCHER_P(CheckVideoStreamCapability, video_streaming_capability, "") {
+  return video_streaming_capability ==
+         (*arg)[strings::msg_params][strings::system_capability]
+               [strings::video_streaming_capability];
+}
+
 class OnSystemCapabilityUpdatedNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  protected:
@@ -224,6 +230,43 @@ TEST_F(
 
   ON_CALL(app_mngr_, applications()).WillByDefault(Return(apps_data));
   EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, _)).Times(0);
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnSystemCapabilityUpdatedNotificationTest,
+       Run_VideoSteamingCapability_AppIdIsAbsent_SendMessageToMobile) {
+  (*message_)[am::strings::msg_params][strings::system_capability]
+             [am::strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+
+  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(message_, false));
+
+  ASSERT_TRUE(command_->Init());
+  command_->Run();
+}
+
+TEST_F(OnSystemCapabilityUpdatedNotificationTest,
+       Run_VideoSteamingCapability_AppIdExistsInMessage_SendMessageToMobile) {
+  (*message_)[strings::msg_params][strings::system_capability]
+             [strings::system_capability_type] =
+                 mobile_apis::SystemCapabilityType::VIDEO_STREAMING;
+  (*message_)[strings::msg_params][strings::app_id] = kAppId;
+  (*message_)[strings::msg_params][strings::system_capability]
+             [strings::video_streaming_capability] =
+                 new smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  auto& video_streaming_capability =
+      (*message_)[strings::msg_params][strings::system_capability]
+                 [strings::video_streaming_capability];
+
+  FillVideoStreamingCapability(video_streaming_capability);
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      SendMessageToMobile(
+          CheckVideoStreamCapability(video_streaming_capability), false));
 
   ASSERT_TRUE(command_->Init());
   command_->Run();

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -191,6 +191,8 @@ const char* policy_type = "policyType";
 const char* property = "property";
 const char* displays = "displays";
 const char* seat_location = "seatLocation";
+const char* app_capability = "appCapability";
+const char* app_capability_type = "appCapabilityType";
 
 // PutFile
 const char* sync_file_name = "syncFileName";

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -434,6 +434,8 @@ const char* const haptic_spatial_data_supported = "hapticSpatialDataSupported";
 const char* const diagonal_screen_size = "diagonalScreenSize";
 const char* const pixel_per_inch = "pixelPerInch";
 const char* const scale = "scale";
+const char* const additional_video_streaming_capabilities =
+    "additionalVideoStreamingCapabilities";
 const char* const haptic_rect_data = "hapticRectData";
 const char* const rect = "rect";
 const char* const x = "x";

--- a/src/components/application_manager/test/hmi_capabilities_test.cc
+++ b/src/components/application_manager/test/hmi_capabilities_test.cc
@@ -686,16 +686,16 @@ TEST_F(
       800,
       vs_capability_so[strings::preferred_resolution][strings::resolution_width]
           .asInt());
-  EXPECT_EQ(350,
+  EXPECT_EQ(380,
             vs_capability_so[strings::preferred_resolution]
                             [strings::resolution_height]
                                 .asInt());
   EXPECT_TRUE(vs_capability_so.keyExists(strings::max_bitrate));
-  EXPECT_EQ(10000, vs_capability_so[strings::max_bitrate].asInt());
+  EXPECT_EQ(20000, vs_capability_so[strings::max_bitrate].asInt());
   EXPECT_TRUE(vs_capability_so.keyExists(strings::supported_formats));
   const size_t supported_formats_len =
       vs_capability_so[strings::supported_formats].length();
-  EXPECT_EQ(1ull, supported_formats_len);
+  EXPECT_EQ(5u, supported_formats_len);
 
   EXPECT_TRUE(vs_capability_so[strings::supported_formats][0].keyExists(
       strings::protocol));
@@ -710,8 +710,20 @@ TEST_F(
 
   EXPECT_TRUE(
       vs_capability_so.keyExists(strings::haptic_spatial_data_supported));
-  EXPECT_FALSE(
+  EXPECT_TRUE(
       vs_capability_so[strings::haptic_spatial_data_supported].asBool());
+  EXPECT_TRUE(vs_capability_so.keyExists(strings::diagonal_screen_size));
+  EXPECT_EQ(8, vs_capability_so[strings::diagonal_screen_size].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists(strings::pixel_per_inch));
+  EXPECT_EQ(96, vs_capability_so[strings::pixel_per_inch].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists(strings::scale));
+  EXPECT_EQ(1, vs_capability_so[strings::scale].asInt());
+  EXPECT_TRUE(vs_capability_so.keyExists(
+      strings::additional_video_streaming_capabilities));
+  const size_t additional_video_streaming_capabilities_len =
+      vs_capability_so[strings::additional_video_streaming_capabilities]
+          .length();
+  EXPECT_EQ(7u, additional_video_streaming_capabilities_len);
 
   EXPECT_TRUE(hmi_capabilities_->video_streaming_supported());
 }

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -53,6 +53,7 @@ namespace components {
 namespace commands_test {
 
 namespace am = ::application_manager;
+namespace strings = am::strings;
 
 using ::testing::_;
 using ::testing::Mock;
@@ -177,6 +178,30 @@ class CommandsTest : public ::testing::Test {
         .WillByDefault(Return(am::HmiInterfaces::STATE_AVAILABLE));
     Mock::VerifyAndClearExpectations(&mock_message_helper_);
     InitHMIToMobileResultConverter();
+  }
+
+  void FillVideoStreamingCapability(
+      smart_objects::SmartObject& video_streaming_capability) {
+    video_streaming_capability[strings::preferred_resolution] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    video_streaming_capability[strings::preferred_resolution]
+                              [strings::resolution_width] = 800;
+    video_streaming_capability[strings::preferred_resolution]
+                              [strings::resolution_height] = 354;
+    video_streaming_capability[strings::max_bitrate] = 10000;
+    video_streaming_capability[strings::supported_formats] =
+        smart_objects::SmartObject(smart_objects::SmartType_Array);
+    video_streaming_capability[strings::supported_formats][0] =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    video_streaming_capability[strings::supported_formats][0]
+                              [strings::protocol] =
+                                  hmi_apis::Common_VideoStreamingProtocol::RAW;
+    video_streaming_capability[strings::supported_formats][0][strings::codec] =
+        hmi_apis::Common_VideoStreamingCodec::H264;
+    video_streaming_capability[strings::haptic_spatial_data_supported] = true;
+    video_streaming_capability[strings::diagonal_screen_size] = 7.47;
+    video_streaming_capability[strings::pixel_per_inch] = 117.f;
+    video_streaming_capability[strings::scale] = 1.f;
   }
 
   void InitHMIToMobileResultConverter() {

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -807,6 +807,11 @@
   </element>
 </enum>
 
+<enum name="AppCapabilityType">
+  <description>Enumerations of all available app capability types</description>
+  <element name="VIDEO_STREAMING"/>
+</enum>
+
 <!--IVI part-->
 <enum name="ElectronicParkBrakeStatus">
   <element name="CLOSED">
@@ -3493,8 +3498,21 @@
     <param name="scale" type="Float" minvalue="1" maxvalue="10" mandatory="false">
       <description>The scaling factor the app should use to change the size of the projecting view.</description>
     </param>
+    <param name="additionalVideoStreamingCapabilities" type="VideoStreamingCapability" array="true" minsize="1" maxsize="100" mandatory="false">
+    </param>
   </struct>
 
+  <struct name="AppCapability">
+    <param name="appCapabilityType" type="AppCapabilityType" mandatory="true">
+        <description>
+            Used as a descriptor of what data to expect in this struct.
+            The corresponding param to this enum should be included and the only other param included.
+        </description>
+    </param>
+    <param name="videoStreamingCapability" type="VideoStreamingCapability" mandatory="false">
+        <description>Describes supported capabilities for video streaming </description>
+    </param>
+  </struct>
 
   <struct name="WindowTypeCapabilities">
     <param name="type" type="Common.WindowType" mandatory="true" />
@@ -4717,6 +4735,13 @@
     </description>
     <param name="properties" type="Common.AppProperties" mandatory="true">
       <description>The new application properties</description>
+    </param>
+  </function>
+
+  <function name="OnAppCapabilityUpdated" messagetype="notification">
+    <description>A notification to inform HMI that a specific app capability has changed.</description>
+    <param name="appCapability" type="Common.AppCapability" mandatory="true">
+        <description>The app capability that has been updated</description>
     </param>
   </function>
 </interface>


### PR DESCRIPTION
Implements https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
http://172.26.147.12/view/0296_update_video_streaming_capabilities/

### Summary

1. New additionalVideoStreamingCapabilities parameter of VideoStreamingCapability processing
- Store additionalVideoStreamingCapabilities from UI.GetCapabilities response
- Send additionalVideoStreamingCapabilities to the mobile app via GetSystemCapabilities
- Resend additionalVideoStreamingCapabilities to the mobile app via OnSystemCapabilityUpdated notification from HMI
2. OnSystemCapabilityUpdated with videoStreamingCapabilities processing
- The notification from HMI which contains appID parameter must be re-sent to appropriate mobile application only if it had been subscribed on it else it must be ignored
- The notification from HMI which does not contain appID parameter must be ignored
3. OnAppCapabilityUpdated notification processing 
- The notification from the mobile must be re-sent to the HMI



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
