### PR TITLE
Fix/revert subscriptions to syscaps and appservices

### DIFF
--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_app_extension.cc
@@ -121,6 +121,7 @@ void AppServiceAppExtension::ProcessResumption(
 void AppServiceAppExtension::RevertResumption(
     const smart_objects::SmartObject& subscriptions) {
   UNUSED(subscriptions);
+  UnsubscribeFromAppService();
 }
 
 AppServiceAppExtension& AppServiceAppExtension::ExtractASExtension(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -758,7 +758,6 @@ void RegisterAppInterfaceRequest::Run() {
   if (is_resumption_required) {
     application_manager_.updateRequestTimeout(
         connection_key(), correlation_id(), 0);
-    sleep(1);
 
     const auto& msg_params = (*message_)[strings::msg_params];
     const auto& hash_id = msg_params[strings::hash_id].asString();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/extensions/system_capability_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/extensions/system_capability_app_extension.cc
@@ -92,6 +92,11 @@ void SystemCapabilityAppExtension::ProcessResumption(
 void SystemCapabilityAppExtension::RevertResumption(
     const smart_objects::SmartObject& subscriptions) {
   UNUSED(subscriptions);
+  for (auto subscription : subscribed_data_) {
+    if (SystemCapabilityType::DISPLAYS != subscription) {
+      UnsubscribeFrom(subscription);
+    }
+  }
 }
 
 SystemCapabilityAppExtension& SystemCapabilityAppExtension::ExtractExtension(


### PR DESCRIPTION
Fixes #[7095](https://adc.luxoft.com/jira/browse/FORDTCN-7095) and #[7096](https://adc.luxoft.com/jira/browse/FORDTCN-7096)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Add logic for reverting subscriptions in case failed resumption.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
