### PR TITLE
[SDL-0190] Handle response from HMI during resumption data

### DIFF
--- a/src/components/application_manager/include/application_manager/app_extension.h
+++ b/src/components/application_manager/include/application_manager/app_extension.h
@@ -33,15 +33,18 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_APP_EXTENSION_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_APP_EXTENSION_H_
 
+#include <functional>
 #include <memory>
 
-namespace ns_smart_device_link {
-namespace ns_smart_objects {
-class SmartObject;
-}
-}  // namespace ns_smart_device_link
+#include "smart_objects/smart_object.h"
+
+namespace resumption {
+struct ResumptionRequest;
+using Subscriber = std::function<void(const int32_t, const ResumptionRequest)>;
+}  // namespace resumption
 
 namespace application_manager {
+namespace ns_smart = ns_smart_device_link::ns_smart_objects;
 
 typedef int AppExtensionUID;
 
@@ -59,16 +62,21 @@ class AppExtension {
    * @param resumption_data data reference to data, that will be appended by
    * plugin
    */
-  virtual void SaveResumptionData(
-      ns_smart_device_link::ns_smart_objects::SmartObject& resumption_data) = 0;
+  virtual void SaveResumptionData(ns_smart::SmartObject& resumption_data) = 0;
 
   /**
    * @brief ProcessResumption Method called by SDL during resumption.
    * @param resumption_data list of resumption data
+   * @param subscriber callbacks for subscribing
    */
-  virtual void ProcessResumption(
-      const ns_smart_device_link::ns_smart_objects::SmartObject&
-          resumption_data) = 0;
+  virtual void ProcessResumption(const ns_smart::SmartObject& resumption_data,
+                                 resumption::Subscriber subscriber) = 0;
+
+  /**
+   * @brief RevertResumption Method called by SDL during revert resumption.
+   * @param subscriptions Subscriptions from which must discard
+   */
+  virtual void RevertResumption(const ns_smart::SmartObject& subscriptions) = 0;
 
  private:
   const AppExtensionUID kUid_;

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -332,12 +332,14 @@ class DynamicApplicationDataImpl : public virtual Application {
   SubMenuMap sub_menu_;
   mutable std::shared_ptr<sync_primitives::RecursiveLock> sub_menu_lock_ptr_;
   ChoiceSetMap choice_set_map_;
-  mutable std::shared_ptr<sync_primitives::Lock> choice_set_map_lock_ptr_;
+  mutable std::shared_ptr<sync_primitives::RecursiveLock>
+      choice_set_map_lock_ptr_;
   PerformChoiceSetMap performinteraction_choice_set_map_;
   mutable std::shared_ptr<sync_primitives::RecursiveLock>
       performinteraction_choice_set_lock_ptr_;
   WindowParamsMap window_params_map_;
-  mutable std::shared_ptr<sync_primitives::Lock> window_params_map_lock_ptr_;
+  mutable std::shared_ptr<sync_primitives::RecursiveLock>
+      window_params_map_lock_ptr_;
   uint32_t is_perform_interaction_active_;
   bool is_reset_global_properties_active_;
   int32_t perform_interaction_mode_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -279,11 +279,11 @@ class ApplicationManagerImpl
 
   /**
    * @brief Checks if Application is subscribed for way points
-   * @param Application pointer
+   * @param Application reference
    * @return true if Application is subscribed for way points
    * otherwise false
    */
-  bool IsAppSubscribedForWayPoints(ApplicationSharedPtr app) const OVERRIDE;
+  bool IsAppSubscribedForWayPoints(Application& app) const OVERRIDE;
 
   void SaveWayPointsMessage(
       smart_objects::SmartObjectSPtr way_points_message) OVERRIDE;
@@ -983,6 +983,13 @@ class ApplicationManagerImpl
    */
   void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) OVERRIDE;
 
+  ResetGlobalPropertiesResult ResetGlobalProperties(
+      const smart_objects::SmartObject& global_properties_ids,
+      const uint32_t app_id) OVERRIDE;
+
+  ResetGlobalPropertiesResult ResetAllApplicationGlobalProperties(
+      const uint32_t app_id) OVERRIDE;
+
   // TODO(AOleynik): Temporary added, to fix build. Should be reworked.
   connection_handler::ConnectionHandler& connection_handler() const OVERRIDE;
   protocol_handler::ProtocolHandler& protocol_handler() const OVERRIDE;
@@ -1343,6 +1350,39 @@ class ApplicationManagerImpl
    */
   void SendMobileMessage(smart_objects::SmartObjectSPtr message);
 
+  /**
+   * @brief Sets default value of the HELPPROMT global property
+   * to the first vrCommand of each Command Menu registered in application
+   *
+   * @param app Registered application
+   * @param is_timeout_promp Flag indicating that timeout prompt
+   * should be reset
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetHelpPromt(ApplicationSharedPtr app) const;
+
+  /**
+   * @brief  Sets default value of the TIMEOUTPROMT global property
+   * to the first vrCommand of each Command Menu registered in application
+   *
+   * @param app Registered application
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetTimeoutPromt(ApplicationSharedPtr app) const;
+
+  /**
+   * @brief Sets default value of the VRHELPTITLE global property
+   * to the application name and value of the VRHELPITEMS global property
+   * to value equal to registered command -1(default command “Help / Cancel”.)
+   *
+   * @param app Registered application
+   *
+   * @return TRUE on success, otherwise FALSE
+   */
+  bool ResetVrHelpTitleItems(ApplicationSharedPtr app) const;
+
  private:
   /*
    * NaviServiceStatusMap shows which navi service (audio/video) is opened
@@ -1365,6 +1405,16 @@ class ApplicationManagerImpl
    */
   std::string GetHashedAppID(uint32_t connection_key,
                              const std::string& policy_app_id) const;
+
+  /**
+   * @brief CreateAllAppGlobalPropsIDList creates an array of all application
+   * global properties IDs. Used as utility to call
+   * ApplicationManger::ResetGlobalProperties
+   * with all global properties.
+   * @return array smart object with global properties identifiers.
+   */
+  const smart_objects::SmartObjectSPtr CreateAllAppGlobalPropsIDList(
+      const uint32_t app_id) const;
 
   /**
    * @brief Removes suspended and stopped timers from timer pool

--- a/src/components/application_manager/include/application_manager/display_capabilities_builder.h
+++ b/src/components/application_manager/include/application_manager/display_capabilities_builder.h
@@ -68,6 +68,16 @@ class DisplayCapabilitiesBuilder {
       const smart_objects::SmartObject& display_capabilities);
 
   /**
+   * @brief IsWaitingForWindowCapabilities checks wheter builder is waiting for
+   * a capabilities notification for at least one window or not
+   * @param incoming_display_capabilities capabilities to analyze
+   * @return true if builder is waiting for capabilities for at least one
+   * window, otherwise returns false
+   */
+  bool IsWaitingForWindowCapabilities(
+      const smart_objects::SmartObject& incoming_display_capabilities) const;
+
+  /**
    * @brief ResetDisplayCapabilities resets stored notification
    */
   void ResetDisplayCapabilities();
@@ -84,13 +94,29 @@ class DisplayCapabilitiesBuilder {
    */
   const smart_objects::SmartObjectSPtr display_capabilities() const;
 
+  /**
+   * @brief IsWindowResumptionNeeded checks that is there a need for
+   * resumption of windows (except main window)
+   * @return true if data about windows to be resumed was saved in window_info,
+   * otherwise returns false
+   */
+
+  bool IsWindowResumptionNeeded() const;
+
  private:
+  /**
+   * @brief InvokeCallbackFunction invokes callback function if all required
+   * criterias met
+   */
+  void InvokeCallbackFunction();
+
   smart_objects::SmartObjectSPtr display_capabilities_;
   typedef std::set<WindowID> WindowIDsToResume;
   WindowIDsToResume window_ids_to_resume_;
   Application& owner_;
   ResumeCallback resume_callback_;
-  sync_primitives::Lock display_capabilities_lock_;
+  mutable sync_primitives::Lock display_capabilities_lock_;
+  bool is_widget_windows_resumption_;
 };
 }  // namespace application_manager
 #endif

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -60,7 +60,41 @@ class PolicyHandlerInterface;
 namespace application_manager {
 namespace mobile_api = mobile_apis;
 
-/*
+/**
+ * @brief ResetGlobalPropertiesResult
+ * contains flags indicating success of
+ * ResetGlobalProperties operation.
+ * Used in MessageHelper functions
+ * to construct relevant requests
+ **/
+struct ResetGlobalPropertiesResult {
+  bool help_prompt;
+  bool timeout_prompt;
+  bool vr_help_title_items;
+  bool menu_name;
+  bool menu_icon;
+  bool keyboard_properties;
+  int number_of_reset_vr;
+
+  ResetGlobalPropertiesResult()
+      : help_prompt(false)
+      , timeout_prompt(false)
+      , vr_help_title_items(false)
+      , menu_name(false)
+      , menu_icon(false)
+      , keyboard_properties(false)
+      , number_of_reset_vr(0) {}
+
+  bool HasUIPropertiesReset() const {
+    return vr_help_title_items || menu_name || menu_icon || keyboard_properties;
+  }
+
+  bool HasTTSPropertiesReset() const {
+    return timeout_prompt || help_prompt;
+  }
+};
+
+/**
  * @brief Typedef for VehicleData
  *
  * @param const char* Name of the parameter in mobile request
@@ -142,7 +176,7 @@ class MessageHelper {
   static void SendGetSystemTimeRequest(const uint32_t correlation_id,
                                        ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Retrieve vehicle data map for param name in mobile request
    * to VehicleDataType
    *
@@ -213,7 +247,7 @@ class MessageHelper {
   static mobile_api::HMILevel::eType StringToHMILevel(
       const std::string& hmi_level);
 
-  /*
+  /**
    * @brief Used to obtain string representation of app's
    * HMI Level.
    * @param hmi_level Desired HMI Level
@@ -221,7 +255,7 @@ class MessageHelper {
   static std::string StringifiedHMILevel(
       const mobile_apis::HMILevel::eType hmi_level);
 
-  /*
+  /**
    * @brief Used to obtain function name by its id
    * @param function_id Function ID
    */
@@ -234,7 +268,7 @@ class MessageHelper {
       const uint32_t correlation_id,
       uint32_t connection_key);
 
-  /*
+  /**
    * @brief Prepare GetDeviceListResponse
    *
    *
@@ -254,6 +288,10 @@ class MessageHelper {
 
   /**
    * @brief Sends button subscription notification
+   * @param app_id Application ID
+   * @param button Enum with button name
+   * @param is_subscribed true if subscribed, false otherwise
+   * @param app_mngr reference to application manager
    */
   static void SendOnButtonSubscriptionNotification(
       const uint32_t app_id,
@@ -262,18 +300,46 @@ class MessageHelper {
       ApplicationManager& app_mngr);
 
   /**
+   * @brief Creates button subscription notification
+   * @param app_id Application ID
+   * @param button Enum with button name
+   * @param is_subscribed true if subscribed, false otherwise
+   * @return notification message in SmartObject format
+   */
+  static smart_objects::SmartObjectSPtr CreateOnButtonSubscriptionNotification(
+      const uint32_t app_id,
+      const hmi_apis::Common_ButtonName::eType button,
+      const bool is_subscribed);
+
+  /**
    * @brief Sends button subscription notifications for all buttons
    * that application is subscribed on
+   * @param app shared pointer to application instance
+   * @param app_mngr reference to application manager
    */
   static void SendAllOnButtonSubscriptionNotificationsForApp(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
+
+  /**
+   * @brief Creates button subscription notifications for buttons
+   * that application is subscribed on
+   * @param app shared pointer to application instance
+   * @param app_mngr reference to application manager
+   * @param button_subscriptions collection of subscribed buttons
+   * @return list of notification messages in SmartObject format
+   */
+  static smart_objects::SmartObjectList
+  CreateOnButtonSubscriptionNotificationsForApp(
+      ApplicationConstSharedPtr app,
+      ApplicationManager& app_mngr,
+      const ButtonSubscriptions& button_subscriptions);
 
   static void SendAppDataToHMI(ApplicationConstSharedPtr app,
                                ApplicationManager& app_man);
   static void SendGlobalPropertiesToHMI(ApplicationConstSharedPtr app,
                                         ApplicationManager& app_mngr);
   static smart_objects::SmartObjectList CreateGlobalPropertiesRequestsToHMI(
-      ApplicationConstSharedPtr app, const uint32_t correlation_id);
+      ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateAppVrHelp(
       ApplicationConstSharedPtr app);
@@ -284,8 +350,6 @@ class MessageHelper {
                                    ApplicationManager& app_mngr);
   static void SendShowConstantTBTRequestToHMI(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_man);
-  static void SendAddCommandRequestToHMI(ApplicationConstSharedPtr app,
-                                         ApplicationManager& app_man);
   static smart_objects::SmartObjectList CreateAddCommandRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
@@ -299,11 +363,6 @@ class MessageHelper {
    */
   static void SendUIChangeRegistrationRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
-  static void SendAddVRCommandToHMI(
-      uint32_t cmd_id,
-      const smart_objects::SmartObject& vr_commands,
-      const uint32_t app_id,
-      ApplicationManager& app_mngr);
 
   static smart_objects::SmartObjectSPtr CreateAddVRCommandToHMI(
       uint32_t cmd_id,
@@ -335,7 +394,7 @@ class MessageHelper {
       ApplicationManager& app_mngr,
       const smart_objects::SmartObject& windows_info);
 
-  /*
+  /**
    * @brief Create Common.DeviceInfo struct from device handle
    * @param device_handle device handle of the app
    * @param session_observer instance of SessionObserver to retrieve device
@@ -353,7 +412,7 @@ class MessageHelper {
       ApplicationManager& app_mngr,
       smart_objects::SmartObject* output);
 
-  /*
+  /**
    * @brief Create Common.HMIApplication struct application instance
    * @param app : applicaton instace
    * @param output smart object to store Common.HMIApplication struct
@@ -368,10 +427,10 @@ class MessageHelper {
 
   static void SendAddSubMenuRequestToHMI(ApplicationConstSharedPtr app,
                                          ApplicationManager& app_mngr);
-  static smart_objects::SmartObjectList CreateAddSubMenuRequestToHMI(
-      ApplicationConstSharedPtr app, const uint32_t correlation_id);
+  static smart_objects::SmartObjectList CreateAddSubMenuRequestsToHMI(
+      ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Creates BasicCommunication.OnAppUnregistered notification
    * @param app Application instance
    * @param is_unexpected_disconnect
@@ -459,7 +518,7 @@ class MessageHelper {
       ApplicationManager& app_mngr);
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
-  /*
+  /**
    * @brief Sends SetVideoConfig request to HMI to negotiate video parameters
    *
    * @param app_id       the application which will start video streaming
@@ -471,7 +530,7 @@ class MessageHelper {
       ApplicationManager& app_mngr,
       const smart_objects::SmartObject& video_params);
 
-  /*
+  /**
    * @brief Sends notification to HMI to start video streaming
    *
    * @param connection_key  Application connection key
@@ -479,7 +538,7 @@ class MessageHelper {
    */
   static void SendNaviStartStream(int32_t app_id, ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Sends notification to HMI to stop video streaming
    *
    * @param connection_key  Application connection key
@@ -487,7 +546,7 @@ class MessageHelper {
    */
   static void SendNaviStopStream(int32_t app_id, ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Send notification for Update of Policy Table
    * with PT Snapshot.
    * @param connection_key Id of application to send message to
@@ -501,7 +560,7 @@ class MessageHelper {
       const std::string& url,
       ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Send notification for Update of Policy Table
    * with PT Snapshot.
    * @param connection_key Id of application to send message to
@@ -541,7 +600,7 @@ class MessageHelper {
   static void SendQueryApps(const uint32_t connection_key,
                             ApplicationManager& app_man);
 
-  /*
+  /**
    * @brief Send notification to mobile on application permissions update
    * @param connection_key Id of application to send message to
    * @param permissions updated permissions for application
@@ -554,7 +613,7 @@ class MessageHelper {
       ApplicationManager& app_mngr,
       const policy::EncryptionRequired encryprion_required);
 
-  /*
+  /**
    * @brief Send notification to HMI on application permissions update
    * @param connection_key Id of application to send message to
    * @param permissions updated permissions for application
@@ -595,7 +654,7 @@ class MessageHelper {
    */
   static void SendGetSystemInfoRequest(ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Sends notification to HMI to start audio streaming
    *
    * @param connection_key  Application connection key
@@ -604,7 +663,7 @@ class MessageHelper {
   static void SendAudioStartStream(int32_t app_id,
                                    ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Sends notification to HMI to stop audio streaming
    *
    * @param connection_key  Application connection key
@@ -616,8 +675,7 @@ class MessageHelper {
   static void SendOnDataStreaming(protocol_handler::ServiceType service,
                                   bool available,
                                   ApplicationManager& app_mngr);
-
-  /*
+  /**
    * @brief Sends notification to HMI to stop audioPathThru
    *
    * @param connection_key  Application connection key
@@ -627,16 +685,44 @@ class MessageHelper {
   static bool SendStopAudioPathThru(ApplicationManager& app_mngr);
 
   /**
-   * @brief Sends UnsubscribeWayPoints request
-   * @return true if UnsubscribedWayPoints is send otherwise false
+   * @brief Creates UnsubscribeWayPoints request
+   * @param correlation_id  Correlation ID
+   * @return request Request to HMI
    */
-  static bool SendUnsubscribedWayPoints(ApplicationManager& app_mngr);
+  static smart_objects::SmartObjectSPtr CreateUnsubscribeWayPointsRequest(
+      const uint32_t correlation_id);
 
   static smart_objects::SmartObjectSPtr CreateNegativeResponse(
       uint32_t connection_key,
       int32_t function_id,
       const uint32_t correlation_id,
       int32_t result_code);
+
+  /**
+   * @brief Creates negative response message from HMI using provided params
+   * @param function_id id of function
+   * @param correlation_id correlation id
+   * @param result_code result code
+   * @param info info message
+   * @return pointer to created message
+   */
+  static smart_objects::SmartObjectSPtr CreateNegativeResponseFromHmi(
+      const int32_t function_id,
+      const uint32_t correlation_id,
+      const int32_t result_code,
+      const std::string& info);
+
+  /**
+   * @brief Creates negative response message from HMI using provided params
+   * @param function_id id of function
+   * @param correlation_id correlation id
+   * @param result_code result code
+   * @return pointer to created message
+   */
+  static smart_objects::SmartObjectSPtr CreateResponseMessageFromHmi(
+      const int32_t function_id,
+      const uint32_t correlation_id,
+      const int32_t result_code);
 
   /**
    * @brief Get the full file path of an app file
@@ -680,7 +766,7 @@ class MessageHelper {
                              ApplicationConstSharedPtr app,
                              ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief Verify image and add image file full path
    *
    * @param SmartObject with image
@@ -710,7 +796,7 @@ class MessageHelper {
   static ChoiceSetVRCommandsStatus CheckChoiceSetVRCommands(
       const smart_objects::SmartObject& choice_set);
 
-  /*
+  /**
    * @brief Finds "Image" structure in request and verify image file presence
    *                      in Core.
    *
@@ -746,7 +832,7 @@ class MessageHelper {
       const policy::PolicyHandlerInterface& policy_handler,
       ApplicationManager& app_mngr);
 
-  /*
+  /**
    * @brief subscribe application to softbutton
    *
    * @param message_params contains data of request
@@ -763,7 +849,7 @@ class MessageHelper {
       int32_t function_id,
       const WindowID window_id);
 
-  /*
+  /**
    * @brief subscribe application to softbutton
    *
    * @param message_params contains data of request
@@ -894,15 +980,30 @@ class MessageHelper {
       mobile_api::AppInterfaceUnregisteredReason::eType reason);
 
   /**
-   * @brief SendDeleteCommandRequest sends requests to HMI to remove UI/VR
+   * @brief CreateDeleteUICommandRequest creates request to HMI to remove UI
+   * command data depending on command parameters
+   * @param cmd Command data
+   * @param app_id ID of application owning the command data
+   * @param corr_id Correlation ID
+   * @return SmartObjectSPtr message to HMI
+   */
+  static smart_objects::SmartObjectSPtr CreateDeleteUICommandRequest(
+      smart_objects::SmartObject* cmd,
+      const uint32_t app_id,
+      const uint32_t corr_id);
+
+  /**
+   * @brief CreateDeleteVRCommandRequest creates request to HMI to remove VR
    * command data depending on command parameters
    * @param cmd Command data
    * @param application Application owning the command data
-   * @param app_mngr Application manager
+   * @param corr_id Correlation ID
+   * @return SmartObjectSPtr message to HMI
    */
-  static void SendDeleteCommandRequest(smart_objects::SmartObject* cmd,
-                                       ApplicationSharedPtr application,
-                                       ApplicationManager& app_mngr);
+  static smart_objects::SmartObjectSPtr CreateDeleteVRCommandRequest(
+      smart_objects::SmartObject* cmd,
+      ApplicationSharedPtr application,
+      const uint32_t corr_id);
 
   /**
    * @brief SendDeleteSubmenuRequest sends UI/VR requests to HMI to remove
@@ -951,12 +1052,10 @@ class MessageHelper {
    * @brief Sends HMI status notification to mobile
    * @param application application with changed HMI status
    * @param window_id id of affected window
-   * @param application_manager reference to application manager
+   * @return SmartObjectSPtr with notification about HMI status
    **/
-  static void SendHMIStatusNotification(
-      ApplicationSharedPtr application,
-      const WindowID window_id,
-      ApplicationManager& application_manager);
+  static smart_objects::SmartObjectSPtr CreateHMIStatusNotification(
+      ApplicationSharedPtr application, const WindowID window_id);
 
   /**
    * @brief SendActivateAppToHMI Sends BasicCommunication.ActivateApp request to
@@ -981,7 +1080,41 @@ class MessageHelper {
    * @return HMI message object with filled header
    */
   static smart_objects::SmartObjectSPtr CreateMessageForHMI(
-      hmi_apis::messageType::eType message_type, const uint32_t correlation_id);
+      const hmi_apis::messageType::eType message_type,
+      const uint32_t correlation_id);
+
+  /**
+   * @brief CreateMessageForHMI Creates HMI message with prepared header
+   * acccoring to message type
+   * @param function_id function id
+   * @param correlation_id Correlation id
+   * @return HMI message object with filled header
+   */
+  static smart_objects::SmartObjectSPtr CreateMessageForHMI(
+      const hmi_apis::FunctionID::eType function_id,
+      const uint32_t correlation_id);
+
+  /**
+   * @brief CreateUIResetGlobalPropertiesRequest Creates request
+   * to reset global properties for UI
+   * @param struct containing result of global properties reset procedure
+   * @param application which properties are to be reset
+   * @return filled smart object with relevant request data
+   */
+  static smart_objects::SmartObjectSPtr CreateUIResetGlobalPropertiesRequest(
+      const ResetGlobalPropertiesResult& reset_result,
+      const ApplicationSharedPtr application);
+
+  /**
+   * @brief CreateTTSResetGlobalPropertiesRequest Creates request
+   * to reset global properties for TTS
+   * @param struct containing result of global properties reset procedure
+   * @param application which properties are to be reset
+   * @return filled smart object with relevant request data
+   */
+  static smart_objects::SmartObjectSPtr CreateTTSResetGlobalPropertiesRequest(
+      const ResetGlobalPropertiesResult& reset_result,
+      const ApplicationSharedPtr application);
 
   static smart_objects::SmartObject CreateAppServiceCapabilities(
       std::vector<smart_objects::SmartObject>& all_services);
@@ -998,6 +1131,19 @@ class MessageHelper {
    */
   static smart_objects::SmartObjectSPtr CreateDisplayCapabilityUpdateToMobile(
       const smart_objects::SmartObject& system_capabilities, Application& app);
+
+  /**
+   * @brief CreateUIDeleteWindowRequestToHMI creates request to delete specified
+   * window
+   * @param application reference to related application
+   * @param app_mngr reference to application manager instance
+   * @param window_id id of window to delete
+   * @return shared ptr to request SO
+   */
+  static smart_objects::SmartObjectSPtr CreateUIDeleteWindowRequestToHMI(
+      ApplicationSharedPtr application,
+      ApplicationManager& app_mngr,
+      const WindowID window_id);
 
  private:
   /**

--- a/src/components/application_manager/include/application_manager/resumption/extension_pending_resumption_handler.h
+++ b/src/components/application_manager/include/application_manager/resumption/extension_pending_resumption_handler.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_EXTENSION_PENDING_RESUMPTION_HANDLER_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_EXTENSION_PENDING_RESUMPTION_HANDLER_H
+#include "application_manager/app_extension.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/event_engine/event_observer.h"
+
+namespace resumption {
+
+namespace app_mngr = application_manager;
+
+/**
+ * @brief The ExtensionPendingResumptionHandler class
+ * responsibility to avoid duplication of subscription requests to HMI
+ * if multiple applications are registering
+ */
+class ExtensionPendingResumptionHandler
+    : public application_manager::event_engine::EventObserver {
+ public:
+  ExtensionPendingResumptionHandler(
+      app_mngr::ApplicationManager& application_manager);
+
+  virtual ~ExtensionPendingResumptionHandler() {}
+
+  /**
+   * @brief HandleResumptionSubscriptionRequest handles all subscriptions
+   * requests, which might be send to HMI under certain conditions
+   * @param extension reference to corresponding application extension
+   * @param subscriber callback for subscribing
+   * @param app reference to application owner
+   */
+  virtual void HandleResumptionSubscriptionRequest(
+      app_mngr::AppExtension& extension,
+      Subscriber& subscriber,
+      application_manager::Application& app) = 0;
+
+  /**
+   * @brief OnResumptionRevert is a callback to be called in the case, when
+   * resumption is failed for current application.
+   */
+  virtual void OnResumptionRevert() = 0;
+
+ protected:
+  /**
+   * @brief MakeResumptionRequest creates resumption request
+   * @param corr_id correlation ID
+   * @param function_id function ID
+   * @param message Message to HMI
+   * @return instance of ResumptionRequest class
+   */
+  ResumptionRequest MakeResumptionRequest(
+      const uint32_t corr_id,
+      const hmi_apis::FunctionID::eType function_id,
+      const smart_objects::SmartObject& message);
+
+  app_mngr::ApplicationManager& application_manager_;
+};
+}  //  namespace resumption
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_EXTENSION_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -59,6 +59,16 @@ class ResumeCtrl {
   virtual ~ResumeCtrl() {}
 
   /**
+   * @brief ResumptionCallBack Function signature to be called when
+   * data resumption will be finished
+   * @param result_code result code for sending to mobile
+   * @param info additional info for sending to mobile
+   */
+  typedef std::function<void(mobile_apis::Result::eType result_code,
+                             const std::string& info)>
+      ResumptionCallBack;
+
+  /**
    * @brief Save all applications info to the file system
    */
   virtual void SaveAllApplications() = 0;
@@ -77,13 +87,6 @@ class ResumeCtrl {
    */
   virtual bool RestoreAppHMIState(
       application_manager::ApplicationSharedPtr application) = 0;
-
-  /**
-   * @brief Restore widgets HMI level on the resumption response from HMI
-   * @param response_message smart_object with HMI message
-   */
-  virtual void RestoreWidgetsHMIState(
-      const smart_objects::SmartObject& response_message) = 0;
 
   /**
    * @brief Set application HMI Level as stored in policy
@@ -106,16 +109,6 @@ class ResumeCtrl {
       application_manager::ApplicationSharedPtr application,
       const mobile_apis::HMILevel::eType hmi_level,
       bool check_policy = true) = 0;
-
-  /**
-   * @brief RestoreAppWidgets add widgets for the application
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   * @return the number of widget windows to be resumed
-   */
-  virtual size_t RestoreAppWidgets(
-      application_manager::ApplicationSharedPtr application,
-      const smart_objects::SmartObject& saved_app) = 0;
 
   /**
    * @brief Remove application from list of saved applications
@@ -175,10 +168,14 @@ class ResumeCtrl {
    * @brief Start timer for resumption applications
    *        Restore D1-D5 data
    * @param application that is need to be restored
+   * @param hash stored hash value for this app
+   * @param callback Function signature to be called when
+   * data resumption will be finished
    * @return true if it was saved, otherwise return false
    */
   virtual bool StartResumption(app_mngr::ApplicationSharedPtr application,
-                               const std::string& hash) = 0;
+                               const std::string& hash,
+                               ResumptionCallBack callback) = 0;
   /**
    * @brief Start timer for resumption applications
    *        Does not restore D1-D5 data
@@ -196,6 +193,15 @@ class ResumeCtrl {
   virtual void RetryResumption(const uint32_t app_id) = 0;
 
   /**
+   * @brief Handle restored data when timeout appeared
+   * @param correlation_id - const int32_t
+   * @param function id hmi_apis::FunctionID::eType
+   */
+
+  virtual void HandleOnTimeOut(const uint32_t correlation_id,
+                               const hmi_apis::FunctionID::eType) = 0;
+
+  /**
    * @brief Check if there are all files need for resumption
    * @param application that is need to be restored
    * @return true if it all files exist, otherwise return false
@@ -206,6 +212,7 @@ class ResumeCtrl {
   /**
    * @brief Check application hash
    * @param application that is need to be restored
+   * @param hash stored hash value to be checked for restoring application
    * @return true if it was saved, otherwise return false
    */
   virtual bool CheckApplicationHash(app_mngr::ApplicationSharedPtr application,
@@ -300,8 +307,15 @@ class ResumeCtrl {
   virtual int32_t GetSavedAppHmiLevel(const std::string& app_id,
                                       const std::string& device_id) const = 0;
 
+  /**
+   * @brief StartWaitingForDisplayCapabilitiesUpdate add application to
+   * capabilities builder waitlist
+   * @param application application to add
+   * @param is_resume_app flag to check whether app data should be resumed or
+   * not
+   */
   virtual void StartWaitingForDisplayCapabilitiesUpdate(
-      app_mngr::ApplicationSharedPtr application) = 0;
+      app_mngr::ApplicationSharedPtr application, const bool is_resume_app) = 0;
 
   virtual time_t LaunchTime() const = 0;
 

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -44,6 +44,7 @@
 #include "application_manager/application.h"
 #include "application_manager/event_engine/event_observer.h"
 #include "application_manager/resumption/resumption_data.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 #include "interfaces/HMI_API.h"
 #include "interfaces/HMI_API_schema.h"
 #include "interfaces/MOBILE_API_schema.h"
@@ -56,8 +57,7 @@ namespace resumption {
  * @brief Contains logic for storage/restore data of applications.
  */
 
-class ResumeCtrlImpl : public ResumeCtrl,
-                       public app_mngr::event_engine::EventObserver {
+class ResumeCtrlImpl : public ResumeCtrl {
  public:
   /**
    * @brief allows to create ResumeCtrlImpl object
@@ -68,12 +68,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @brief allows to destroy ResumeCtrlImpl object
    */
   ~ResumeCtrlImpl();
-
-  /**
-   * @brief Event, that raised if application get resumption response from HMI
-   * @param event : event object, that contains smart_object with HMI message
-   */
-  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Save all applications info to the file system
@@ -92,9 +86,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * @return true if success, otherwise return false
    */
   bool RestoreAppHMIState(app_mngr::ApplicationSharedPtr application) OVERRIDE;
-
-  void RestoreWidgetsHMIState(
-      const smart_objects::SmartObject& response_message) OVERRIDE;
 
   /**
    * @brief Set application HMI Level as stored in policy
@@ -116,15 +107,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
   bool SetAppHMIState(app_mngr::ApplicationSharedPtr application,
                       const mobile_apis::HMILevel::eType hmi_level,
                       bool check_policy = true) OVERRIDE;
-
-  /**
-   * @brief RestoreAppWidgets add widgets for the application
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  size_t RestoreAppWidgets(
-      application_manager::ApplicationSharedPtr application,
-      const smart_objects::SmartObject& saved_app) OVERRIDE;
 
   /**
    * @brief Remove application from list of saved applications
@@ -181,21 +163,13 @@ class ResumeCtrlImpl : public ResumeCtrl,
    */
   void StopRestoreHmiLevelTimer();
 
-  /**
-   * @brief Start timer for resumption applications
-   *        Restore D1-D5 data
-   * @param application that is need to be restored
-   * @return true if it was saved, otherwise return false
-   */
   bool StartResumption(app_mngr::ApplicationSharedPtr application,
-                       const std::string& hash) OVERRIDE;
+                       const std::string& hash,
+                       ResumptionCallBack callback) OVERRIDE;
 
-  /**
-   * @brief Start timer for resumption applications
-   *        Does not restore D1-D5 data
-   * @param application that is need to be restored
-   * @return true if it was saved, otherwise return false
-   */
+  void HandleOnTimeOut(const uint32_t correlation_id,
+                       const hmi_apis::FunctionID::eType) OVERRIDE;
+
   bool StartResumptionOnlyHMILevel(
       app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
@@ -310,7 +284,8 @@ class ResumeCtrlImpl : public ResumeCtrl,
                               const std::string& device_id) const OVERRIDE;
 
   void StartWaitingForDisplayCapabilitiesUpdate(
-      app_mngr::ApplicationSharedPtr application) OVERRIDE;
+      app_mngr::ApplicationSharedPtr application,
+      const bool is_resume_app) OVERRIDE;
 
   /**
    * @brief geter for launch_time_
@@ -354,9 +329,12 @@ class ResumeCtrlImpl : public ResumeCtrl,
   /**
    * @brief restores saved data of application
    * @param application contains application for which restores data
+   * @param callback lambda callback, which contains logic for sending response
+   * to mobile and updating hash
    * @return true if success, otherwise return false
    */
-  bool RestoreApplicationData(app_mngr::ApplicationSharedPtr application);
+  bool RestoreApplicationData(app_mngr::ApplicationSharedPtr application,
+                              ResumptionCallBack callback);
 
   /**
    * @brief SaveDataOnTimer :
@@ -370,67 +348,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
    * persistent data timer to avoid further persisting
    */
   void FinalPersistData();
-
-  /**
-   * @brief AddFiles allows to add files for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddFiles(app_mngr::ApplicationSharedPtr application,
-                const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddSubmenues allows to add sub menues for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddSubmenues(app_mngr::ApplicationSharedPtr application,
-                    const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddCommands allows to add commands for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddCommands(app_mngr::ApplicationSharedPtr application,
-                   const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddChoicesets allows to add choice sets for the application
-   * which should be resumed
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddChoicesets(app_mngr::ApplicationSharedPtr application,
-                     const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief SetGlobalProperties allows to restore global properties.
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void SetGlobalProperties(app_mngr::ApplicationSharedPtr application,
-                           const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddSubscriptions allows to restore subscriptions
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddSubscriptions(app_mngr::ApplicationSharedPtr application,
-                        const smart_objects::SmartObject& saved_app);
-
-  /**
-   * @brief AddWayPointsSubscription allows to restore subscription
-   * for WayPoints
-   * @param application application which will be resumed
-   * @param saved_app application specific section from backup file
-   */
-  void AddWayPointsSubscription(app_mngr::ApplicationSharedPtr application,
-                                const smart_objects::SmartObject& saved_app);
 
   /**
    * @brief Checks if saved HMI level is allowed for resumption
@@ -541,21 +458,6 @@ class ResumeCtrlImpl : public ResumeCtrl,
    */
   void SetLastIgnOffTime(time_t ign_off_time);
 
-  /**
-   * @brief Process specified HMI request
-   * @param request Request to process
-   * @param use_events Process request events or not flag
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ProcessHMIRequest(smart_objects::SmartObjectSPtr request = NULL,
-                         bool use_events = false);
-
-  /**
-   * @brief Process list of HMI requests using ProcessHMIRequest method
-   * @param requests List of requests to process
-   */
-  void ProcessHMIRequests(const smart_objects::SmartObjectList& requests);
-
   void InsertToTimerQueue(uint32_t app_id, uint32_t time_stamp);
 
   /**
@@ -635,6 +537,7 @@ class ResumeCtrlImpl : public ResumeCtrl,
   time_t wake_up_time_;
   std::shared_ptr<ResumptionData> resumption_storage_;
   application_manager::ApplicationManager& application_manager_;
+  ResumptionDataProcessor resumption_data_processor_;
   /**
    *@brief Mapping correlation id to request
    *wait for on event response from HMI to resume HMI Level

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -1,0 +1,449 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUMPTION_PROCESS_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUMPTION_PROCESS_
+
+#include <functional>
+#include <map>
+#include <vector>
+
+#include "application_manager/application.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/resume_ctrl.h"
+#include "smart_objects/smart_object.h"
+#include "utils/rwlock.h"
+
+namespace resumption {
+
+namespace app_mngr = application_manager;
+
+/**
+ * @brief The ResumptionRequestIDs struct contains fields, needed during
+ * processing events, related to responses from HMI to each resumption request
+ */
+struct ResumptionRequestIDs {
+  hmi_apis::FunctionID::eType function_id;
+  int32_t correlation_id;
+
+  /**
+   * @brief This operator is needed for correct iteration through map, which
+   * contains keys with type ResumptionRequestID
+   */
+  bool operator<(const ResumptionRequestIDs& other) const;
+};
+
+/**
+ * @brief The ResumptionRequest struct contains information, needed for
+ * processing event, and request message
+ */
+struct ResumptionRequest {
+  ResumptionRequestIDs request_ids;
+  smart_objects::SmartObject message;
+};
+
+/**
+ * @brief ApplicationResumptionStatus contains information about all requests,
+ * which was sent, and results of this operation
+ */
+struct ApplicationResumptionStatus {
+  std::vector<ResumptionRequest> list_of_sent_requests;
+  std::vector<ResumptionRequest> error_requests;
+  std::vector<ResumptionRequest> successful_requests;
+  std::vector<std::string> unsuccessful_vehicle_data_subscriptions_;
+  std::vector<std::string> successful_vehicle_data_subscriptions_;
+};
+
+/**
+ * @brief Determines whether response is successful
+ * judging from type of response received from HMI
+ * @param response from HMI
+ */
+bool IsResponseSuccessful(const smart_objects::SmartObject& response);
+
+/**
+ * @brief Contains logic for the resumption and revert resumption data of
+ *  applications.
+ */
+class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
+ public:
+  /**
+   * @brief allows to create ResumptionDataProcessor object
+   */
+  explicit ResumptionDataProcessor(
+      application_manager::ApplicationManager& application_manager);
+
+  /**
+   * @brief allows to destroy ResumptionDataProcessor object
+   */
+  ~ResumptionDataProcessor();
+
+  /**
+   * @brief Running resumption data process from saved_app to application.
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void Restore(app_mngr::ApplicationSharedPtr application,
+               smart_objects::SmartObject& saved_app,
+               ResumeCtrl::ResumptionCallBack callback);
+
+  /**
+   * @brief Event, that raised if application get resumption response from HMI
+   * @param event : event object, that contains smart_object HMI response
+   * message
+   */
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+
+  /**
+   * @brief Handle restored data when timeout appeared
+   * @param application id - const int32_t
+   */
+  void HandleOnTimeOut(const uint32_t correlation_id,
+                       const hmi_apis::FunctionID::eType);
+
+ private:
+  /**
+   * @brief GetAppIdWaitingForResponse returns application ID, which corresponds
+   * to function ID and correlation ID from event
+   * @param function_id Function ID
+   * @param corr_id Correlation ID
+   * @return optional object, which contains application ID, or empty optional,
+   * if such ID wasn't found
+   */
+  utils::Optional<uint32_t> GetAppIdWaitingForResponse(
+      const hmi_apis::FunctionID::eType function_id, const int32_t corr_id);
+
+  /**
+   * @brief GetRequest returns ResumptionRequest, which corresponds to
+   * function ID and correlation ID from event
+   * @param app_id ID of application, related to event
+   * @param function_id Function ID
+   * @param corr_id Correlation ID
+   * @return optional object, which contains resumption request, or empty
+   * optional, if such request wasn't found
+   */
+  utils::Optional<ResumptionRequest> GetRequest(
+      const uint32_t app_id,
+      const hmi_apis::FunctionID::eType function_id,
+      const int32_t corr_id);
+
+  /**
+   * @brief ProcessResumptionStatus processes received response to determine
+   * whether it is successful or not
+   * @param app_id ID of application, related to event
+   * @param response reference to response message
+   * @param found_request reference to found request
+   */
+  void ProcessResumptionStatus(const uint32_t app_id,
+                               const smart_objects::SmartObject& response,
+                               const ResumptionRequest& found_request);
+
+  /**
+   * @brief IsResumptionFinished checks whether some responses are still waiting
+   * @param app_id ID of application, related to event
+   * @param found_request reference to found request
+   * @return true, if resumption for this application is finished, or false, if
+   * some requests aren't processed  yet
+   */
+  bool IsResumptionFinished(const uint32_t app_id,
+                            const ResumptionRequest& found_request);
+
+  /**
+   * @brief IsResumptionSuccessful checks whether overall resumption status
+   * is successful or not
+   * @param app_id ID of application, related to event
+   * @return true, if resumption is successful, false otherwise
+   */
+  bool IsResumptionSuccessful(const uint32_t app_id);
+
+  /**
+   * @brief GetResumptionCallback returns ResumptionCallBack, which was stored
+   * for application, related to event
+   * @param app_id ID of application, related to event
+   * @return optional object, which contains callback, or empty optional,
+   * if callback wasn't found for such application ID
+   */
+  utils::Optional<ResumeCtrl::ResumptionCallBack> GetResumptionCallback(
+      const uint32_t app_id);
+
+  /**
+   * @brief EraseAppResumptionData erases data, needed for resumption, for
+   * given application
+   * @param app_id ID of application, related to event
+   * @param function_id Function ID
+   * @param corr_id Correlation ID
+   */
+  void EraseAppResumptionData(const uint32_t app_id,
+                              const hmi_apis::FunctionID::eType function_id,
+                              const int32_t corr_id);
+
+  /**
+   * @brief Processes response message from HMI
+   * @param response reference to response message
+   * @param function_id function id of response
+   * @param corr_id correlation id of response
+   */
+  void ProcessResponseFromHMI(const smart_objects::SmartObject& response,
+                              const hmi_apis::FunctionID::eType function_id,
+                              const int32_t corr_id);
+
+  /**
+   * @brief Revert the data to the state before Resumption
+   * @param shared ptr to application
+   */
+  void RevertRestoredData(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief subscribe to events for the application and save request
+   * @param app_id application id
+   * @param request for saving
+   */
+  void SubscribeToResponse(const int32_t app_id,
+                           const ResumptionRequest& request);
+
+  /**
+   * @brief Process specified HMI message
+   * @param request Message to process
+   * @param use_events flag to specify should message events be processed or
+   * not
+   * @return TRUE on success, otherwise FALSE
+   */
+  void ProcessMessageToHMI(smart_objects::SmartObjectSPtr request,
+                           bool subscribe_on_response);
+
+  /**
+   * @brief Process list of HMI messages using ProcessHMIRequest method
+   * @param messages List of messages to process
+   */
+  void ProcessMessagesToHMI(const smart_objects::SmartObjectList& messages);
+
+  /**
+   * @brief AddFiles allows to add files for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddFiles(app_mngr::ApplicationSharedPtr application,
+                const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddWindows allows to add widget windows for the application
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddWindows(app_mngr::ApplicationSharedPtr application,
+                  const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddSubmenues allows to add sub-menus for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddSubmenues(app_mngr::ApplicationSharedPtr application,
+                    const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting sub-menus that have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteSubmenues(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief AddCommands allows to add commands for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddCommands(app_mngr::ApplicationSharedPtr application,
+                   const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting all commands that have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteCommands(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief AddChoicesets allows to add choice sets for the application
+   * which should be resumed
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddChoicesets(app_mngr::ApplicationSharedPtr application,
+                     const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting choice sets that have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteChoicesets(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief SetGlobalProperties allows to restore global properties.
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void SetGlobalProperties(app_mngr::ApplicationSharedPtr application,
+                           const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Reset global properties that have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteGlobalProperties(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief AddSubscriptions allows to restore subscriptions
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddSubscriptions(app_mngr::ApplicationSharedPtr application,
+                        const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddSubscriptions allows to restore subscriptions
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddButtonsSubscriptions(app_mngr::ApplicationSharedPtr application,
+                               const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief AddSubscriptions allows to restore subscriptions
+   * @param application application which will be resumed
+   * @param saved_app application specific section from backup file
+   */
+  void AddPluginsSubscriptions(app_mngr::ApplicationSharedPtr application,
+                               const smart_objects::SmartObject& saved_app);
+
+  /**
+   * @brief Deleting subscriptions have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteSubscriptions(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Deleting buttons subscriptions have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteButtonsSubscriptions(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Deleting plugins subscriptions have been resumed
+   * @param app_id application id
+   */
+  void DeletePluginsSubscriptions(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Deletting subscription for CreateWindow have been resumed
+   * @param shared ptr to application
+   */
+  void DeleteWindowsSubscriptions(app_mngr::ApplicationSharedPtr application);
+
+  /**
+   * @brief Get button subscriptions that need to be resumed.
+   * Since some subscriptions can be set by default during
+   * app registration, this function is needed to discard subscriptions
+   * that do not need to be resumed
+   * @param application which subscriptions to resume
+   */
+  app_mngr::ButtonSubscriptions GetButtonSubscriptionsToResume(
+      app_mngr::ApplicationSharedPtr application) const;
+
+  /**
+   * @brief Checks whether SubscribeVehicleData response successful or not and
+   * handles it
+   * @param request reference to request SO
+   * @param response reference to response SO
+   * @param status reference to struct, which stores informaion about
+   * successful and unsuccessful subscriptions to vehicle data
+   */
+  void CheckVehicleDataResponse(const smart_objects::SmartObject& request,
+                                const smart_objects::SmartObject& response,
+                                ApplicationResumptionStatus& status);
+
+  /**
+   * @brief Checks whether CreateWindow response successful or not and handles
+   * it
+   * @param request reference to request SO
+   * @param response reference to response SO
+   */
+  void CheckCreateWindowResponse(
+      const smart_objects::SmartObject& request,
+      const smart_objects::SmartObject& response) const;
+
+  /**
+   * @brief Determines whether application has saved data, including
+   * submenues, commands and choice sets, to restore. This does not include
+   * global properties and subscriptions
+   * @param saved_app smart object containing saved app data
+   * @return bool value stating whether app has mentioned data to restore
+   */
+  bool HasDataToRestore(const smart_objects::SmartObject& saved_app) const;
+
+  /**
+   * @brief Determines whether application has saved global properties
+   * to restore
+   * @param saved_app smart object containing saved app data
+   * @return bool value stating whether app has mentioned data to restore
+   */
+  bool HasGlobalPropertiesToRestore(
+      const smart_objects::SmartObject& saved_app) const;
+
+  /**
+   * @brief Determines whether application has saved subscriptions
+   * to restore
+   * @param saved_app smart object containing saved app data
+   * @return bool value stating whether app has mentioned data to restore
+   */
+  bool HasSubscriptionsToRestore(
+      const smart_objects::SmartObject& saved_app) const;
+
+  app_mngr::ApplicationManager& application_manager_;
+
+  /**
+   * @brief A map of the IDs and Application Resumption Status for these ID
+   **/
+  std::map<std::int32_t, ApplicationResumptionStatus> resumption_status_;
+  sync_primitives::RWLock resumption_status_lock_;
+
+  /**
+   * @brief A map of callbacks used when resumption is finished
+   */
+  std::map<std::int32_t, ResumeCtrl::ResumptionCallBack> register_callbacks_;
+  sync_primitives::RWLock register_callbacks_lock_;
+
+  /**
+   * @brief A map of sent requests and corresponding app_id
+   */
+  std::map<ResumptionRequestIDs, std::uint32_t> request_app_ids_;
+  sync_primitives::RWLock request_app_ids_lock_;
+};
+
+}  // namespace resumption
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_RESUMPTION_RESUMPTION_PROCESS_

--- a/src/components/application_manager/include/application_manager/state_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/state_controller_impl.h
@@ -126,6 +126,10 @@ class StateControllerImpl : public event_engine::EventObserver,
   void ActivateDefaultWindow(ApplicationSharedPtr app) OVERRIDE;
   void ExitDefaultWindow(ApplicationSharedPtr app) OVERRIDE;
 
+  void ResumePostponedWindows(const uint32_t app_id) OVERRIDE;
+
+  void DropPostponedWindows(const uint32_t app_id) OVERRIDE;
+
  private:
   int64_t RequestHMIStateChange(ApplicationConstSharedPtr app,
                                 hmi_apis::Common_HMILevel::eType level,
@@ -426,6 +430,11 @@ class StateControllerImpl : public event_engine::EventObserver,
   StateIDList active_states_;
   mutable sync_primitives::Lock active_states_lock_;
   std::map<uint32_t, HmiStatePtr> waiting_for_response_;
+
+  typedef std::pair<WindowID, HmiStatePtr> WindowStatePair;
+  typedef std::list<WindowStatePair> WindowStatePairs;
+  std::map<uint32_t, WindowStatePairs> postponed_app_widgets_;
+
   ApplicationManager& app_mngr_;
 };
 }  // namespace application_manager

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/app_service_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/app_service_app_extension.h
@@ -97,20 +97,14 @@ class AppServiceAppExtension : public app_mngr::AppExtension {
    */
   AppServiceSubscriptions Subscriptions();
 
-  /**
-   * @brief SaveResumptionData saves vehicle info data
-   * @param resumption_data plase to store resumption data
-   */
   void SaveResumptionData(ns_smart_device_link::ns_smart_objects::SmartObject&
                               resumption_data) OVERRIDE;
 
-  /**
-   * @brief ProcessResumption load resumtion data back to plugin during
-   * resumption
-   * @param resumption_data resumption data
-   */
-  void ProcessResumption(
-      const smart_objects::SmartObject& resumption_data) OVERRIDE;
+  void ProcessResumption(const smart_objects::SmartObject& saved_app,
+                         resumption::Subscriber subscriber) OVERRIDE;
+
+  void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) OVERRIDE;
 
   /**
    * @brief ExtractVIExtension utility function to extract application extension

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/app_service_plugin/app_service_app_extension_test.cc
@@ -40,7 +40,8 @@ namespace {
 const std::string kAppServiceType1 = "AppServiceType1";
 const std::string kAppServiceType2 = "AppServiceType2";
 const std::string kResumptionDataKey = "kResumptionDataKey";
-const std::string kAppServiceInfoKey = "appService";
+const std::string kAppServiceInfoKey =
+    application_manager::hmi_interface::app_service;
 }  // namespace
 
 namespace test {
@@ -195,9 +196,11 @@ TEST_F(AppServiceAppExtensionTest, ProcessResumption_SUCCESS) {
       smart_objects::SmartObject(kAppServiceType2));
 
   smart_objects::SmartObject resumption_data;
-  resumption_data[kAppServiceInfoKey] = app_service_data;
+  resumption_data[application_manager::strings::application_subscriptions]
+                 [kAppServiceInfoKey] = app_service_data;
 
-  app_service_app_extension_->ProcessResumption(resumption_data);
+  resumption::Subscriber subscriber;
+  app_service_app_extension_->ProcessResumption(resumption_data, subscriber);
 
   for (const auto& app_service_type : {kAppServiceType1, kAppServiceType2}) {
     EXPECT_TRUE(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
@@ -203,11 +203,13 @@ class RCAppExtension : public application_manager::AppExtension {
 
   // AppExtension interface
  public:
-  void SaveResumptionData(ns_smart_device_link::ns_smart_objects::SmartObject&
-                              resumption_data) OVERRIDE;
-  void ProcessResumption(
-      const ns_smart_device_link::ns_smart_objects::SmartObject&
-          resumption_data) OVERRIDE;
+  void SaveResumptionData(smart_objects::SmartObject& resumption_data) OVERRIDE;
+
+  void ProcessResumption(const smart_objects::SmartObject& saved_app,
+                         resumption::Subscriber subscriber) OVERRIDE;
+
+  void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) OVERRIDE;
 };
 
 typedef std::shared_ptr<RCAppExtension> RCAppExtensionPtr;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
@@ -81,11 +81,14 @@ bool RCAppExtension::IsSubscribedToInteriorVehicleData(
 }
 
 void RCAppExtension::SaveResumptionData(
-    ns_smart_device_link::ns_smart_objects::SmartObject& resumption_data) {}
+    smart_objects::SmartObject& resumption_data) {}
 
 void RCAppExtension::ProcessResumption(
-    const ns_smart_device_link::ns_smart_objects::SmartObject&
-        resumption_data) {}
+    const smart_objects::SmartObject& saved_app,
+    resumption::Subscriber subscriber) {}
+
+void RCAppExtension::RevertResumption(
+    const smart_objects::SmartObject& subscriptions) {}
 
 std::set<ModuleUid> RCAppExtension::InteriorVehicleDataSubscriptions() const {
   return subscribed_interior_vehicle_data_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/CMakeLists.txt
@@ -54,7 +54,6 @@ set(LIBRARIES
   ApplicationManager
   HMI_API
   MOBILE_API
-  MessageHelper
   connectionHandler
   v4_protocol_v1_2_no_extra
   SmartObjects
@@ -72,6 +71,7 @@ target_link_libraries("sdl_rpc_plugin_static" ${LIBRARIES})
 
 add_library("sdl_rpc_plugin" SHARED "src/sdl_rpc_plugin.cc")
 target_link_libraries("sdl_rpc_plugin" sdl_rpc_plugin_static)
+target_link_libraries("sdl_rpc_plugin" MessageHelper)
 
 set(INSTALL_DESTINATION bin)
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h
@@ -65,6 +65,8 @@ class NaviSubscribeWayPointsRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run() OVERRIDE;
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviSubscribeWayPointsRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h
@@ -67,6 +67,8 @@ class TTSSetGlobalPropertiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSSetGlobalPropertiesRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_command_request.h
@@ -66,6 +66,8 @@ class UIAddCommandRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UIAddCommandRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h
@@ -66,6 +66,8 @@ class UIAddSubmenuRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UIAddSubmenuRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_create_window_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_create_window_request.h
@@ -55,6 +55,8 @@ class UICreateWindowRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() FINAL;
 
+  void onTimeOut() FINAL;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UICreateWindowRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
@@ -77,7 +77,7 @@ class UIIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief onTimeOut from requrst Controller
    */
-  virtual void onTimeOut() OVERRIDE;
+  void onTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h
@@ -67,6 +67,8 @@ class UISetGlobalPropertiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(UISetGlobalPropertiesRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_add_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_add_command_request.h
@@ -66,6 +66,8 @@ class VRAddCommandRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  void onTimeOut() OVERRIDE;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(VRAddCommandRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
@@ -85,40 +85,6 @@ class ResetGlobalPropertiesRequest
 
  private:
   /*
-   * @brief Sets default value of the HELPPROMT global property
-   * to the first vrCommand of each Command Menu registered in application
-   *
-   * @param app Registered application
-   * @param is_timeout_promp Flag indicating that timeout prompt
-   * should be reset
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetHelpPromt(app_mngr::ApplicationSharedPtr app);
-
-  /*
-   * @brief  Sets default value of the TIMEOUTPROMT global property
-   * to the first vrCommand of each Command Menu registered in application
-   *
-   * @param app Registered application
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetTimeoutPromt(application_manager::ApplicationSharedPtr const app);
-
-  /*
-   * @brief Sets default value of the VRHELPTITLE global property
-   * to the application name and value of the VRHELPITEMS global property
-   * to value equal to registered command -1(default command “Help / Cancel”.)
-   *
-   * @param app Registered application
-   *
-   * @return TRUE on success, otherwise FALSE
-   */
-  bool ResetVrHelpTitleItems(
-      application_manager::ApplicationSharedPtr const app);
-
-  /*
    * @brief Prepare result for sending to mobile application
    * @param out_result_code contains result code for sending to mobile
    * application
@@ -134,6 +100,12 @@ class ResetGlobalPropertiesRequest
    * @return true if all responses received
    */
   bool IsPendingResponseExist();
+
+  /*
+   * @brief ResetGlobalProperties gets global properties data from message_
+   * and passes it to ApplicationManager::ResetGlobalProperties
+   */
+  void ResetGlobalProperties();
 
   DISALLOW_COPY_AND_ASSIGN(ResetGlobalPropertiesRequest);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/extensions/system_capability_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/extensions/system_capability_app_extension.h
@@ -62,11 +62,13 @@ class SystemCapabilityAppExtension : public app_mngr_::AppExtension {
 
   SystemCapabilitySubscriptions Subscriptions();
 
-  void SaveResumptionData(ns_smart_device_link::ns_smart_objects::SmartObject&
-                              resumption_data) OVERRIDE;
+  void SaveResumptionData(smart_objects::SmartObject& resumption_data) OVERRIDE;
 
-  void ProcessResumption(
-      const smart_objects::SmartObject& resumption_data) OVERRIDE;
+  void ProcessResumption(const smart_objects::SmartObject& saved_app,
+                         resumption::Subscriber subscriber) OVERRIDE;
+
+  void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) OVERRIDE;
 
   static const app_mngr_::AppExtensionUID SystemCapabilityAppExtensionUID;
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_app_extension.h
@@ -1,0 +1,70 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_APP_EXTENSION_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_APP_EXTENSION_H
+
+#include <application_manager/application_manager.h>
+
+namespace sdl_rpc_plugin {
+class SDLRPCPlugin;
+
+namespace app_mngr = application_manager;
+
+/**
+ * @brief Intended to handle subscriptions on way points
+ */
+class SDLAppExtension : public app_mngr::AppExtension {
+ public:
+  /**
+   * @brief SDLAppExtension constructor
+   * @param plugin sdl info plugin
+   * @param app application that contains this plugin
+   */
+  SDLAppExtension(SDLRPCPlugin& plugin, app_mngr::Application& app);
+  virtual ~SDLAppExtension();
+
+  void SaveResumptionData(smart_objects::SmartObject& resumption_data) OVERRIDE;
+
+  void ProcessResumption(const smart_objects::SmartObject& saved_app,
+                         resumption::Subscriber subscriber) OVERRIDE;
+
+  void RevertResumption(
+      const smart_objects::SmartObject& subscriptions) OVERRIDE;
+
+  /**
+   * @brief SDLAppExtensionUID unique identifier of VehicleInfo
+   * aplication extension
+   */
+  static unsigned SDLAppExtensionUID;
+
+ private:
+  SDLRPCPlugin& plugin_;
+  app_mngr::Application& app_;
+};
+}  // namespace sdl_rpc_plugin
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_APP_EXTENSION_H

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
@@ -1,0 +1,95 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H
+
+#include <map>
+#include <queue>
+#include <vector>
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "sdl_rpc_plugin/sdl_app_extension.h"
+
+namespace sdl_rpc_plugin {
+
+namespace app_mngr = application_manager;
+
+class SDLPendingResumptionHandler
+    : public resumption::ExtensionPendingResumptionHandler {
+ public:
+  SDLPendingResumptionHandler(
+      app_mngr::ApplicationManager& application_manager);
+
+  // EventObserver interface
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+
+  void HandleResumptionSubscriptionRequest(
+      app_mngr::AppExtension& extension,
+      resumption::Subscriber& subscriber,
+      application_manager::Application& app) OVERRIDE;
+
+  void OnResumptionRevert() OVERRIDE;
+
+ private:
+  /**
+   * @brief RaiseFakeSuccessfulResponse raize event for the subscriber that
+   * contains emulated successful response from HMI To avoid double subscription
+   * SDLPendingResumptionHandler freezes sending requests to HMI. But
+   * subscriber() function need to be called to provide information that some
+   * data need to be resumed. So if pending request exists, SDL creates
+   * preliminary requests to HMI, subscribe the subscriber to this request but
+   * do not send it to HMI. It freezes this requests to precess the one by one
+   * when a response to the current request will be received When SDL receives a
+   * response from HMI it may satisfy some frozen requests. If it does SDL will
+   * create faked HMI response(based on the real one with corr_id replacement)
+   * and raize event. So that subscriber::on_event will be called with an
+   * appropriate response to the request that SDL was not sent to HMI.
+   * @param response message that will be raised with corr_id replacement
+   * @param corr_id correlation id that will be replaced in response to notify
+   * the subscriber
+   */
+  void RaiseFakeSuccessfulResponse(smart_objects::SmartObject response,
+                                   const int32_t corr_id);
+  smart_objects::SmartObjectSPtr CreateSubscriptionRequest();
+
+  struct ResumptionAwaitingHandling {
+    const uint32_t app_id;
+    SDLAppExtension& ext;
+    resumption::Subscriber subscriber;
+    resumption::ResumptionRequest request_to_send_;
+  };
+
+  typedef std::pair<SDLAppExtension, resumption::Subscriber> FreezedResumption;
+  std::vector<ResumptionAwaitingHandling> freezed_resumptions_;
+  std::map<uint32_t, smart_objects::SmartObject> pending_requests_;
+  std::queue<uint32_t> app_ids_;
+};
+}  // namespace sdl_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_rpc_plugin.h
@@ -34,16 +34,19 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_SDL_RPC_PLUGIN_H
 #include "application_manager/command_factory.h"
 #include "application_manager/plugin_manager/rpc_plugin.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
 namespace plugins = application_manager::plugin_manager;
 
 class SystemCapabilityAppExtension;
+class SDLAppExtension;
 
 class SDLRPCPlugin : public plugins::RPCPlugin {
   // RPCPlugin interface
  public:
+  SDLRPCPlugin();
   bool Init(app_mngr::ApplicationManager& app_manager,
             app_mngr::rpc_service::RPCService& rpc_service,
             app_mngr::HMICapabilities& hmi_capabilities,
@@ -56,6 +59,30 @@ class SDLRPCPlugin : public plugins::RPCPlugin {
             app_mngr::HMICapabilities& hmi_capabilities,
             policy::PolicyHandlerInterface& policy_handler,
             resumption::LastState& last_state) OVERRIDE;
+
+  /**
+   * @brief ProcessResumptionSubscription send appropriate subscribe requests
+   * to HMI
+   * @param app application for subscription
+   * @param ext application extension
+   * @param subscriber callback for subscription
+   */
+  void ProcessResumptionSubscription(application_manager::Application& app,
+                                     SDLAppExtension& ext,
+                                     resumption::Subscriber subscriber);
+
+  /**
+   * @brief Revert the data to the state before Resumption.
+   * @param app Application owning resumption data
+   **/
+  void RevertResumption(application_manager::Application& app);
+
+  /**
+   * @brief SaveResumptionData saves subscription data
+   * @param resumption_data plase to store resumption data
+   */
+  void SaveResumptionData(application_manager::Application& app,
+                          smart_objects::SmartObject& resumption_data);
 
   bool IsAbleToProcess(
       const int32_t function_id,
@@ -71,6 +98,10 @@ class SDLRPCPlugin : public plugins::RPCPlugin {
   void ClearSubscriptions(app_mngr::ApplicationSharedPtr app);
 
   std::unique_ptr<application_manager::CommandFactory> command_factory_;
+  application_manager::ApplicationManager* application_manager_;
+  using ExtensionPendingResumptionHandlerSPtr =
+      std::shared_ptr<resumption::ExtensionPendingResumptionHandler>;
+  ExtensionPendingResumptionHandlerSPtr pending_resumption_handler_;
 };
 }  // namespace sdl_rpc_plugin
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_subscribe_way_points_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void NaviSubscribeWayPointsRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void NaviSubscribeWayPointsRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.cc
@@ -87,10 +87,11 @@ OnBCSystemCapabilityUpdatedNotificationFromHMI::
   (*message_)[strings::params][strings::connection_key] =
       (*message_)[strings::msg_params][strings::app_id];
   (*message_)[strings::msg_params].erase(strings::app_id);
-  if (app->is_resuming() && app->is_app_data_resumption_allowed()) {
-    LOG4CXX_DEBUG(logger_, "Application is resuming");
-    app->display_capabilities_builder().UpdateDisplayCapabilities(
-        display_capabilities);
+
+  auto& builder = app->display_capabilities_builder();
+  if (builder.IsWaitingForWindowCapabilities(display_capabilities)) {
+    LOG4CXX_DEBUG(logger_, "Application is waiting for capabilities");
+    builder.UpdateDisplayCapabilities(display_capabilities);
     return ProcessSystemDisplayCapabilitiesResult::CAPABILITIES_CACHED;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_set_global_properties_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,13 @@ void TTSSetGlobalPropertiesRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void TTSSetGlobalPropertiesRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_command_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_add_command_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void UIAddCommandRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UIAddCommandRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_submenu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_submenu_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,13 @@ void UIAddSubmenuRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UIAddSubmenuRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_create_window_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_create_window_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void UICreateWindowRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UICreateWindowRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_set_global_properties_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,13 @@ void UISetGlobalPropertiesRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void UISetGlobalPropertiesRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_add_command_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/vr_add_command_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -55,6 +56,14 @@ void VRAddCommandRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
 
   SendRequest();
+}
+
+void VRAddCommandRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
@@ -36,6 +36,7 @@
 
 #include "application_manager/application.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/resumption/resume_ctrl.h"
 #include "utils/custom_string.h"
 #include "utils/file_system.h"
 #include "utils/helpers.h"
@@ -71,6 +72,12 @@ void AddCommandRequest::onTimeOut() {
   LOG4CXX_AUTO_TRACE(logger_);
   RemoveCommand();
   CommandRequestImpl::onTimeOut();
+
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 bool AddCommandRequest::Init() {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_interaction_choice_set_request.cc
@@ -39,6 +39,7 @@
 
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/resumption/resume_ctrl.h"
 #include "utils/gen_hash.h"
 #include "utils/helpers.h"
 
@@ -419,6 +420,12 @@ void CreateInteractionChoiceSetRequest::onTimeOut() {
   }
   CommandRequestImpl::onTimeOut();
   DeleteChoices();
+
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 
   // We have to keep request alive until receive all responses from HMI
   // according to SDLAQ-CRS-2976

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
@@ -157,13 +157,6 @@ void OnSystemCapabilityUpdatedNotification::Run() {
       [&system_capability_type,
        &initial_connection_key](const ApplicationSharedPtr app) {
         DCHECK_OR_RETURN(app, false);
-        auto& ext = SystemCapabilityAppExtension::ExtractExtension(*app);
-        if (!ext.IsSubscribedTo(system_capability_type)) {
-          LOG4CXX_DEBUG(logger_,
-                        "App " << app->app_id()
-                               << " is not subscribed to this capability type");
-          return false;
-        }
 
         if (mobile_apis::SystemCapabilityType::DISPLAYS ==
                 system_capability_type &&
@@ -172,6 +165,27 @@ void OnSystemCapabilityUpdatedNotification::Run() {
                         "Display capabilities notification for app "
                             << initial_connection_key << " only");
           return app->app_id() == initial_connection_key;
+        }
+
+        auto ext_ptr = app->QueryInterface(
+            SystemCapabilityAppExtension::SystemCapabilityAppExtensionUID);
+
+        if (!ext_ptr) {
+          LOG4CXX_DEBUG(logger_,
+                        "App "
+                            << app->app_id()
+                            << " does not have SystemCapabilityAppExtension");
+          return false;
+        }
+
+        auto ext =
+            std::static_pointer_cast<SystemCapabilityAppExtension>(ext_ptr);
+
+        if (!ext->IsSubscribedTo(system_capability_type)) {
+          LOG4CXX_DEBUG(logger_,
+                        "App " << app->app_id()
+                               << " is not subscribed to this capability type");
+          return false;
         }
 
         LOG4CXX_DEBUG(logger_,
@@ -208,13 +222,14 @@ void OnSystemCapabilityUpdatedNotification::Run() {
     if (mobile_apis::SystemCapabilityType::DISPLAYS == system_capability_type) {
       LOG4CXX_DEBUG(logger_, "Using common display capabilities");
       auto capabilities = hmi_capabilities_.system_display_capabilities();
-      if (app->is_resuming() && app->is_app_data_resumption_allowed()) {
+
+      auto& builder = app->display_capabilities_builder();
+      if (app->is_resuming() && builder.IsWindowResumptionNeeded()) {
         LOG4CXX_DEBUG(logger_,
                       "Application "
                           << app->app_id()
                           << " is resuming. Providing cached capabilities");
-        auto display_caps =
-            app->display_capabilities_builder().display_capabilities();
+        auto display_caps = builder.display_capabilities();
         capabilities = display_caps;
       } else if (app->display_capabilities()) {
         LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -186,7 +186,10 @@ RegisterAppInterfaceRequest::RegisterAppInterfaceRequest(
                          rpc_service,
                          hmi_capabilities,
                          policy_handler)
-    , result_code_(mobile_apis::Result::INVALID_ENUM)
+    , are_tts_chunks_invalid_(false)
+    , are_hmi_types_invalid_(false)
+    , is_resumption_failed_(false)
+    , is_wrong_language_(false)
     , device_handle_(0) {}
 
 RegisterAppInterfaceRequest::~RegisterAppInterfaceRequest() {}
@@ -196,18 +199,7 @@ bool RegisterAppInterfaceRequest::Init() {
   return true;
 }
 
-void RegisterAppInterfaceRequest::Run() {
-  using namespace helpers;
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "Connection key is " << connection_key());
-
-  // Fix problem with SDL and HMI HTML. This problem is not actual for HMI PASA.
-  // Flag conditional compilation specific to customer is used in order to
-  // exclude hit code
-  // to RTC
-  // FIXME(EZamakhov): on shutdown - get freez
-
-  // wait till HMI started
+void RegisterAppInterfaceRequest::WaitForHMIIsReady() {
   while (!application_manager_.IsStopping() &&
          !application_manager_.IsHMICooperating()) {
     LOG4CXX_DEBUG(logger_,
@@ -221,6 +213,327 @@ void RegisterAppInterfaceRequest::Run() {
     sleep(1);
     // TODO(DK): timer_->StartWait(1);
   }
+}
+
+void RegisterAppInterfaceRequest::FillApplicationParams(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto& msg_params = (*message_)[strings::msg_params];
+  application->set_is_media_application(
+      msg_params[strings::is_media_application].asBool());
+
+  if (msg_params.keyExists(strings::vr_synonyms)) {
+    application->set_vr_synonyms(msg_params[strings::vr_synonyms]);
+  }
+
+  if (msg_params.keyExists(strings::ngn_media_screen_app_name)) {
+    application->set_ngn_media_screen_name(
+        msg_params[strings::ngn_media_screen_app_name]);
+  }
+
+  if (msg_params.keyExists(strings::tts_name)) {
+    smart_objects::SmartObject& tts_name =
+        (*message_)[strings::msg_params][strings::tts_name];
+    mobile_apis::Result::eType verification_result =
+        MessageHelper::VerifyTtsFiles(
+            tts_name, application, application_manager_);
+
+    if (mobile_apis::Result::FILE_NOT_FOUND == verification_result) {
+      LOG4CXX_WARN(
+          logger_,
+          "MessageHelper::VerifyTtsFiles return " << verification_result);
+      response_info_ = "One or more files needed for tts_name are not present";
+      are_tts_chunks_invalid_ = true;
+    }
+    application->set_tts_name(tts_name);
+  }
+
+  if (msg_params.keyExists(strings::app_hmi_type)) {
+    application->set_app_types(msg_params[strings::app_hmi_type]);
+
+    // check app type
+    const smart_objects::SmartObject& app_type =
+        msg_params.getElement(strings::app_hmi_type);
+
+    for (size_t i = 0; i < app_type.length(); ++i) {
+      mobile_apis::AppHMIType::eType current_app_type =
+          static_cast<mobile_apis::AppHMIType::eType>(
+              app_type.getElement(i).asUInt());
+
+      switch (current_app_type) {
+        case mobile_apis::AppHMIType::NAVIGATION: {
+          application->set_is_navi(true);
+          break;
+        }
+        case mobile_apis::AppHMIType::COMMUNICATION: {
+          application->set_voice_communication_supported(true);
+          break;
+        }
+        case mobile_apis::AppHMIType::PROJECTION: {
+          application->set_mobile_projection_enabled(true);
+          break;
+        }
+        case mobile_apis::AppHMIType::REMOTE_CONTROL: {
+          application->set_remote_control_supported(true);
+          break;
+        }
+        default: {}
+      }
+    }
+  }
+
+  if (msg_params.keyExists(strings::day_color_scheme)) {
+    application->set_day_color_scheme(msg_params[strings::day_color_scheme]);
+  }
+
+  if (msg_params.keyExists(strings::night_color_scheme)) {
+    application->set_night_color_scheme(
+        msg_params[strings::night_color_scheme]);
+  }
+}
+
+void RegisterAppInterfaceRequest::SetupAppDeviceInfo(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto& msg_params = (*message_)[strings::msg_params];
+
+  policy::DeviceParams dev_params;
+  if (-1 == application_manager_.connection_handler()
+                .get_session_observer()
+                .GetDataOnDeviceID(application->device(),
+                                   &dev_params.device_name,
+                                   NULL,
+                                   &dev_params.device_mac_address,
+                                   &dev_params.device_connection_type)) {
+    LOG4CXX_ERROR(
+        logger_,
+        "Failed to extract information for device " << application->device());
+  }
+  policy::DeviceInfo device_info;
+  device_info.AdoptDeviceType(dev_params.device_connection_type);
+  if (msg_params.keyExists(strings::device_info)) {
+    FillDeviceInfo(&device_info);
+  }
+  const std::string& device_mac = application->mac_address();
+  GetPolicyHandler().SetDeviceInfo(device_mac, device_info);
+}
+
+bool RegisterAppInterfaceRequest::ApplicationDataShouldBeResumed(
+    std::string& add_info) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto& msg_params = (*message_)[strings::msg_params];
+  resumption::ResumeCtrl& resumer = application_manager_.resume_controller();
+
+  const uint32_t key = connection_key();
+  ApplicationSharedPtr application = application_manager_.application(key);
+
+  const bool hash_id_present = msg_params.keyExists(strings::hash_id);
+  const std::string hash_id = msg_params[strings::hash_id].asString();
+  const bool resumption = hash_id_present && !hash_id.empty();
+
+  if (!resumption) {
+    LOG4CXX_DEBUG(logger_, "Hash id is missing, no resumption required");
+    return false;
+  }
+
+  if (!resumer.CheckApplicationHash(application, hash_id)) {
+    LOG4CXX_WARN(logger_, "Hash from RAI does not match to saved resume data.");
+    add_info = "Hash from RAI does not match to saved resume data.";
+    is_resumption_failed_ = true;
+    return false;
+  }
+
+  if (!resumer.CheckPersistenceFilesForResumption(application)) {
+    LOG4CXX_WARN(logger_, "Persistent data is missing.");
+    add_info = "Persistent data is missing.";
+    is_resumption_failed_ = true;
+    return false;
+  }
+
+  LOG4CXX_WARN(logger_, "Resume succeeded.");
+  add_info = "Resume succeeded.";
+  application->set_app_data_resumption_allowance(true);
+  application->set_is_resuming(true);
+
+  return true;
+}
+
+mobile_apis::Result::eType
+RegisterAppInterfaceRequest::CalculateFinalResultCode() const {
+  if (is_wrong_language_) {
+    LOG4CXX_DEBUG(logger_, "Language was wrong");
+    return mobile_apis::Result::WRONG_LANGUAGE;
+  }
+
+  if (are_hmi_types_invalid_ || are_tts_chunks_invalid_) {
+    LOG4CXX_DEBUG(logger_, "HMI types or TTS chunks are invalid");
+    return mobile_apis::Result::WARNINGS;
+  }
+
+  if (is_resumption_failed_) {
+    LOG4CXX_DEBUG(logger_, "Resumption has been failed");
+    return mobile_apis::Result::RESUME_FAILED;
+  }
+
+  return mobile_apis::Result::SUCCESS;
+}
+
+policy::StatusNotifier RegisterAppInterfaceRequest::AddApplicationDataToPolicy(
+    application_manager::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  AppHmiTypes hmi_types;
+  if ((*message_)[strings::msg_params].keyExists(strings::app_hmi_type)) {
+    smart_objects::SmartArray* hmi_types_ptr =
+        (*message_)[strings::msg_params][strings::app_hmi_type].asArray();
+    if (hmi_types_ptr) {
+      SmartArrayValueExtractor extractor;
+      if (hmi_types_ptr && 0 < hmi_types_ptr->size()) {
+        std::transform(hmi_types_ptr->begin(),
+                       hmi_types_ptr->end(),
+                       std::back_inserter(hmi_types),
+                       extractor);
+      }
+    }
+  }
+
+  return policy_handler_.AddApplication(
+      application->mac_address(), application->policy_app_id(), hmi_types);
+}
+
+void RegisterAppInterfaceRequest::CheckLanguage() {
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  DCHECK_OR_RETURN_VOID(application);
+  const auto& msg_params = (*message_)[strings::msg_params];
+  if (msg_params[strings::language_desired].asInt() !=
+          hmi_capabilities_.active_vr_language() ||
+      msg_params[strings::hmi_display_language_desired].asInt() !=
+          hmi_capabilities_.active_ui_language()) {
+    LOG4CXX_WARN(logger_,
+                 "Wrong language on registering application "
+                     << application->name().c_str());
+
+    LOG4CXX_ERROR(
+        logger_,
+        "VR language desired code is "
+            << msg_params[strings::language_desired].asInt()
+            << " , active VR language code is "
+            << hmi_capabilities_.active_vr_language()
+            << ", UI language code is "
+            << msg_params[strings::hmi_display_language_desired].asInt()
+            << " , active UI language code is "
+            << hmi_capabilities_.active_ui_language());
+
+    is_wrong_language_ = true;
+  }
+}
+
+smart_objects::SmartObjectSPtr GetLockScreenIconUrlNotification(
+    policy::PolicyHandlerInterface& policy_handler,
+    const uint32_t connection_key,
+    ApplicationSharedPtr app) {
+  DCHECK_OR_RETURN(app.get(), smart_objects::SmartObjectSPtr());
+  smart_objects::SmartObjectSPtr message =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  (*message)[strings::params][strings::function_id] =
+      mobile_apis::FunctionID::OnSystemRequestID;
+  (*message)[strings::params][strings::connection_key] = connection_key;
+  (*message)[strings::params][strings::message_type] =
+      mobile_apis::messageType::notification;
+  (*message)[strings::params][strings::protocol_type] =
+      application_manager::commands::CommandImpl::mobile_protocol_type_;
+  (*message)[strings::params][strings::protocol_version] =
+      app->protocol_version();
+  (*message)[strings::msg_params][strings::request_type] =
+      mobile_apis::RequestType::LOCK_SCREEN_ICON_URL;
+  (*message)[strings::msg_params][strings::url] =
+      policy_handler.GetLockScreenIconUrl(app->policy_app_id());
+  return message;
+}
+
+void SendDriverDistractionAndIconUrlNotifications(
+    ApplicationManager& app_manager,
+    const uint32_t connection_key,
+    ApplicationSharedPtr app) {
+  policy::PolicyHandlerInterface& policy_handler =
+      app_manager.GetPolicyHandler();
+  smart_objects::SmartObjectSPtr so =
+      GetLockScreenIconUrlNotification(policy_handler, connection_key, app);
+  app_manager.GetRPCService().ManageMobileCommand(
+      so, app_mngr::commands::Command::SOURCE_SDL);
+  app_manager.SendDriverDistractionState(app);
+  // Create onSystemRequest to mobile to obtain cloud app icons
+  app_manager.SendGetIconUrlNotifications(connection_key, app);
+}
+
+/**
+ * @brief FinishSendingResponseToMobile is needed because by the time
+ SendRegisterAppInterfaceResponseToMobile() is called from callback
+ in Run(), request object is deleted, which results in SDL crash. This function
+ is intended to prevent that, safely conclude sending response to mobile and
+ perform other related operations (sending notifications, setting HMI level
+ etc.)
+ * @param msg_params copy of request object
+ * @param app_manager reference to application manager
+ * @param connection_key connection key
+ * @param notify_upd_manager pointer to status notifier callback function
+ */
+void FinishSendingResponseToMobile(const smart_objects::SmartObject& msg_params,
+                                   ApplicationManager& app_manager,
+                                   const uint32_t connection_key,
+                                   policy::StatusNotifier notify_upd_manager) {
+  resumption::ResumeCtrl& resume_ctrl = app_manager.resume_controller();
+  auto application = app_manager.application(connection_key);
+
+  policy::PolicyHandlerInterface& policy_handler =
+      app_manager.GetPolicyHandler();
+
+  if (msg_params.keyExists(strings::app_hmi_type)) {
+    policy_handler.SetDefaultHmiTypes(application->device(),
+                                      application->policy_app_id(),
+                                      &(msg_params[strings::app_hmi_type]));
+  }
+
+  // Default HMI level should be set before any permissions validation, since
+  // it relies on HMI level.
+  app_manager.OnApplicationRegistered(application);
+
+  // Once HMI level is set we can safely forward system capabilities for the
+  // main window and it won't be blocked by policies
+  application->display_capabilities_builder().StopWaitingForWindow(
+      mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+
+  if (notify_upd_manager) {
+    (*notify_upd_manager)();
+  }
+
+  auto send_rc_status = [application](plugin_manager::RPCPlugin& plugin) {
+    plugin.OnApplicationEvent(plugin_manager::kRCStatusChanged, application);
+  };
+  app_manager.ApplyFunctorForEachPlugin(send_rc_status);
+
+  // Start PTU after successfull registration
+  // Sends OnPermissionChange notification to mobile right after RAI response
+  // and HMI level set-up
+  policy_handler.OnAppRegisteredOnMobile(application->mac_address(),
+                                         application->policy_app_id());
+  SendDriverDistractionAndIconUrlNotifications(
+      app_manager, connection_key, application);
+  const bool is_app_saved_in_resumption = resume_ctrl.IsApplicationSaved(
+      application->policy_app_id(), application->mac_address());
+  if (is_app_saved_in_resumption) {
+    resume_ctrl.StartResumptionOnlyHMILevel(application);
+  }
+}
+
+void RegisterAppInterfaceRequest::Run() {
+  using namespace helpers;
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_, "Connection key is " << connection_key());
+
+  WaitForHMIIsReady();
 
   if (application_manager_.IsStopping()) {
     LOG4CXX_WARN(logger_, "The ApplicationManager is stopping!");
@@ -423,68 +736,29 @@ void RegisterAppInterfaceRequest::Run() {
     application->set_msg_version(module_version);
   }
 
-  application->set_is_media_application(
-      msg_params[strings::is_media_application].asBool());
+  FillApplicationParams(application);
+  SetupAppDeviceInfo(application);
+  auto status_notifier = AddApplicationDataToPolicy(application);
 
-  if (msg_params.keyExists(strings::vr_synonyms)) {
-    application->set_vr_synonyms(msg_params[strings::vr_synonyms]);
-  }
+  std::string add_info;
+  const auto is_resumption_required = ApplicationDataShouldBeResumed(add_info);
 
-  if (msg_params.keyExists(strings::ngn_media_screen_app_name)) {
-    application->set_ngn_media_screen_name(
-        msg_params[strings::ngn_media_screen_app_name]);
-  }
+  auto& resume_ctrl = application_manager_.resume_controller();
 
-  if (msg_params.keyExists(strings::tts_name)) {
-    smart_objects::SmartObject& tts_name =
-        (*message_)[strings::msg_params][strings::tts_name];
-    mobile_apis::Result::eType verification_result =
-        MessageHelper::VerifyTtsFiles(
-            tts_name, application, application_manager_);
+  // DisplayCapabilitiesBuilder has to collect all the information
+  // from incoming HMI notifications and send only one notification
+  // to mobile app, even if hash does not match, which means that app data
+  // will not be resumed, notification should be sent for default window as
+  // it will be resumed in any case
+  resume_ctrl.StartWaitingForDisplayCapabilitiesUpdate(application,
+                                                       is_resumption_required);
 
-    if (mobile_apis::Result::FILE_NOT_FOUND == verification_result) {
-      LOG4CXX_WARN(
-          logger_,
-          "MessageHelper::VerifyTtsFiles return " << verification_result);
-      response_info_ = "One or more files needed for tts_name are not present";
-      result_code_ = mobile_apis::Result::WARNINGS;
-    }
-    application->set_tts_name(tts_name);
-  }
+  SendOnAppRegisteredNotificationToHMI(
+      application, is_resumption_required && !is_resumption_failed_);
 
-  if (msg_params.keyExists(strings::app_hmi_type)) {
-    application->set_app_types(msg_params[strings::app_hmi_type]);
-
-    // check app type
-    const smart_objects::SmartObject& app_type =
-        msg_params.getElement(strings::app_hmi_type);
-
-    for (size_t i = 0; i < app_type.length(); ++i) {
-      mobile_apis::AppHMIType::eType current_app_type =
-          static_cast<mobile_apis::AppHMIType::eType>(
-              app_type.getElement(i).asUInt());
-
-      switch (current_app_type) {
-        case mobile_apis::AppHMIType::NAVIGATION: {
-          application->set_is_navi(true);
-          break;
-        }
-        case mobile_apis::AppHMIType::COMMUNICATION: {
-          application->set_voice_communication_supported(true);
-          break;
-        }
-        case mobile_apis::AppHMIType::PROJECTION: {
-          application->set_mobile_projection_enabled(true);
-          break;
-        }
-        case mobile_apis::AppHMIType::REMOTE_CONTROL: {
-          application->set_remote_control_supported(true);
-          break;
-        }
-        default: {}
-      }
-    }
-  }
+  // By default app subscribed to CUSTOM_BUTTON
+  SendSubscribeCustomButtonNotification();
+  SendChangeRegistrationOnHMI(application);
 
   auto on_app_registered = [application](plugin_manager::RPCPlugin& plugin) {
     plugin.OnApplicationEvent(plugin_manager::kApplicationRegistered,
@@ -492,67 +766,34 @@ void RegisterAppInterfaceRequest::Run() {
   };
   application_manager_.ApplyFunctorForEachPlugin(on_app_registered);
 
-  if (msg_params.keyExists(strings::day_color_scheme)) {
-    application->set_day_color_scheme(msg_params[strings::day_color_scheme]);
+  if (is_resumption_required) {
+    application_manager_.updateRequestTimeout(
+        connection_key(), correlation_id(), 0);
+
+    const auto& msg_params = (*message_)[strings::msg_params];
+    const auto& hash_id = msg_params[strings::hash_id].asString();
+    LOG4CXX_WARN(logger_, "Start Data Resumption");
+    auto send_response = [this, application, status_notifier](
+                             mobile_apis::Result::eType result_code,
+                             const std::string info) {
+      LOG4CXX_DEBUG(logger_, "Invoking lambda callback for: " << this);
+      if (result_code != mobile_apis::Result::SUCCESS) {
+        is_resumption_failed_ = true;
+      }
+
+      SendRegisterAppInterfaceResponseToMobile(
+          ApplicationType::kNewApplication, status_notifier, info);
+      application->UpdateHash();
+    };
+    resume_ctrl.StartResumption(application, hash_id, send_response);
+
+    return;
   }
 
-  if (msg_params.keyExists(strings::night_color_scheme)) {
-    application->set_night_color_scheme(
-        msg_params[strings::night_color_scheme]);
-  }
+  CheckLanguage();
 
-  // Add device to policy table and set device info, if any
-  policy::DeviceParams dev_params;
-  if (-1 == application_manager_.connection_handler()
-                .get_session_observer()
-                .GetDataOnDeviceID(application->device(),
-                                   &dev_params.device_name,
-                                   NULL,
-                                   &dev_params.device_mac_address,
-                                   &dev_params.device_connection_type)) {
-    LOG4CXX_ERROR(
-        logger_,
-        "Failed to extract information for device " << application->device());
-  }
-  policy::DeviceInfo device_info;
-  device_info.AdoptDeviceType(dev_params.device_connection_type);
-  if (msg_params.keyExists(strings::device_info)) {
-    FillDeviceInfo(&device_info);
-  }
-
-  const std::string& device_mac = application->mac_address();
-
-  GetPolicyHandler().SetDeviceInfo(device_mac, device_info);
-
-  SendRegisterAppInterfaceResponseToMobile(ApplicationType::kNewApplication);
-  smart_objects::SmartObjectSPtr so =
-      GetLockScreenIconUrlNotification(connection_key(), application);
-  rpc_service_.ManageMobileCommand(so, SOURCE_SDL);
-  application_manager_.SendDriverDistractionState(application);
-  // Create onSystemRequest to mobile to obtain cloud app icons
-  application_manager_.SendGetIconUrlNotifications(connection_key(),
-                                                   application);
-}
-
-smart_objects::SmartObjectSPtr
-RegisterAppInterfaceRequest::GetLockScreenIconUrlNotification(
-    const uint32_t connection_key, ApplicationSharedPtr app) {
-  DCHECK_OR_RETURN(app.get(), smart_objects::SmartObjectSPtr());
-  smart_objects::SmartObjectSPtr message =
-      std::make_shared<smart_objects::SmartObject>(
-          smart_objects::SmartType_Map);
-  (*message)[strings::params][strings::function_id] =
-      mobile_apis::FunctionID::OnSystemRequestID;
-  (*message)[strings::params][strings::connection_key] = connection_key;
-  (*message)[strings::params][strings::message_type] =
-      mobile_apis::messageType::notification;
-  (*message)[strings::params][strings::protocol_type] = mobile_protocol_type_;
-  (*message)[strings::params][strings::protocol_version] = protocol_version_;
-  (*message)[strings::msg_params][strings::request_type] =
-      mobile_apis::RequestType::LOCK_SCREEN_ICON_URL;
-  (*message)[strings::msg_params][strings::url] =
-      GetPolicyHandler().GetLockScreenIconUrl(app->policy_app_id());
-  return message;
+  SendRegisterAppInterfaceResponseToMobile(
+      ApplicationType::kNewApplication, status_notifier, add_info);
 }
 
 void FillVRRelatedFields(smart_objects::SmartObject& response_params,
@@ -682,27 +923,16 @@ void FillUIRelatedFields(smart_objects::SmartObject& response_params,
 }
 
 void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
-    ApplicationType app_type) {
+    ApplicationType app_type,
+    policy::StatusNotifier status_notifier,
+    const std::string& add_info) {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject response_params(smart_objects::SmartType_Map);
-
-  mobile_apis::Result::eType result_code = mobile_apis::Result::SUCCESS;
 
   const HMICapabilities& hmi_capabilities = hmi_capabilities_;
 
   const uint32_t key = connection_key();
   ApplicationSharedPtr application = application_manager_.application(key);
-
-  resumption::ResumeCtrl& resumer = application_manager_.resume_controller();
-
-  if (!application) {
-    LOG4CXX_ERROR(logger_,
-                  "There is no application for such connection key" << key);
-    LOG4CXX_DEBUG(logger_, "Need to start resume data persistent timer");
-    resumer.OnAppRegistrationEnd();
-    return;
-  }
-
   utils::SemanticVersion negotiated_version = application->msg_version();
 
   response_params[strings::sync_msg_version][strings::major_version] =
@@ -714,27 +944,6 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
 
   const smart_objects::SmartObject& msg_params =
       (*message_)[strings::msg_params];
-
-  if (msg_params[strings::language_desired].asInt() !=
-          hmi_capabilities.active_vr_language() ||
-      msg_params[strings::hmi_display_language_desired].asInt() !=
-          hmi_capabilities.active_ui_language()) {
-    LOG4CXX_WARN(logger_,
-                 "Wrong language on registering application "
-                     << application->name().c_str());
-
-    LOG4CXX_ERROR(
-        logger_,
-        "VR language desired code is "
-            << msg_params[strings::language_desired].asInt()
-            << " , active VR language code is "
-            << hmi_capabilities.active_vr_language() << ", UI language code is "
-            << msg_params[strings::hmi_display_language_desired].asInt()
-            << " , active UI language code is "
-            << hmi_capabilities.active_ui_language());
-
-    result_code = mobile_apis::Result::WRONG_LANGUAGE;
-  }
 
   if (HmiInterfaces::STATE_NOT_AVAILABLE !=
       application_manager_.hmi_interfaces().GetInterfaceState(
@@ -760,39 +969,36 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     FillVIRelatedFields(response_params, hmi_capabilities);
   }
 
-  auto button_capabilities = hmi_capabilities.button_capabilities();
-  if (button_capabilities) {
-    response_params[hmi_response::button_capabilities] = *button_capabilities;
+  if (hmi_capabilities.button_capabilities()) {
+    response_params[hmi_response::button_capabilities] =
+        *hmi_capabilities.button_capabilities();
   }
 
-  auto soft_button_capabilities = hmi_capabilities.soft_button_capabilities();
-  if (soft_button_capabilities) {
+  if (hmi_capabilities.soft_button_capabilities()) {
     response_params[hmi_response::soft_button_capabilities] =
-        *soft_button_capabilities;
+        *hmi_capabilities.soft_button_capabilities();
   }
 
-  auto preset_bank_capabilities = hmi_capabilities.preset_bank_capabilities();
-  if (preset_bank_capabilities) {
+  if (hmi_capabilities.preset_bank_capabilities()) {
     response_params[hmi_response::preset_bank_capabilities] =
-        *preset_bank_capabilities;
+        *hmi_capabilities.preset_bank_capabilities();
   }
 
-  auto hmi_zone_capabilities = hmi_capabilities.hmi_zone_capabilities();
-  if (hmi_zone_capabilities) {
-    if (smart_objects::SmartType_Array == hmi_zone_capabilities->getType()) {
+  if (hmi_capabilities.hmi_zone_capabilities()) {
+    if (smart_objects::SmartType_Array ==
+        hmi_capabilities.hmi_zone_capabilities()->getType()) {
       // hmi_capabilities json contains array and HMI response object
       response_params[hmi_response::hmi_zone_capabilities] =
-          *hmi_zone_capabilities;
+          *hmi_capabilities.hmi_zone_capabilities();
     } else {
       response_params[hmi_response::hmi_zone_capabilities][0] =
-          *hmi_zone_capabilities;
+          *hmi_capabilities.hmi_zone_capabilities();
     }
   }
 
-  auto pcm_stream_capabilities = hmi_capabilities.pcm_stream_capabilities();
-  if (pcm_stream_capabilities) {
+  if (hmi_capabilities.pcm_stream_capabilities()) {
     response_params[strings::pcm_stream_capabilities] =
-        *pcm_stream_capabilities;
+        *hmi_capabilities.pcm_stream_capabilities();
   }
 
   const std::vector<uint32_t>& diag_modes =
@@ -834,108 +1040,18 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     return;
   }
 
-  const bool hash_id_present =
-      (*message_)[strings::msg_params].keyExists(strings::hash_id);
-  const std::string hash_id =
-      (*message_)[strings::msg_params][strings::hash_id].asString();
-
-  const bool resumption = hash_id_present && !hash_id.empty();
-  bool need_restore_vr = resumption;
-
-  std::string add_info;
-  if (resumption) {
-    if (!resumer.CheckApplicationHash(application, hash_id)) {
-      LOG4CXX_WARN(logger_,
-                   "Hash from RAI does not match to saved resume data.");
-      result_code = mobile_apis::Result::RESUME_FAILED;
-      add_info = "Hash from RAI does not match to saved resume data.";
-      need_restore_vr = false;
-    } else if (!resumer.CheckPersistenceFilesForResumption(application)) {
-      LOG4CXX_WARN(logger_, "Persistent data is missing.");
-      result_code = mobile_apis::Result::RESUME_FAILED;
-      add_info = "Persistent data is missing.";
-      need_restore_vr = false;
-    } else {
-      add_info = "Resume succeeded.";
-      application->set_app_data_resumption_allowance(true);
-      application->set_is_resuming(true);
-    }
-  }
-  if ((mobile_apis::Result::SUCCESS == result_code) &&
-      (mobile_apis::Result::INVALID_ENUM != result_code_)) {
-    add_info += response_info_;
-    result_code = result_code_;
-  }
-
-  // In case application exist in resumption we need to send resumeVrgrammars
-  const bool is_app_saved_in_resumption = resumer.IsApplicationSaved(
-      application->policy_app_id(), application->mac_address());
-
-  // If app is in resuming state
-  // DisplayCapabilitiesBuilder has to collect all the information
-  // from incoming HMI notifications and send only one notification
-  // to mobile app, even if hash does not match, which means that app data
-  // will not be resumed, notification should be sent for default window as
-  // it will be resumed in any case
-  if (resumption || is_app_saved_in_resumption) {
-    resumer.StartWaitingForDisplayCapabilitiesUpdate(application);
-  }
-
-  AppHmiTypes hmi_types;
-  if ((*message_)[strings::msg_params].keyExists(strings::app_hmi_type)) {
-    smart_objects::SmartArray* hmi_types_ptr =
-        (*message_)[strings::msg_params][strings::app_hmi_type].asArray();
-    DCHECK_OR_RETURN_VOID(hmi_types_ptr);
-    SmartArrayValueExtractor extractor;
-    if (hmi_types_ptr && 0 < hmi_types_ptr->size()) {
-      std::transform(hmi_types_ptr->begin(),
-                     hmi_types_ptr->end(),
-                     std::back_inserter(hmi_types),
-                     extractor);
-    }
-  }
-  policy::StatusNotifier notify_upd_manager = GetPolicyHandler().AddApplication(
-      application->mac_address(), application->policy_app_id(), hmi_types);
+  response_info_ += add_info;
 
   response_params[strings::icon_resumed] =
       file_system::FileExists(application->app_icon_path());
 
-  SendResponse(true, result_code, add_info.c_str(), &response_params);
-  if (msg_params.keyExists(strings::app_hmi_type)) {
-    GetPolicyHandler().SetDefaultHmiTypes(application->device(),
-                                          application->policy_app_id(),
-                                          &(msg_params[strings::app_hmi_type]));
-  }
+  smart_objects::SmartObject msg_params_copy = msg_params;
+  const auto result_code = CalculateFinalResultCode();
 
-  // Default HMI level should be set before any permissions validation, since it
-  // relies on HMI level.
-  application_manager_.OnApplicationRegistered(application);
+  SendResponse(true, result_code, response_info_.c_str(), &response_params);
 
-  auto send_rc_status = [application](plugin_manager::RPCPlugin& plugin) {
-    plugin.OnApplicationEvent(plugin_manager::kRCStatusChanged, application);
-  };
-  application_manager_.ApplyFunctorForEachPlugin(send_rc_status);
-
-  SendOnAppRegisteredNotificationToHMI(
-      application, resumption, need_restore_vr);
-  (*notify_upd_manager)();
-
-  // Start PTU after successfull registration
-  // Sends OnPermissionChange notification to mobile right after RAI response
-  // and HMI level set-up
-  GetPolicyHandler().OnAppRegisteredOnMobile(application->mac_address(),
-                                             application->policy_app_id());
-
-  if (result_code != mobile_apis::Result::RESUME_FAILED &&
-      application->is_app_data_resumption_allowed()) {
-    resumer.StartResumption(application, hash_id);
-  } else if (is_app_saved_in_resumption) {
-    resumer.StartResumptionOnlyHMILevel(application);
-  }
-
-  // By default app subscribed to CUSTOM_BUTTON
-  SendSubscribeCustomButtonNotification();
-  SendChangeRegistrationOnHMI(application);
+  FinishSendingResponseToMobile(
+      msg_params_copy, application_manager_, key, status_notifier);
 }
 
 void RegisterAppInterfaceRequest::SendChangeRegistration(
@@ -971,7 +1087,7 @@ void RegisterAppInterfaceRequest::SendChangeRegistrationOnHMI(
 }
 
 void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
-    ApplicationConstSharedPtr app, bool resumption, bool need_restore_vr) {
+    ApplicationConstSharedPtr app, bool resumption) {
   using namespace smart_objects;
   SmartObjectSPtr notification = std::make_shared<SmartObject>(SmartType_Map);
   if (!notification) {
@@ -992,7 +1108,7 @@ void RegisterAppInterfaceRequest::SendOnAppRegisteredNotificationToHMI(
   // Due to current requirements in case when we're in resumption mode
   // we have to always send resumeVRGrammar field.
   if (resumption) {
-    msg_params[strings::resume_vr_grammars] = need_restore_vr;
+    msg_params[strings::resume_vr_grammars] = resumption;
   }
 
   if (app->vr_synonyms()) {
@@ -1180,6 +1296,7 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckWithPolicyData() {
     if (message[strings::msg_params].keyExists(strings::app_hmi_type)) {
       // If AppHmiTypes are partially same, the system should allow those listed
       // in the policy table and send warning info on missed values
+
       smart_objects::SmartArray app_types =
           *(message[strings::msg_params][strings::app_hmi_type].asArray());
 
@@ -1191,7 +1308,7 @@ mobile_apis::Result::eType RegisterAppInterfaceRequest::CheckWithPolicyData() {
             "Following AppHmiTypes are not present in policy "
             "table:" +
             log;
-        result_code_ = mobile_apis::Result::WARNINGS;
+        are_hmi_types_invalid_ = true;
       }
     }
     // Replace AppHmiTypes in request with values allowed by policy table
@@ -1483,12 +1600,15 @@ bool RegisterAppInterfaceRequest::IsApplicationSwitched() {
   }
 
   application_manager_.ProcessReconnection(app, connection_key());
-  SendRegisterAppInterfaceResponseToMobile(app_type);
 
-  MessageHelper::SendHMIStatusNotification(
-      app,
-      mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
-      application_manager_);
+  const std::string additional_info;
+  SendRegisterAppInterfaceResponseToMobile(
+      app_type, policy::StatusNotifier(), additional_info);
+
+  auto notification = MessageHelper::CreateHMIStatusNotification(
+      app, mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+  application_manager_.GetRPCService().ManageMobileCommand(notification,
+                                                           SOURCE_SDL);
 
   application_manager_.OnApplicationSwitched(app);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -61,208 +61,7 @@ ResetGlobalPropertiesRequest::ResetGlobalPropertiesRequest(
 ResetGlobalPropertiesRequest::~ResetGlobalPropertiesRequest() {}
 
 void ResetGlobalPropertiesRequest::Run() {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  uint32_t app_id =
-      (*message_)[strings::params][strings::connection_key].asUInt();
-  ApplicationSharedPtr app = application_manager_.application(app_id);
-
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "No application associated with session key");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return;
-  }
-
-  size_t obj_length =
-      (*message_)[strings::msg_params][strings::properties].length();
-  // if application waits for sending ttsGlobalProperties need to remove this
-  // application from tts_global_properties_app_list_
-  LOG4CXX_INFO(logger_, "RemoveAppFromTTSGlobalPropertiesList");
-  application_manager_.RemoveAppFromTTSGlobalPropertiesList(app_id);
-
-  bool helpt_promt = false;
-  bool timeout_prompt = false;
-  bool vr_help_title_items = false;
-  bool menu_name = false;
-  bool menu_icon = false;
-  bool is_key_board_properties = false;
-  int number_of_reset_vr = 0;
-  mobile_apis::GlobalProperty::eType global_property =
-      mobile_apis::GlobalProperty::INVALID_ENUM;
-
-  for (size_t i = 0; i < obj_length; ++i) {
-    global_property = static_cast<mobile_apis::GlobalProperty::eType>(
-        (*message_)[strings::msg_params][strings::properties][i].asInt());
-
-    if (mobile_apis::GlobalProperty::HELPPROMPT == global_property) {
-      helpt_promt = ResetHelpPromt(app);
-    } else if (mobile_apis::GlobalProperty::TIMEOUTPROMPT == global_property) {
-      timeout_prompt = ResetTimeoutPromt(app);
-    } else if (((mobile_apis::GlobalProperty::VRHELPTITLE == global_property) ||
-                (mobile_apis::GlobalProperty::VRHELPITEMS ==
-                 global_property)) &&
-               (0 == number_of_reset_vr)) {
-      ++number_of_reset_vr;
-      vr_help_title_items = ResetVrHelpTitleItems(app);
-    } else if (mobile_apis::GlobalProperty::MENUNAME == global_property) {
-      menu_name = true;
-    } else if (mobile_apis::GlobalProperty::MENUICON == global_property) {
-      menu_icon = true;
-    } else if (mobile_apis::GlobalProperty::KEYBOARDPROPERTIES ==
-               global_property) {
-      is_key_board_properties = true;
-    }
-  }
-
-  if (vr_help_title_items || menu_name || menu_icon ||
-      is_key_board_properties) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
-  }
-
-  if (timeout_prompt || helpt_promt) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
-  }
-
-  app->set_reset_global_properties_active(true);
-
-  if (vr_help_title_items || menu_name || menu_icon ||
-      is_key_board_properties) {
-    smart_objects::SmartObject msg_params =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-    if (vr_help_title_items) {
-      smart_objects::SmartObjectSPtr vr_help =
-          MessageHelper::CreateAppVrHelp(app);
-      if (!vr_help) {
-        return;
-      }
-      msg_params = *vr_help;
-    }
-    if (menu_name) {
-      msg_params[hmi_request::menu_title] = "";
-      app->set_menu_title(msg_params[hmi_request::menu_title]);
-    }
-    // TODO(DT): clarify the sending parameter menuIcon
-    // if (menu_icon) {
-    //}
-    if (is_key_board_properties) {
-      smart_objects::SmartObject key_board_properties =
-          smart_objects::SmartObject(smart_objects::SmartType_Map);
-      key_board_properties[strings::language] =
-          static_cast<int32_t>(hmi_apis::Common_Language::EN_US);
-      key_board_properties[hmi_request::keyboard_layout] =
-          static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
-
-      // Look for APPLINK-4432 for details.
-      /*smart_objects::SmartObject limited_character_list =
-      smart_objects::SmartObject(
-            smart_objects::SmartType_Array);
-      limited_character_list[0] = "";
-      key_board_properties[hmi_request::limited_character_list] =
-        limited_character_list;*/
-
-      key_board_properties[hmi_request::auto_complete_list] =
-          smart_objects::SmartObject(smart_objects::SmartType_Array);
-      msg_params[hmi_request::keyboard_properties] = key_board_properties;
-    }
-
-    msg_params[strings::app_id] = app->app_id();
-    SendHMIRequest(
-        hmi_apis::FunctionID::UI_SetGlobalProperties, &msg_params, true);
-  }
-
-  if (timeout_prompt || helpt_promt) {
-    // create ui request
-    smart_objects::SmartObject msg_params =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-    if (helpt_promt) {
-      msg_params[strings::help_prompt] = (*app->help_prompt());
-    }
-
-    if (timeout_prompt) {
-      msg_params[strings::timeout_prompt] = (*app->timeout_prompt());
-    }
-
-    msg_params[strings::app_id] = app->app_id();
-
-    SendHMIRequest(
-        hmi_apis::FunctionID::TTS_SetGlobalProperties, &msg_params, true);
-  }
-}
-
-bool ResetGlobalPropertiesRequest::ResetHelpPromt(
-    application_manager::ApplicationSharedPtr app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-  const std::vector<std::string>& help_prompt =
-      application_manager_.get_settings().help_prompt();
-
-  smart_objects::SmartObject so_help_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  for (size_t i = 0; i < help_prompt.size(); ++i) {
-    smart_objects::SmartObject help_prompt_item =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-    help_prompt_item[strings::text] = help_prompt[i];
-    help_prompt_item[strings::type] =
-        hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-    so_help_prompt[i] = help_prompt_item;
-  }
-
-  app->set_help_prompt(so_help_prompt);
-  return true;
-}
-
-bool ResetGlobalPropertiesRequest::ResetTimeoutPromt(
-    application_manager::ApplicationSharedPtr const app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-
-  const std::vector<std::string>& time_out_promt =
-      application_manager_.get_settings().time_out_promt();
-
-  smart_objects::SmartObject so_time_out_promt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  for (size_t i = 0; i < time_out_promt.size(); ++i) {
-    smart_objects::SmartObject timeoutPrompt =
-        smart_objects::SmartObject(smart_objects::SmartType_Map);
-    timeoutPrompt[strings::text] = time_out_promt[i];
-    timeoutPrompt[strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-    so_time_out_promt[i] = timeoutPrompt;
-  }
-
-  app->set_timeout_prompt(so_time_out_promt);
-
-  return true;
-}
-
-bool ResetGlobalPropertiesRequest::ResetVrHelpTitleItems(
-    application_manager::ApplicationSharedPtr const app) {
-  if (!app) {
-    LOG4CXX_ERROR(logger_, "Null pointer");
-    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
-    return false;
-  }
-
-  const std::string& vr_help_title =
-      application_manager_.get_settings().vr_help_title();
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-
-  app->reset_vr_help_title();
-  app->reset_vr_help();
-  app->set_vr_help_title(so_vr_help_title);
-
-  return true;
+  ResetGlobalProperties();
 }
 
 void ResetGlobalPropertiesRequest::on_event(const event_engine::Event& event) {
@@ -351,6 +150,56 @@ bool ResetGlobalPropertiesRequest::PrepareResponseParameters(
 bool ResetGlobalPropertiesRequest::IsPendingResponseExist() {
   return IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS) ||
          IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI);
+}
+
+void ResetGlobalPropertiesRequest::ResetGlobalProperties() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  uint32_t app_id =
+      (*message_)[strings::params][strings::connection_key].asUInt();
+  ApplicationSharedPtr app = application_manager_.application(app_id);
+
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "No application associated with session key");
+    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
+    return;
+  }
+
+  const auto& global_properties =
+      (*message_)[strings::msg_params][strings::properties];
+
+  auto reset_global_props_result =
+      application_manager_.ResetGlobalProperties(global_properties, app_id);
+
+  if (reset_global_props_result.HasUIPropertiesReset()) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+  }
+
+  if (reset_global_props_result.HasTTSPropertiesReset()) {
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
+  }
+
+  app->set_reset_global_properties_active(true);
+
+  if (reset_global_props_result.HasUIPropertiesReset()) {
+    // create ui request
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(
+            reset_global_props_result, app);
+    if (msg_params.get()) {
+      SendHMIRequest(
+          hmi_apis::FunctionID::UI_SetGlobalProperties, msg_params.get(), true);
+    }
+  }
+
+  if (reset_global_props_result.HasTTSPropertiesReset()) {
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+            reset_global_props_result, app);
+
+    SendHMIRequest(
+        hmi_apis::FunctionID::TTS_SetGlobalProperties, msg_params.get(), true);
+  }
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
@@ -66,7 +66,7 @@ void SubscribeWayPointsRequest::Run() {
     return;
   }
 
-  if (application_manager_.IsAppSubscribedForWayPoints(app)) {
+  if (application_manager_.IsAppSubscribedForWayPoints(*app)) {
     SendResponse(false, mobile_apis::Result::IGNORED);
     return;
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -66,7 +66,7 @@ void UnsubscribeWayPointsRequest::Run() {
     return;
   }
 
-  if (!application_manager_.IsAppSubscribedForWayPoints(app)) {
+  if (!application_manager_.IsAppSubscribedForWayPoints(*app)) {
     SendResponse(false, mobile_apis::Result::IGNORED);
     return;
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/extensions/system_capability_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/extensions/system_capability_app_extension.cc
@@ -1,9 +1,12 @@
 #include "sdl_rpc_plugin/extensions/system_capability_app_extension.h"
+#include "application_manager/smart_object_keys.h"
 
 namespace sdl_rpc_plugin {
 CREATE_LOGGERPTR_GLOBAL(logger_, "GetSystemCapabilitiesAppExtension")
 
 namespace app_mngr_ = application_manager;
+namespace strings = app_mngr::strings;
+
 const app_mngr_::AppExtensionUID
     SystemCapabilityAppExtension::SystemCapabilityAppExtensionUID = 200;
 
@@ -53,34 +56,45 @@ SystemCapabilitySubscriptions SystemCapabilityAppExtension::Subscriptions() {
 }
 
 void SystemCapabilityAppExtension::SaveResumptionData(
-    ns_smart_device_link::ns_smart_objects::SmartObject& resumption_data) {
+    smart_objects::SmartObject& resumption_data) {
   LOG4CXX_AUTO_TRACE(logger_);
-  const char* application_system_capability = "systemCapability";
 
-  resumption_data[application_system_capability] =
+  resumption_data[strings::system_capability] =
       smart_objects::SmartObject(smart_objects::SmartType_Array);
 
   int i = 0;
   for (const auto& subscription : subscribed_data_) {
-    resumption_data[application_system_capability][i] = subscription;
+    resumption_data[strings::system_capability][i] = subscription;
     i++;
   }
 }
 
 void SystemCapabilityAppExtension::ProcessResumption(
-    const smart_objects::SmartObject& resumption_data) {
+    const smart_objects::SmartObject& saved_app,
+    resumption::Subscriber subscriber) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  const char* application_system_capability = "systemCapability";
-  if (resumption_data.keyExists(application_system_capability)) {
-    const smart_objects::SmartObject& subscriptions =
-        resumption_data[application_system_capability];
-    for (size_t i = 0; i < subscriptions.length(); ++i) {
-      SystemCapabilityType capability_type =
-          static_cast<SystemCapabilityType>((resumption_data[i]).asInt());
+  UNUSED(subscriber);
+
+  const smart_objects::SmartObject& subscriptions =
+      saved_app[application_manager::strings::application_subscriptions];
+
+  if (saved_app.keyExists(strings::system_capability)) {
+    const auto& system_capability_subscriptions =
+        subscriptions[strings::system_capability];
+    for (size_t i = 0; i < system_capability_subscriptions.length(); ++i) {
+      SystemCapabilityType capability_type = static_cast<SystemCapabilityType>(
+          (system_capability_subscriptions[i]).asInt());
       SubscribeTo(capability_type);
     }
   }
+}
+
+void SystemCapabilityAppExtension::RevertResumption(
+    const smart_objects::SmartObject& subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  UNUSED(subscriptions);
 }
 
 SystemCapabilityAppExtension& SystemCapabilityAppExtension::ExtractExtension(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_app_extension.cc
@@ -1,0 +1,77 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/sdl_app_extension.h"
+#include "sdl_rpc_plugin/sdl_rpc_plugin.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "SDLAppExtension")
+
+namespace sdl_rpc_plugin {
+namespace strings = application_manager::strings;
+unsigned SDLAppExtension::SDLAppExtensionUID = 138;
+
+SDLAppExtension::SDLAppExtension(SDLRPCPlugin& plugin,
+                                 application_manager::Application& app)
+    : app_mngr::AppExtension(SDLAppExtension::SDLAppExtensionUID)
+    , plugin_(plugin)
+    , app_(app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+}
+
+SDLAppExtension::~SDLAppExtension() {
+  LOG4CXX_AUTO_TRACE(logger_);
+}
+
+void SDLAppExtension::SaveResumptionData(
+    smart_objects::SmartObject& resumption_data) {
+  plugin_.SaveResumptionData(app_, resumption_data);
+}
+
+void SDLAppExtension::ProcessResumption(
+    const smart_objects::SmartObject& saved_app,
+    resumption::Subscriber subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!saved_app.keyExists(strings::subscribed_for_way_points)) {
+    LOG4CXX_ERROR(logger_, "subscribed_for_way_points section does not exist");
+    return;
+  }
+  const bool subscribed_for_way_points_so =
+      saved_app[strings::subscribed_for_way_points].asBool();
+  if (subscribed_for_way_points_so) {
+    plugin_.ProcessResumptionSubscription(app_, *this, subscriber);
+  }
+}
+
+void SDLAppExtension::RevertResumption(
+    const smart_objects::SmartObject& subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  UNUSED(subscriptions);
+
+  plugin_.RevertResumption(app_);
+}
+}  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
@@ -1,0 +1,218 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/sdl_pending_resumption_handler.h"
+#include "application_manager/event_engine/event.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "utils/helpers.h"
+
+namespace sdl_rpc_plugin {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "SdlRPCPlugin")
+
+SDLPendingResumptionHandler::SDLPendingResumptionHandler(
+    application_manager::ApplicationManager& application_manager)
+    : ExtensionPendingResumptionHandler(application_manager) {}
+
+smart_objects::SmartObjectSPtr
+SDLPendingResumptionHandler::CreateSubscriptionRequest() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto subscribe_waypoints_msg =
+      application_manager::MessageHelper::CreateMessageForHMI(
+          hmi_apis::FunctionID::Navigation_SubscribeWayPoints,
+          application_manager_.GetNextHMICorrelationID());
+  (*subscribe_waypoints_msg)[application_manager::strings::params]
+                            [application_manager::strings::message_type] =
+                                hmi_apis::messageType::request;
+  return subscribe_waypoints_msg;
+}
+
+void SDLPendingResumptionHandler::OnResumptionRevert() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+
+  if (!pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_, "Still waiting for some response");
+    return;
+  }
+
+  if (!freezed_resumptions_.empty()) {
+    ResumptionAwaitingHandling freezed_resumption = freezed_resumptions_.back();
+    freezed_resumptions_.pop_back();
+
+    auto request = std::make_shared<smart_objects::SmartObject>(
+        freezed_resumption.request_to_send_.message);
+    const uint32_t cid =
+        (*request)[strings::params][strings::correlation_id].asUInt();
+    const auto fid = static_cast<hmi_apis::FunctionID::eType>(
+        (*request)[strings::params][strings::function_id].asInt());
+
+    LOG4CXX_DEBUG(logger_,
+                  "Subscribing for event with function id: "
+                      << fid << " correlation id: " << cid);
+    subscribe_on_event(fid, cid);
+    pending_requests_[cid] = *request;
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with fid: " << fid << " and cid: " << cid);
+    application_manager_.GetRPCService().ManageHMICommand(request);
+  }
+}
+
+void SDLPendingResumptionHandler::RaiseFakeSuccessfulResponse(
+    ns_smart_device_link::ns_smart_objects::SmartObject response,
+    const int32_t corr_id) {
+  using namespace application_manager;
+  response[strings::params][strings::correlation_id] = corr_id;
+  auto fid = static_cast<hmi_apis::FunctionID::eType>(
+      response[strings::params][strings::function_id].asInt());
+  event_engine::Event event(fid);
+  event.set_smart_object(response);
+
+  LOG4CXX_TRACE(logger_,
+                "Raise fake response for subscriber. corr_id : " << corr_id);
+  event.raise(application_manager_.event_dispatcher());
+}
+
+void SDLPendingResumptionHandler::on_event(
+    const application_manager::event_engine::Event& event) {
+  using namespace application_manager;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const smart_objects::SmartObject& response = event.smart_object();
+  const uint32_t corr_id = event.smart_object_correlation_id();
+
+  LOG4CXX_TRACE(logger_,
+                "Received event with function id: "
+                    << event.id() << " and correlation id: " << corr_id);
+
+  smart_objects::SmartObject pending_request;
+  if (pending_requests_.find(corr_id) == pending_requests_.end()) {
+    LOG4CXX_DEBUG(logger_, "corr id " << corr_id << " NOT found");
+    return;
+  }
+  pending_request = pending_requests_[corr_id];
+  pending_requests_.erase(corr_id);
+  if (app_ids_.empty()) {
+    LOG4CXX_ERROR(logger_, "app_ids is empty");
+    return;
+  }
+  uint32_t app_id = app_ids_.front();
+  app_ids_.pop();
+  auto app = application_manager_.application(app_id);
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Application not found " << app_id);
+    return;
+  }
+
+  if (resumption::IsResponseSuccessful(response)) {
+    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is successful");
+
+    application_manager_.SubscribeAppForWayPoints(app);
+
+    for (auto& freezed_resumption : freezed_resumptions_) {
+      auto corr_id = freezed_resumption.request_to_send_
+                         .message[strings::params][strings::correlation_id]
+                         .asInt();
+      RaiseFakeSuccessfulResponse(response, corr_id);
+      application_manager_.SubscribeAppForWayPoints(freezed_resumption.app_id);
+    }
+    freezed_resumptions_.clear();
+  } else {
+    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is NOT successful");
+
+    if (freezed_resumptions_.empty()) {
+      LOG4CXX_DEBUG(logger_, "freezed resumptions is empty");
+      return;
+    }
+
+    ResumptionAwaitingHandling freezed_resumption = freezed_resumptions_.back();
+    freezed_resumptions_.pop_back();
+    auto resumption_req = freezed_resumption.request_to_send_;
+    const uint32_t cid =
+        resumption_req.message[strings::params][strings::correlation_id]
+            .asInt();
+    const hmi_apis::FunctionID::eType fid =
+        static_cast<hmi_apis::FunctionID::eType>(
+            resumption_req.message[strings::params][strings::function_id]
+                .asInt());
+    subscribe_on_event(fid, cid);
+    auto request =
+        std::make_shared<smart_objects::SmartObject>(resumption_req.message);
+    LOG4CXX_DEBUG(logger_,
+                  "Subscribing for event with function id: "
+                      << fid << " correlation id: " << cid);
+    pending_requests_[cid] = *request;
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with fid: " << fid << " and cid: " << cid);
+    application_manager_.GetRPCService().ManageHMICommand(request);
+  }
+}
+
+void SDLPendingResumptionHandler::HandleResumptionSubscriptionRequest(
+    application_manager::AppExtension& extension,
+    resumption::Subscriber& subscriber,
+    application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  SDLAppExtension& ext = dynamic_cast<SDLAppExtension&>(extension);
+  smart_objects::SmartObjectSPtr request = CreateSubscriptionRequest();
+  smart_objects::SmartObject& request_ref = *request;
+  const auto function_id = static_cast<hmi_apis::FunctionID::eType>(
+      request_ref[application_manager::strings::params]
+                 [application_manager::strings::function_id]
+                     .asInt());
+  const uint32_t corr_id =
+      request_ref[application_manager::strings::params]
+                 [application_manager::strings::correlation_id]
+                     .asUInt();
+
+  auto resumption_request =
+      MakeResumptionRequest(corr_id, function_id, *request);
+  app_ids_.push(app.app_id());
+
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_,
+                  "There are no pending requests for app_id: " << app.app_id());
+    pending_requests_[corr_id] = request_ref;
+    subscribe_on_event(function_id, corr_id);
+    LOG4CXX_DEBUG(logger_,
+                  "Sending request with function id: "
+                      << function_id << " and correlation_id: " << corr_id);
+
+    application_manager_.GetRPCService().ManageHMICommand(request);
+  } else {
+    LOG4CXX_DEBUG(logger_,
+                  "There are pending requests. Freeze resumption for app id "
+                      << app.app_id() << " corr id = " << corr_id);
+    ResumptionAwaitingHandling frozen_res{
+        app.app_id(), ext, subscriber, resumption_request};
+    freezed_resumptions_.push_back(frozen_res);
+  }
+  subscriber(app.app_id(), resumption_request);
+}
+}  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -31,9 +31,12 @@
  */
 
 #include "sdl_rpc_plugin/sdl_rpc_plugin.h"
+#include "application_manager/message_helper.h"
 #include "application_manager/plugin_manager/plugin_keys.h"
 #include "sdl_rpc_plugin/extensions/system_capability_app_extension.h"
+#include "sdl_rpc_plugin/sdl_app_extension.h"
 #include "sdl_rpc_plugin/sdl_command_factory.h"
+#include "sdl_rpc_plugin/sdl_pending_resumption_handler.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -41,12 +44,18 @@ namespace plugins = application_manager::plugin_manager;
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "SdlRPCPlugin")
 
+SDLRPCPlugin::SDLRPCPlugin()
+    : application_manager_(nullptr), pending_resumption_handler_(nullptr) {}
+
 bool SDLRPCPlugin::Init(app_mngr::ApplicationManager& app_manager,
                         app_mngr::rpc_service::RPCService& rpc_service,
                         app_mngr::HMICapabilities& hmi_capabilities,
                         policy::PolicyHandlerInterface& policy_handler,
                         resumption::LastStateWrapperPtr last_state) {
   UNUSED(last_state);
+  application_manager_ = &app_manager;
+  pending_resumption_handler_ =
+      std::make_shared<SDLPendingResumptionHandler>(app_manager);
   command_factory_.reset(new sdl_rpc_plugin::SDLCommandFactory(
       app_manager, rpc_service, hmi_capabilities, policy_handler));
   return true;
@@ -83,7 +92,11 @@ void SDLRPCPlugin::OnPolicyEvent(plugins::PolicyEvent event) {}
 void SDLRPCPlugin::OnApplicationEvent(
     plugins::ApplicationEvent event,
     app_mngr::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (plugins::ApplicationEvent::kApplicationRegistered == event) {
+    application->AddExtension(
+        std::make_shared<SDLAppExtension>(*this, *application));
+
     auto sys_cap_ext_ptr =
         std::make_shared<SystemCapabilityAppExtension>(*this, *application);
     application->AddExtension(sys_cap_ext_ptr);
@@ -92,8 +105,51 @@ void SDLRPCPlugin::OnApplicationEvent(
         mobile_apis::SystemCapabilityType::eType::DISPLAYS;
     LOG4CXX_DEBUG(logger_, "Subscription to DISPLAYS capability is enabled");
     sys_cap_ext_ptr->SubscribeTo(capability_type);
+
   } else if (plugins::ApplicationEvent::kDeleteApplicationData == event) {
     ClearSubscriptions(application);
+  }
+}
+
+void SDLRPCPlugin::ProcessResumptionSubscription(
+    application_manager::Application& app,
+    SDLAppExtension& ext,
+    resumption::Subscriber subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (application_manager_->IsAnyAppSubscribedForWayPoints()) {
+    LOG4CXX_DEBUG(logger_,
+                  "Subscription to waypoint already exist, no need to send "
+                  "request to HMI");
+    application_manager_->SubscribeAppForWayPoints(app.app_id());
+    return;
+  }
+
+  pending_resumption_handler_->HandleResumptionSubscriptionRequest(
+      ext, subscriber, app);
+}
+
+void SDLRPCPlugin::SaveResumptionData(
+    application_manager::Application& app,
+    smart_objects::SmartObject& resumption_data) {
+  resumption_data[application_manager::strings::subscribed_for_way_points] =
+      application_manager_->IsAppSubscribedForWayPoints(app);
+}
+
+void SDLRPCPlugin::RevertResumption(application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  pending_resumption_handler_->OnResumptionRevert();
+
+  if (application_manager_->IsAppSubscribedForWayPoints(app)) {
+    application_manager_->UnsubscribeAppFromWayPoints(app.app_id());
+    if (!application_manager_->IsAnyAppSubscribedForWayPoints()) {
+      LOG4CXX_DEBUG(logger_, "Send UnsubscribeWayPoints");
+      auto request =
+          application_manager::MessageHelper::CreateUnsubscribeWayPointsRequest(
+              application_manager_->GetNextHMICorrelationID());
+      application_manager_->GetRPCService().ManageHMICommand(request);
+    }
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
@@ -957,7 +957,7 @@ TEST_F(HMICommandsNotificationsTest,
       kCorrelationId_;
   MessageSharedPtr temp_message = CreateMessage();
 
-  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
   EXPECT_CALL(app_mngr_, resume_controller())
       .WillOnce(ReturnRef(mock_resume_ctrl));
   EXPECT_CALL(mock_resume_ctrl, OnSuspend());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
@@ -137,6 +137,9 @@ TEST_F(
   (*message_)[strings::msg_params][strings::app_id] = kAppId;
 
   ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+  application_manager::DisplayCapabilitiesBuilder builder(*mock_app_);
+  ON_CALL(*mock_app_, display_capabilities_builder())
+      .WillByDefault(ReturnRef(builder));
 
   EXPECT_CALL(*mock_app_,
               set_display_capabilities(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
@@ -48,6 +48,7 @@
 #include "application_manager/mock_help_prompt_manager.h"
 #include "application_manager/mock_hmi_interface.h"
 #include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_resume_ctrl.h"
 #include "application_manager/smart_object_keys.h"
 #include "smart_objects/smart_object.h"
 #include "utils/custom_string.h"
@@ -221,6 +222,11 @@ class AddCommandRequestTest
         mock_rpc_service_,
         ManageMobileCommand(response,
                             am::commands::Command::CommandSource::SOURCE_SDL));
+
+    resumption_test::MockResumeCtrl mock_resume_ctrl;
+    EXPECT_CALL(app_mngr_, resume_controller())
+        .WillOnce(ReturnRef(mock_resume_ctrl));
+    EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
     std::shared_ptr<CommandRequestImpl> base_class_request =
         static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
     base_class_request->onTimeOut();
@@ -1092,6 +1098,12 @@ TEST_F(AddCommandRequestTest,
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
+
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
+
   std::shared_ptr<CommandRequestImpl> base_class_request =
       static_cast<std::shared_ptr<CommandRequestImpl> >(
           CreateCommand<AddCommandRequest>(msg_));
@@ -1142,6 +1154,12 @@ TEST_F(AddCommandRequestTest, OnTimeOut_AppRemoveCommandCalled) {
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
+
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
+
   std::shared_ptr<CommandRequestImpl> base_class_request =
       static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
   base_class_request->onTimeOut();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -44,6 +44,7 @@
 #include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/mock_hmi_interface.h"
 #include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_resume_ctrl.h"
 #include "application_manager/smart_object_keys.h"
 #include "gtest/gtest.h"
 #include "smart_objects/smart_object.h"
@@ -183,6 +184,11 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeout_GENERIC_ERROR) {
       mock_rpc_service_,
       ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
       .WillOnce(DoAll(SaveArg<0>(&vr_command_result), Return(true)));
+
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
 
   req_vr->onTimeOut();
   EXPECT_EQ(
@@ -704,7 +710,12 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
                   MobileResultCodeIs(mobile_apis::Result::GENERIC_ERROR),
                   am::commands::Command::SOURCE_SDL));
 
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+
   command_->onTimeOut();
 }
 
@@ -748,7 +759,12 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(*mock_app_, RemoveChoiceSet(kChoiceSetId));
 
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+
   command_->onTimeOut();
 }
 
@@ -794,6 +810,11 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(invalid_app));
   EXPECT_CALL(*mock_app_, RemoveChoiceSet(_)).Times(0);
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
+
   command_->onTimeOut();
 }
 
@@ -833,6 +854,10 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   FillMessageFieldsItem2(message_);
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
 
   Event event(hmi_apis::FunctionID::VR_AddCommand);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
@@ -183,6 +183,10 @@ TEST_F(
   ON_CALL(mock_hmi_capabilities_, system_display_capabilities())
       .WillByDefault(Return(system_display_capabilities));
 
+  application_manager::DisplayCapabilitiesBuilder builder(*mock_app_);
+  ON_CALL(*mock_app_, display_capabilities_builder())
+      .WillByDefault(ReturnRef(builder));
+
   sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
 
   std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
@@ -197,7 +201,7 @@ TEST_F(
       DataAccessor<application_manager::ApplicationSet>(apps, apps_lock_));
 
   ON_CALL(app_mngr_, applications()).WillByDefault(Return(apps_data));
-  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
+  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
   ON_CALL(*mock_app_, display_capabilities()).WillByDefault(Return(nullptr));
   ON_CALL(*mock_app_,
           QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -43,6 +43,7 @@
 #include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/mock_hmi_interface.h"
 #include "application_manager/mock_resume_ctrl.h"
+#include "application_manager/mock_rpc_plugin_manager.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
 #include "application_manager/smart_object_keys.h"
 #include "connection_handler/mock_connection_handler.h"
@@ -73,6 +74,7 @@ using ::testing::SetArgPointee;
 namespace am = ::application_manager;
 
 using am::commands::MessageSharedPtr;
+using am::plugin_manager::MockRPCPluginManager;
 using sdl_rpc_plugin::commands::RegisterAppInterfaceRequest;
 
 namespace {
@@ -107,17 +109,32 @@ class RegisterAppInterfaceRequestTest
       , pending_lock_ptr_(std::make_shared<sync_primitives::Lock>())
       , mock_application_helper_(
             application_manager_test::MockApplicationHelper::
-                application_helper_mock()) {
+                application_helper_mock())
+      , mock_rpc_plugin_manager_(
+            std::make_shared<NiceMock<MockRPCPluginManager> >())
+      , message_helper_mock_(
+            *application_manager::MockMessageHelper::message_helper_mock()) {
     InitGetters();
     InitLanguage();
   }
 
   void SetUp() OVERRIDE {
     testing::Mock::VerifyAndClearExpectations(&mock_application_helper_);
+    testing::Mock::VerifyAndClearExpectations(&message_helper_mock_);
+
+    ON_CALL(app_mngr_, GetPluginManager())
+        .WillByDefault(ReturnRef(*mock_rpc_plugin_manager_));
+
+    ON_CALL(app_mngr_, GetPolicyHandler())
+        .WillByDefault(ReturnRef(mock_policy_handler_));
+
+    ON_CALL(app_mngr_, GetRPCService())
+        .WillByDefault(ReturnRef(mock_rpc_service_));
   }
 
   void TearDown() OVERRIDE {
     testing::Mock::VerifyAndClearExpectations(&mock_application_helper_);
+    testing::Mock::VerifyAndClearExpectations(&message_helper_mock_);
   }
 
   void InitBasicMessage() {
@@ -150,6 +167,9 @@ class RegisterAppInterfaceRequestTest
     ON_CALL(*mock_app, policy_app_id()).WillByDefault(Return(kAppId1));
     ON_CALL(*mock_app, msg_version())
         .WillByDefault(ReturnRef(mock_semantic_version));
+    ON_CALL(*mock_app, protocol_version())
+        .WillByDefault(
+            Return(protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_5));
     return mock_app;
   }
 
@@ -279,6 +299,11 @@ class RegisterAppInterfaceRequestTest
             HMIResultCodeIs(hmi_apis::FunctionID::VR_ChangeRegistration), _))
         .Times(0);
 
+    auto notification = std::make_shared<smart_objects::SmartObject>();
+    ON_CALL(message_helper_mock_, CreateHMIStatusNotification(_, _))
+        .WillByDefault(Return(notification));
+    EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(notification, _));
+
     EXPECT_CALL(app_mngr_,
                 OnApplicationSwitched(
                     std::static_pointer_cast<application_manager::Application>(
@@ -298,7 +323,7 @@ class RegisterAppInterfaceRequestTest
   typedef IsNiceMock<policy_test::MockPolicyHandlerInterface,
                      kMocksAreNice>::Result MockPolicyHandlerInterface;
 
-  typedef IsNiceMock<resumprion_test::MockResumeCtrl, kMocksAreNice>::Result
+  typedef IsNiceMock<resumption_test::MockResumeCtrl, kMocksAreNice>::Result
       MockResumeCtrl;
 
   typedef IsNiceMock<connection_handler_test::MockConnectionHandler,
@@ -314,6 +339,9 @@ class RegisterAppInterfaceRequestTest
   MockConnectionHandler mock_connection_handler_;
   MockSessionObserver mock_session_observer_;
   application_manager_test::MockApplicationHelper& mock_application_helper_;
+  std::shared_ptr<am::plugin_manager::MockRPCPluginManager>
+      mock_rpc_plugin_manager_;
+  application_manager::MockMessageHelper& message_helper_mock_;
 };
 
 TEST_F(RegisterAppInterfaceRequestTest, Init_SUCCESS) {
@@ -351,8 +379,8 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
       .WillByDefault(Return(DataAccessor<am::AppsWaitRegistrationSet>(
           pending_app_set_, pending_lock_ptr_)));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+  ON_CALL(app_mngr_, application(kConnectionKey))
+      .WillByDefault(Return(mock_app));
 
   ON_CALL(mock_policy_handler_, PolicyEnabled()).WillByDefault(Return(true));
   ON_CALL(mock_policy_handler_, GetInitialAppData(kAppId1, _, _))
@@ -376,6 +404,11 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
           HMIResultCodeIs(hmi_apis::FunctionID::Buttons_OnButtonSubscription),
           _))
       .WillOnce(Return(true));
+
+  application_manager::DisplayCapabilitiesBuilder builder(*mock_app);
+  ON_CALL(*mock_app, display_capabilities_builder())
+      .WillByDefault(ReturnRef(builder));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, am::commands::Command::SOURCE_SDL))
       .Times(2);
@@ -431,8 +464,8 @@ TEST_F(RegisterAppInterfaceRequestTest,
   EXPECT_CALL(app_mngr_, application(kMacAddress1, kAppId1))
       .WillRepeatedly(Return(ApplicationSharedPtr()));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillOnce(Return(mock_app));
+  ON_CALL(app_mngr_, application(kConnectionKey))
+      .WillByDefault(Return(mock_app));
 
   MessageSharedPtr expected_message =
       CreateMessage(smart_objects::SmartType_Map);
@@ -517,6 +550,11 @@ TEST_F(RegisterAppInterfaceRequestTest,
       ManageHMICommand(
           HMIResultCodeIs(hmi_apis::FunctionID::UI_ChangeRegistration), _))
       .WillOnce(Return(true));
+
+  application_manager::DisplayCapabilitiesBuilder builder(*mock_app);
+  ON_CALL(*mock_app, display_capabilities_builder())
+      .WillByDefault(ReturnRef(builder));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, am::commands::Command::SOURCE_SDL))
       .Times(2);
@@ -562,8 +600,8 @@ TEST_F(RegisterAppInterfaceRequestTest,
 
   EXPECT_CALL(mock_application_helper_, RecallApplicationData(_, _)).Times(0);
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillRepeatedly(Return(mock_app));
+  ON_CALL(app_mngr_, application(kConnectionKey))
+      .WillByDefault(Return(mock_app));
 
   SetCommonExpectionsOnSwitchedApplication(mock_app,
                                            mobile_apis::Result::SUCCESS);
@@ -609,8 +647,8 @@ TEST_F(RegisterAppInterfaceRequestTest,
 
   EXPECT_CALL(app_mngr_, RegisterApplication(msg_)).Times(0);
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillRepeatedly(Return(mock_app));
+  ON_CALL(app_mngr_, application(kConnectionKey))
+      .WillByDefault(Return(mock_app));
 
   SetCommonExpectionsOnSwitchedApplication(mock_app,
                                            mobile_apis::Result::RESUME_FAILED);
@@ -645,8 +683,8 @@ TEST_F(RegisterAppInterfaceRequestTest,
 
   EXPECT_CALL(app_mngr_, RegisterApplication(msg_)).Times(0);
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey))
-      .WillRepeatedly(Return(mock_app));
+  ON_CALL(app_mngr_, application(kConnectionKey))
+      .WillByDefault(Return(mock_app));
 
   SetCommonExpectionsOnSwitchedApplication(mock_app,
                                            mobile_apis::Result::RESUME_FAILED);
@@ -739,8 +777,8 @@ TEST_F(RegisterAppInterfaceRequestTest,
   EXPECT_CALL(app_mngr_, reregister_application_by_policy_id(kAppId1))
       .WillOnce(Return(ApplicationSharedPtr()));
 
-  EXPECT_CALL(app_mngr_, application(kConnectionKey2))
-      .WillOnce(Return(mock_app2));
+  ON_CALL(app_mngr_, application(kConnectionKey2))
+      .WillByDefault(Return(mock_app2));
 
   ON_CALL(mock_policy_handler_, PolicyEnabled()).WillByDefault(Return(true));
   ON_CALL(mock_policy_handler_, GetInitialAppData(kAppId1, _, _))
@@ -782,6 +820,11 @@ TEST_F(RegisterAppInterfaceRequestTest,
       ManageHMICommand(
           HMIResultCodeIs(hmi_apis::FunctionID::UI_ChangeRegistration), _))
       .WillOnce(Return(true));
+
+  application_manager::DisplayCapabilitiesBuilder builder(*mock_app2);
+  ON_CALL(*mock_app2, display_capabilities_builder())
+      .WillByDefault(ReturnRef(builder));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(_, am::commands::Command::SOURCE_SDL))
       .Times(2);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -125,157 +125,50 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidApp_UNSUCCESS) {
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-  std::vector<std::string> help_prompt = {"help_prompt"};
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  EXPECT_CALL(app_mngr_settings_, help_prompt())
-      .WillOnce(ReturnRef(help_prompt));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(smart_objects::SmartObjectSPtr()));
 
-  smart_objects::SmartObject so_help_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  so_help_prompt[am::strings::text] = help_prompt[0];
-  so_help_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+  ON_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillByDefault(Return(std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map)));
 
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  so_prompt[0] = so_help_prompt;
-
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
-
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
-
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
-
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
-
-  smart_objects::SmartObjectSPtr vr_help;  // = NULL;
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
-
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(0);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
 
   command_->Run();
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
+  result.number_of_reset_vr = 1;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-
-  std::vector<std::string> help_prompt = {"help_prompt"};
-
-  EXPECT_CALL(app_mngr_settings_, help_prompt())
-      .WillOnce(ReturnRef(help_prompt));
-
-  smart_objects::SmartObject so_help_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  so_help_prompt[am::strings::text] = help_prompt[0];
-  so_help_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  so_prompt[0] = so_help_prompt;
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
-
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
-
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
-
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  ON_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillByDefault(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
-  smart_objects::SmartObjectSPtr vr_help =
+  smart_objects::SmartObjectSPtr msg_params =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
-  smart_objects::SmartObject msg_params =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  msg_params[am::hmi_request::menu_title] = "";
-
-  EXPECT_CALL(*mock_app_,
-              set_menu_title(msg_params[am::hmi_request::menu_title]));
-
-  EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(&so_help_prompt));
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(&so_help_prompt));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -304,27 +197,18 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       hmi_apis::Common_Result::SUCCESS;
   (*msg_)[am::strings::params][am::hmi_response::code] = result_code;
 
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
 
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
-
-  smart_objects::SmartObjectSPtr vr_help =
+  smart_objects::SmartObjectSPtr msg_params =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
+
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+
   EXPECT_CALL(
       mock_rpc_service_,
       ManageHMICommand(
@@ -353,20 +237,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   MessageSharedPtr ui_msg = CreateMessage();
   (*ui_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
@@ -412,19 +298,22 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   (*msg_)[am::strings::msg_params][am::strings::properties][0] =
       mobile_apis::GlobalProperty::VRHELPTITLE;
 
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
 
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .Times(0);
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+
   EXPECT_CALL(
       mock_rpc_service_,
       ManageHMICommand(
@@ -433,8 +322,6 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   smart_objects::SmartObjectSPtr vr_help =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
   EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
 
@@ -461,20 +348,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -528,18 +417,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
@@ -594,18 +485,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_way_points_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/subscribe_way_points_request_test.cc
@@ -71,7 +71,7 @@ TEST_F(SubscribeWayPointsRequestTest, Run_SUCCESS) {
   MockAppPtr app(CreateMockApp());
 
   ON_CALL(app_mngr_, application(_)).WillByDefault(Return(app));
-  ON_CALL(app_mngr_, IsAppSubscribedForWayPoints(A<am::ApplicationSharedPtr>()))
+  ON_CALL(app_mngr_, IsAppSubscribedForWayPoints(Ref(*app)))
       .WillByDefault(Return(false));
   ON_CALL(app_mngr_, IsAnyAppSubscribedForWayPoints())
       .WillByDefault(Return(true));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/unsubscribe_way_points_request_test.cc
@@ -100,9 +100,7 @@ TEST_F(UnsubscribeWayPointsRequestTest,
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_,
-              IsAppSubscribedForWayPoints(
-                  ::testing::Matcher<am::ApplicationSharedPtr>(mock_app)))
+  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(Ref(*mock_app)))
       .WillOnce(Return(false));
 
   EXPECT_CALL(
@@ -117,9 +115,7 @@ TEST_F(UnsubscribeWayPointsRequestTest, Run_AppSubscribedForWayPoints_SUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(mock_app));
 
-  EXPECT_CALL(app_mngr_,
-              IsAppSubscribedForWayPoints(
-                  ::testing::Matcher<am::ApplicationSharedPtr>(mock_app)))
+  EXPECT_CALL(app_mngr_, IsAppSubscribedForWayPoints(Ref(*mock_app)))
       .WillOnce(Return(true));
 
   const std::set<uint32_t> subscribed_apps{kConnectionKey};

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h
@@ -66,6 +66,8 @@ class VISubscribeVehicleDataRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
+  void onTimeOut() OVERRIDE;
+
  private:
   CustomVehicleDataManager& custom_vehicle_data_manager_;
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -1,0 +1,153 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H
+#include <queue>
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+
+#include "utils/optional.h"
+#include "vehicle_info_app_extension.h"
+namespace vehicle_info_plugin {
+class CustomVehicleDataManager;
+
+namespace app_mngr = application_manager;
+
+class VehicleInfoPendingResumptionHandler
+    : public resumption::ExtensionPendingResumptionHandler {
+ public:
+  typedef std::set<std::string> VehicleDataList;
+  VehicleInfoPendingResumptionHandler(
+      app_mngr::ApplicationManager& application_manager,
+      CustomVehicleDataManager& custom_vehicle_data_manager);
+
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+
+  void HandleResumptionSubscriptionRequest(app_mngr::AppExtension& extension,
+                                           resumption::Subscriber& subscriber,
+                                           app_mngr::Application& app) OVERRIDE;
+  void OnResumptionRevert() OVERRIDE;
+
+  smart_objects::SmartObjectSPtr CreateSubscribeRequestToHMI(
+      const VehicleDataList& subscriptions);
+
+  ns_smart_device_link::ns_smart_objects::SmartObject CreateFakeResponseFromHMI(
+      const std::map<std::string, smart_objects::SmartObject>& subscriptions,
+      const uint32_t fake_corrlation_id);
+
+ private:
+  void ProcessNextPendingResumption(
+      const smart_objects::SmartObject& response_message);
+  void TriggerPendingResumption();
+
+  struct PendingSubscriptionsResumption {
+    PendingSubscriptionsResumption(
+        const uint32_t app_id,
+        const uint32_t corr_id,
+        const VehicleDataList& requested_vehicle_data)
+        : app_id_(app_id)
+        , fake_corr_id_(corr_id)
+        , waiting_for_hmi_response_(false)
+        , requested_vehicle_data_(requested_vehicle_data) {}
+
+    PendingSubscriptionsResumption(const PendingSubscriptionsResumption& copy) =
+        default;
+
+    /**
+     * @brief IsSuccessfullyDone check if SDL restored all required data or not
+     * @return
+     */
+    bool IsSuccessfullyDone() const;
+    bool DataWasRequested(const std::string& vd) const;
+    VehicleDataList NotSubscribedData() const;
+
+    /**
+     * @brief FillSubscriptionResults fill subscription results based on
+     * response message
+     * @param response
+     */
+    void FillSubscriptionResults(const smart_objects::SmartObject& response);
+
+    /**
+     * @brief FillSubscriptionResults fill subscription results based on list of
+     * requested data and list of restored data
+     *
+     */
+    void FillSubscriptionResults();
+
+    void FillRestoredData(const VehicleDataList& successful_subscriptions);
+
+    uint32_t app_id_;
+    uint32_t fake_corr_id_;
+    bool waiting_for_hmi_response_;
+    VehicleDataList requested_vehicle_data_;
+    VehicleDataList restored_vehicle_data_;
+    std::map<std::string, smart_objects::SmartObject> subscription_results_;
+  };
+
+  void SendHMIRequestForNotSubscribed(
+      const PendingSubscriptionsResumption& pending_resumption);
+  void RaiseFinishedPendingResumption(
+      const PendingSubscriptionsResumption& pending_resumption);
+  /**
+   * @brief SubscribeToFakeRequest will create fake subscription for subscriber
+   * ( resumption_data_processor)
+   * Fake request is required only for subscriber subscription.
+   * This request will not be sen't to HMI so it named as fake request.
+   * Fake request contains all data that need to be resumed for the application
+   * When HMI will resopond for any VehicleDara request,
+   * PendingSubscriptionsResumption will go through all pending resumptions and
+   * fill them with received subscriptions. If certain pending resumption will
+   * take all requested subscriptions PendingSubscriptionsResumption will take
+   * this fake request correaltion id and create fake response based on it.
+   * Within fake response it will notify subscriber about resumption status.
+   *
+   * @param app_id applicaiton to pass into subscriber
+   * @param subscriptions list of requested subscriptions
+   * @param subscriber function to subscribe caller for finished resumption
+   * @return pending_resumption with information about fake correlation id for
+   * subscriber, list of vehicle data to subscribe
+   */
+  PendingSubscriptionsResumption SubscribeToFakeRequest(
+      const uint32_t app,
+      const VehicleDataList& subscriptions,
+      resumption::Subscriber& subscriber);
+
+  std::deque<PendingSubscriptionsResumption> pending_requests_;
+
+  CustomVehicleDataManager& custom_vehicle_data_manager_;
+  sync_primitives::RecursiveLock pending_resumption_lock_;
+};
+}  // namespace vehicle_info_plugin
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -34,12 +34,15 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_VEHICLE_INFO_PLUGIN_H
 
 #include "application_manager/command_factory.h"
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
 #include "vehicle_info_plugin/custom_vehicle_data_manager.h"
 
 namespace vehicle_info_plugin {
 class VehicleInfoAppExtension;
 namespace app_mngr = application_manager;
 namespace plugins = application_manager::plugin_manager;
+
+enum SubscribeStatus { SUBSCRIBE, UNSUBSCRIBE };
 
 class VehicleInfoPlugin : public plugins::RPCPlugin {
  public:
@@ -74,19 +77,38 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
    * to HMI
    * @param app application for subscription
    * @param ext application extension
+   * @param subscriber callback for subscription
    */
   void ProcessResumptionSubscription(app_mngr::Application& app,
-                                     VehicleInfoAppExtension& ext);
+                                     VehicleInfoAppExtension& ext,
+                                     resumption::Subscriber subscriber);
+
+  /**
+   * @brief Revert the data to the state before Resumption.
+   * @param subscriptions Subscriptions to be returned
+   **/
+  void RevertResumption(app_mngr::Application& app,
+                        const std::set<std::string>& list_of_subscriptions);
+
+  smart_objects::SmartObjectSPtr CreateSubscriptionRequest(
+      const std::set<std::string>& list_of_subscriptions);
+
+  smart_objects::SmartObjectSPtr CreateUnsubscriptionRequest(
+      const std::set<std::string>& list_of_subscriptions);
 
  private:
+  bool IsSubscribedAppExist(const std::string& ivi);
   void UnsubscribeFromRemovedVDItems();
   smart_objects::SmartObjectSPtr GetUnsubscribeIVIRequest(
       const std::vector<std::string>& ivi_names);
   void DeleteSubscriptions(app_mngr::ApplicationSharedPtr app);
 
   std::unique_ptr<app_mngr::CommandFactory> command_factory_;
-  std::unique_ptr<CustomVehicleDataManager> custom_vehicle_data_manager_;
+  typedef std::shared_ptr<resumption::ExtensionPendingResumptionHandler>
+      ExtensionPendingResumptionHandlerSPtr;
   app_mngr::ApplicationManager* application_manager_;
+  std::unique_ptr<CustomVehicleDataManager> custom_vehicle_data_manager_;
+  ExtensionPendingResumptionHandlerSPtr pending_resumption_handler_;
 };
 }  // namespace vehicle_info_plugin
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
@@ -32,6 +32,7 @@
 
 #include "vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/resumption/resume_ctrl.h"
 
 namespace vehicle_info_plugin {
 using namespace application_manager;
@@ -72,6 +73,19 @@ void VISubscribeVehicleDataRequest::Run() {
   }
 
   SendRequest();
+}
+
+void VISubscribeVehicleDataRequest::onTimeOut() {
+  event_engine::Event timeout_event(
+      hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData);
+
+  auto error_response = MessageHelper::CreateNegativeResponseFromHmi(
+      function_id(),
+      correlation_id(),
+      hmi_apis::Common_Result::GENERIC_ERROR,
+      std::string("Timed out"));
+  timeout_event.set_smart_object(*error_response);
+  timeout_event.raise(application_manager_.event_dispatcher());
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -1,0 +1,421 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
+#include <boost/range/algorithm/set_algorithm.hpp>
+#include <functional>
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "utils/helpers.h"
+#include "vehicle_info_plugin/custom_vehicle_data_manager.h"
+
+namespace vehicle_info_plugin {
+CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPlugin")
+
+using hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
+
+uint32_t get_corr_id_from_message(const smart_objects::SmartObject& message) {
+  using namespace application_manager;
+  return message[strings::params][strings::correlation_id].asInt();
+}
+
+template <class T>
+std::string Stringify(const T& container) {
+  std::stringstream ss;
+  for (const auto& val : container) {
+    ss << val << " ";
+  }
+  return ss.str();
+}
+
+VehicleInfoPendingResumptionHandler::VehicleDataList SubscriptionsFromResponse(
+    const smart_objects::SmartObject& response,
+    std::function<bool(const smart_objects::SmartObject& vehicle_data)>
+        vehicle_data_check) {
+  namespace strings = application_manager::strings;
+  VehicleInfoPendingResumptionHandler::VehicleDataList result;
+  const auto response_params = response[strings::msg_params];
+  const auto response_keys = response_params.enumerate();
+  for (auto key : response_keys) {
+    if (vehicle_data_check(response_params[key])) {
+      result.insert(key);
+    }
+  }
+  return result;
+}
+
+void FillResponseWithMissedVD(
+    const VehicleInfoPendingResumptionHandler::VehicleDataList& vehicle_data,
+    smart_objects::SmartObject* response) {
+  DCHECK(response)
+  namespace strings = application_manager::strings;
+  auto& msg_params = (*response)[strings::msg_params];
+  for (const auto& vd : vehicle_data) {
+    smart_objects::SmartObject vd_result(smart_objects::SmartType_Map);
+    vd_result[strings::result_code] =
+        hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+    msg_params[vd] = vd_result;
+  }
+}
+
+VehicleInfoPendingResumptionHandler::VehicleDataList
+SuccessfulSubscriptionsFromResponse(
+    const smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+
+  VehicleInfoPendingResumptionHandler::VehicleDataList result;
+  if (!resumption::IsResponseSuccessful(response)) {
+    return result;
+  }
+
+  auto successful_vehicle_data =
+      [](const smart_objects::SmartObject& vehicle_data) {
+        constexpr auto kSuccess =
+            hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+        const auto vd_result_code = vehicle_data[strings::result_code].asInt();
+        return kSuccess == vd_result_code;
+      };
+  return SubscriptionsFromResponse(response, successful_vehicle_data);
+}
+
+VehicleInfoPendingResumptionHandler::VehicleInfoPendingResumptionHandler(
+    application_manager::ApplicationManager& application_manager,
+    CustomVehicleDataManager& custom_vehicle_data_manager)
+    : ExtensionPendingResumptionHandler(application_manager)
+    , custom_vehicle_data_manager_(custom_vehicle_data_manager) {}
+
+void VehicleInfoPendingResumptionHandler::OnResumptionRevert() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(pending_resumption_lock_);
+  TriggerPendingResumption();
+}
+
+void VehicleInfoPendingResumptionHandler::RaiseFinishedPendingResumption(
+    const PendingSubscriptionsResumption& pending_resumption) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+
+  auto app = application_manager_.application(pending_resumption.app_id_);
+  if (!app) {
+    LOG4CXX_DEBUG(logger_,
+                  "Application not found " << pending_resumption.app_id_);
+    return;
+  }
+  auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+  ext.RemovePendingSubscriptions();
+  for (const auto& subscription : pending_resumption.restored_vehicle_data_) {
+    LOG4CXX_DEBUG(logger_,
+                  "Subscribe " << app->app_id() << "  to " << subscription);
+    ext.subscribeToVehicleInfo(subscription);
+  }
+
+  auto fake_response =
+      CreateFakeResponseFromHMI(pending_resumption.subscription_results_,
+                                pending_resumption.fake_corr_id_);
+  event_engine::Event event(VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(fake_response);
+  LOG4CXX_DEBUG(logger_, "Raise fake response for resumption data processor");
+  event.raise(application_manager_.event_dispatcher());
+}
+
+void VehicleInfoPendingResumptionHandler::SendHMIRequestForNotSubscribed(
+    const PendingSubscriptionsResumption& pending_resumption) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto remaining_subscriptions = pending_resumption.NotSubscribedData();
+  auto request = CreateSubscribeRequestToHMI(remaining_subscriptions);
+  const auto corr_id = get_corr_id_from_message(*request);
+  subscribe_on_event(VehicleInfo_SubscribeVehicleData, corr_id);
+  application_manager_.GetRPCService().ManageHMICommand(request);
+}
+
+void VehicleInfoPendingResumptionHandler::ProcessNextPendingResumption(
+    const smart_objects::SmartObject& response_message) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_, "No more pending resumptions");
+    return;
+  }
+  auto& pending = pending_requests_.front();
+  if (pending.waiting_for_hmi_response_) {
+    LOG4CXX_DEBUG(logger_,
+                  "Requests was already sent to HMI for " << pending.app_id_);
+    return;
+  }
+  const auto successful_subscriptions =
+      SuccessfulSubscriptionsFromResponse(response_message);
+  pending.FillRestoredData(successful_subscriptions);
+
+  if (!pending.IsSuccessfullyDone()) {
+    SendHMIRequestForNotSubscribed(pending);
+    pending.waiting_for_hmi_response_ = true;
+    return;
+  }
+  auto pending_copy = pending;
+  pending_requests_.pop_front();
+  RaiseFinishedPendingResumption(pending_copy);
+  ProcessNextPendingResumption(response_message);
+}
+
+void VehicleInfoPendingResumptionHandler::TriggerPendingResumption() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_, "No pending resumptions");
+    return;
+  }
+  auto& pending_resumption = pending_requests_.front();
+  if (pending_resumption.waiting_for_hmi_response_) {
+    LOG4CXX_DEBUG(logger_,
+                  "Pending resumption for  "
+                      << pending_resumption.app_id_
+                      << " is already waiting for HMI response");
+    return;
+  }
+  SendHMIRequestForNotSubscribed(pending_resumption);
+  pending_resumption.waiting_for_hmi_response_ = true;
+}
+
+void VehicleInfoPendingResumptionHandler::on_event(
+    const application_manager::event_engine::Event& event) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(pending_resumption_lock_);
+  using namespace application_manager;
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_, "Not waiting for any response");
+    return;
+  }
+
+  auto current_pending = pending_requests_.front();
+
+  auto response_message = event.smart_object();
+  smart_objects::SmartObject converted_msg_params(
+      response_message[strings::msg_params]);
+
+  custom_vehicle_data_manager_.CreateMobileMessageParams(converted_msg_params);
+  response_message[strings::msg_params] = converted_msg_params;
+  pending_requests_.pop_front();
+
+  const auto vs_count_in_response =
+      response_message[application_manager::strings::msg_params].length();
+  if (resumption::IsResponseSuccessful(response_message) &&
+      vs_count_in_response == 0) {
+    FillResponseWithMissedVD(current_pending.requested_vehicle_data_,
+                             &response_message);
+  }
+
+  current_pending.FillSubscriptionResults(response_message);
+
+  RaiseFinishedPendingResumption(current_pending);
+
+  ProcessNextPendingResumption(response_message);
+}
+
+VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption
+VehicleInfoPendingResumptionHandler::SubscribeToFakeRequest(
+    const uint32_t app_id,
+    const VehicleDataList& subscriptions,
+    resumption::Subscriber& subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto fake_request = CreateSubscribeRequestToHMI(subscriptions);
+  const auto fake_corr_id = get_corr_id_from_message(*fake_request);
+  auto resumption_request = MakeResumptionRequest(
+      fake_corr_id,
+      hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
+      *fake_request);
+  LOG4CXX_DEBUG(logger_,
+                "Subscribe subscriber "
+                    << app_id
+                    << " to fake request with corr id = " << fake_corr_id);
+  subscriber(app_id, resumption_request);
+  PendingSubscriptionsResumption pending_request(
+      app_id, fake_corr_id, subscriptions);
+  return pending_request;
+}
+
+void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
+    application_manager::AppExtension& extension,
+    resumption::Subscriber& subscriber,
+    application_manager::Application& app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock lock(pending_resumption_lock_);
+  LOG4CXX_TRACE(logger_, "app id " << app.app_id());
+  UNUSED(extension);
+  auto& ext = VehicleInfoAppExtension::ExtractVIExtension(app);
+
+  const auto subscriptions = ext.PendingSubscriptions().GetData();
+  if (subscriptions.empty()) {
+    LOG4CXX_DEBUG(logger_, "Subscriptions is empty");
+    return;
+  }
+  LOG4CXX_TRACE(logger_,
+                "resume subscriptions to : " << Stringify(subscriptions));
+  auto pending_request =
+      SubscribeToFakeRequest(app.app_id(), subscriptions, subscriber);
+
+  pending_requests_.push_back(pending_request);
+  LOG4CXX_DEBUG(
+      logger_,
+      "Add to pending resumptins corr_id = " << pending_request.fake_corr_id_);
+  if (pending_requests_.size() == 1) {
+    TriggerPendingResumption();
+  }
+  // If there was pending resumption before, it will be triggered on HMI
+  // response
+}
+
+smart_objects::SmartObjectSPtr
+VehicleInfoPendingResumptionHandler::CreateSubscribeRequestToHMI(
+    const VehicleDataList& subscriptions) {
+  sync_primitives::AutoLock lock(pending_resumption_lock_);
+  using namespace application_manager;
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  for (const auto& ivi_data : subscriptions) {
+    msg_params[ivi_data] = true;
+  }
+
+  smart_objects::SmartObjectSPtr request =
+      application_manager::MessageHelper::CreateModuleInfoSO(
+          VehicleInfo_SubscribeVehicleData, application_manager_);
+  (*request)[strings::msg_params] = msg_params;
+
+  return request;
+}
+
+smart_objects::SmartObject
+VehicleInfoPendingResumptionHandler::CreateFakeResponseFromHMI(
+    const std::map<std::string, smart_objects::SmartObject>& subscriptions,
+    const uint32_t fake_corrlation_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  namespace strings = application_manager::strings;
+
+  auto response =
+      application_manager::MessageHelper::CreateResponseMessageFromHmi(
+          VehicleInfo_SubscribeVehicleData,
+          fake_corrlation_id,
+          hmi_apis::Common_Result::SUCCESS);
+  auto& message = *response;
+  smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
+  for (const auto& subscription : subscriptions) {
+    msg_params[subscription.first] = subscription.second;
+    LOG4CXX_DEBUG(logger_,
+                  "fake response data : "
+                      << subscription.first << " result = "
+                      << subscription.second[strings::result_code].asInt());
+  }
+
+  message[strings::msg_params] = msg_params;
+  return *response;
+}
+
+bool VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    IsSuccessfullyDone() const {
+  return requested_vehicle_data_.size() == restored_vehicle_data_.size();
+}
+
+bool VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    DataWasRequested(const std::string& vd) const {
+  bool result =
+      (requested_vehicle_data_.end() != requested_vehicle_data_.find(vd));
+  return result;
+}
+
+VehicleInfoPendingResumptionHandler::VehicleDataList
+VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    NotSubscribedData() const {
+  VehicleDataList not_subscribed;
+  boost::set_difference(requested_vehicle_data_,
+                        restored_vehicle_data_,
+                        std::inserter(not_subscribed, not_subscribed.end()));
+  return not_subscribed;
+}
+
+void VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    FillSubscriptionResults() {
+  namespace strings = application_manager::strings;
+  for (const auto& key : restored_vehicle_data_) {
+    smart_objects::SmartObject vd_result(smart_objects::SmartType_Map);
+    vd_result[strings::result_code] =
+        hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+    subscription_results_[key] = vd_result;
+  }
+
+  const auto not_subscribed = NotSubscribedData();
+  for (const auto& key : not_subscribed) {
+    smart_objects::SmartObject vd_result(smart_objects::SmartType_Map);
+    vd_result[strings::result_code] =
+        hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED;
+    subscription_results_[key] = vd_result;
+  }
+}
+
+void VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    FillRestoredData(const VehicleDataList& successful_subscriptions) {
+  for (auto& subscribed : successful_subscriptions) {
+    if (DataWasRequested(subscribed)) {
+      restored_vehicle_data_.insert(subscribed);
+    }
+  }
+}
+
+void VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    FillSubscriptionResults(const smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+
+  auto successful_subscriptions = SuccessfulSubscriptionsFromResponse(response);
+
+  LOG4CXX_DEBUG(logger_,
+                "Requested data : " << Stringify(requested_vehicle_data_));
+  LOG4CXX_DEBUG(logger_,
+                "Successful subscription in response : "
+                    << Stringify(successful_subscriptions));
+
+  FillRestoredData(successful_subscriptions);
+
+  LOG4CXX_DEBUG(logger_,
+                "Restored data : " << Stringify(restored_vehicle_data_));
+
+  FillSubscriptionResults();
+
+  auto msg_params = response[strings::msg_params];
+  auto keys = msg_params.enumerate();
+  for (auto key : keys) {
+    if (DataWasRequested(key)) {
+      subscription_results_[key] = msg_params[key];
+    }
+  }
+}
+
+}  // namespace vehicle_info_plugin

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -33,11 +33,13 @@
 #include "vehicle_info_plugin/vehicle_info_plugin.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/plugin_manager/plugin_keys.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 #include "application_manager/rpc_handler.h"
 #include "application_manager/smart_object_keys.h"
 #include "vehicle_info_plugin/custom_vehicle_data_manager_impl.h"
 #include "vehicle_info_plugin/vehicle_info_app_extension.h"
 #include "vehicle_info_plugin/vehicle_info_command_factory.h"
+#include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
 
 namespace vehicle_info_plugin {
 CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPlugin")
@@ -46,7 +48,8 @@ namespace strings = application_manager::strings;
 namespace plugins = application_manager::plugin_manager;
 namespace commands = application_manager::commands;
 
-VehicleInfoPlugin::VehicleInfoPlugin() : application_manager_(nullptr) {}
+VehicleInfoPlugin::VehicleInfoPlugin()
+    : application_manager_(nullptr), pending_resumption_handler_(nullptr) {}
 
 bool VehicleInfoPlugin::Init(
     application_manager::ApplicationManager& app_manager,
@@ -58,6 +61,9 @@ bool VehicleInfoPlugin::Init(
   application_manager_ = &app_manager;
   custom_vehicle_data_manager_.reset(
       new CustomVehicleDataManagerImpl(policy_handler, rpc_service));
+  pending_resumption_handler_ =
+      std::make_shared<VehicleInfoPendingResumptionHandler>(
+          app_manager, *custom_vehicle_data_manager_);
   command_factory_.reset(new vehicle_info_plugin::VehicleInfoCommandFactory(
       app_manager,
       rpc_service,
@@ -107,6 +113,7 @@ void VehicleInfoPlugin::OnPolicyEvent(plugins::PolicyEvent event) {
 void VehicleInfoPlugin::OnApplicationEvent(
     plugins::ApplicationEvent event,
     app_mngr::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (plugins::ApplicationEvent::kApplicationRegistered == event) {
     application->AddExtension(
         std::make_shared<VehicleInfoAppExtension>(*this, *application));
@@ -125,7 +132,7 @@ void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
     auto applications = application_manager_->applications();
     for (auto& app : applications.GetData()) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-      auto subscription_names = ext.Subscriptions();
+      auto subscription_names = ext.Subscriptions().GetData();
       for (auto& subscription_name : subscription_names) {
         if (custom_vehicle_data_manager_->IsRemovedCustomVehicleDataName(
                 subscription_name)) {
@@ -154,50 +161,89 @@ void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
   application_manager_->GetRPCService().ManageHMICommand(message);
 }
 
-bool IsOtherAppAlreadySubscribedFor(
-    const std::string& ivi_name,
-    const application_manager::ApplicationManager& app_mngr,
-    const uint32_t current_app_id) {
-  auto applications = app_mngr.applications();
+void VehicleInfoPlugin::ProcessResumptionSubscription(
+    application_manager::Application& app,
+    VehicleInfoAppExtension& ext,
+    resumption::Subscriber subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
 
-  for (auto& app : applications.GetData()) {
+  auto pending = ext.PendingSubscriptions().GetData();
+  for (const auto& ivi : pending) {
+    if (IsSubscribedAppExist(ivi)) {
+      ext.RemovePendingSubscription(ivi);
+      ext.subscribeToVehicleInfo(ivi);
+    }
+  }
+  pending_resumption_handler_->HandleResumptionSubscriptionRequest(
+      ext, subscriber, app);
+}
+
+void VehicleInfoPlugin::RevertResumption(
+    application_manager::Application& app,
+    const std::set<std::string>& list_of_subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  UNUSED(app);
+
+  pending_resumption_handler_->OnResumptionRevert();
+
+  std::set<std::string> subscriptions_to_revert;
+  for (auto& ivi_data : list_of_subscriptions) {
+    if (!IsSubscribedAppExist(ivi_data)) {
+      subscriptions_to_revert.insert(ivi_data);
+    }
+  }
+
+  if (subscriptions_to_revert.empty()) {
+    LOG4CXX_DEBUG(logger_, "No data to unsubscribe");
+    return;
+  }
+  const auto request = CreateUnsubscriptionRequest(subscriptions_to_revert);
+  application_manager_->GetRPCService().ManageHMICommand(request);
+}
+
+smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateSubscriptionRequest(
+    const std::set<std::string>& list_of_subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto msg_params = smart_objects::SmartObject(smart_objects::SmartType_Map);
+  for (auto& ivi_data : list_of_subscriptions) {
+    msg_params[ivi_data] = true;
+  }
+
+  auto request = application_manager::MessageHelper::CreateModuleInfoSO(
+      hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
+      *application_manager_);
+  (*request)[strings::msg_params] = msg_params;
+  return request;
+}
+
+smart_objects::SmartObjectSPtr VehicleInfoPlugin::CreateUnsubscriptionRequest(
+    const std::set<std::string>& list_of_subscriptions) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto msg_params = smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  for (auto& ivi_data : list_of_subscriptions) {
+    msg_params[ivi_data] = true;
+  }
+
+  auto request = application_manager::MessageHelper::CreateModuleInfoSO(
+      hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData,
+      *application_manager_);
+  (*request)[strings::msg_params] = msg_params;
+
+  return request;
+}
+
+bool VehicleInfoPlugin::IsSubscribedAppExist(const std::string& ivi) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto apps_accessor = application_manager_->applications();
+
+  for (auto& app : apps_accessor.GetData()) {
     auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-    if (ext.isSubscribedToVehicleInfo(ivi_name) &&
-        (app->app_id() != current_app_id)) {
+    if (ext.isSubscribedToVehicleInfo(ivi)) {
       return true;
     }
   }
   return false;
-}
-
-void VehicleInfoPlugin::ProcessResumptionSubscription(
-    application_manager::Application& app, VehicleInfoAppExtension& ext) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  smart_objects::SmartObject msg_params =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-  const auto& subscriptions = ext.Subscriptions();
-
-  if (subscriptions.empty()) {
-    LOG4CXX_DEBUG(logger_, "No vehicle data to subscribe. Exiting");
-    return;
-  }
-
-  for (auto& ivi : subscriptions) {
-    if (!IsOtherAppAlreadySubscribedFor(
-            ivi, *application_manager_, app.app_id())) {
-      msg_params[ivi] = true;
-    }
-  }
-
-  if (!msg_params.empty()) {
-    auto request = application_manager::MessageHelper::CreateModuleInfoSO(
-        hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
-        *application_manager_);
-    msg_params[strings::app_id] = app.app_id();
-    (*request)[strings::msg_params] = msg_params;
-    application_manager_->GetRPCService().ManageHMICommand(request);
-  }
 }
 
 application_manager::ApplicationSharedPtr FindAppSubscribedToIVI(
@@ -264,7 +310,7 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::GetUnsubscribeIVIRequest(
 void VehicleInfoPlugin::DeleteSubscriptions(
     application_manager::ApplicationSharedPtr app) {
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-  auto subscriptions = ext.Subscriptions();
+  auto subscriptions = ext.Subscriptions().GetData();
   std::vector<std::string> ivi_to_unsubscribe;
   for (auto& ivi : subscriptions) {
     ext.unsubscribeFromVehicleInfo(ivi);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/CMakeLists.txt
@@ -52,6 +52,7 @@ file(GLOB SOURCES
   ${COMMANDS_TEST_DIR}/mobile/*
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_vehicle_data_manager_test.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/vehicle_data_item_schema_test.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/vehicle_info_pending_resumption_test.cc
   ${COMPONENTS_DIR}/application_manager/src/message.cc
   ${COMPONENTS_DIR}/application_manager/src/event_engine/*
   ${COMPONENTS_DIR}/resumption/src/last_state_wrapper_impl.cc
@@ -60,7 +61,6 @@ file(GLOB SOURCES
 set(LIBRARIES
   gmock
   Utils
-  SmartObjects
   HMI_API
   MOBILE_API
   connectionHandler

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/subscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/subscribe_vehicle_request_test.cc
@@ -87,6 +87,8 @@ class SubscribeVehicleRequestTest
   void SetUp() OVERRIDE {
     ON_CALL(app_mngr_, GetRPCHandler())
         .WillByDefault(ReturnRef(mock_rpc_handler_));
+    ON_CALL(app_mngr_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_));
 
     vi_plugin_.Init(app_mngr_,
                     mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/unsubscribe_vehicle_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/mobile/unsubscribe_vehicle_request_test.cc
@@ -88,6 +88,8 @@ class UnsubscribeVehicleRequestTest
   void SetUp() OVERRIDE {
     ON_CALL(app_mngr_, GetRPCHandler())
         .WillByDefault(ReturnRef(mock_rpc_handler_));
+    ON_CALL(app_mngr_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_));
 
     vi_plugin_.Init(app_mngr_,
                     mock_rpc_service_,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
@@ -1,0 +1,659 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE. */
+
+#include <boost/range/algorithm/set_algorithm.hpp>
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_event_dispatcher.h"
+#include "application_manager/mock_event_observer.h"
+#include "application_manager/mock_message_helper.h"
+#include "application_manager/mock_rpc_service.h"
+#include "gtest/gtest.h"
+#include "vehicle_info_plugin/mock_custom_vehicle_data_manager.h"
+#include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
+#include "vehicle_info_plugin/vehicle_info_plugin.h"
+
+namespace vehicle_info_plugin_test {
+using namespace vehicle_info_plugin;
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::SaveArg;
+
+using application_manager::MockMessageHelper;
+typedef NiceMock< ::test::components::event_engine_test::MockEventDispatcher>
+    MockEventDispatcher;
+typedef NiceMock< ::test::components::event_engine_test::MockEventObserver>
+    MockEventObserver;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockApplicationManager>
+    MockApplicationManager;
+typedef NiceMock< ::test::components::application_manager_test::MockApplication>
+    MockApplication;
+typedef NiceMock<test::components::application_manager_test::MockRPCService>
+    MockRPCService;
+typedef std::shared_ptr<MockApplication> MockAppPtr;
+typedef std::shared_ptr<vehicle_info_plugin::VehicleInfoAppExtension>
+    VehicleInfoAppExtensionPtr;
+using hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
+
+class SubscribeCatcher {
+ public:
+  MOCK_METHOD2(subscribe,
+               void(const int32_t, const resumption::ResumptionRequest));
+};
+
+smart_objects::SmartObjectSPtr CreateVDRequest(const uint32_t corr_id) {
+  using namespace application_manager;
+  smart_objects::SmartObjectSPtr request =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  smart_objects::SmartObject& object = *request;
+  const auto message_type_request = 0;
+  object[strings::params][strings::message_type] = message_type_request;
+  object[strings::params][strings::function_id] =
+      static_cast<int>(VehicleInfo_SubscribeVehicleData);
+
+  object[strings::params][strings::correlation_id] = corr_id;
+  object[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  return request;
+}
+
+mobile_apis::VehicleDataType::eType ToVDType(const std::string& vd) {
+  if ("gps" == vd) {
+    return mobile_apis::VehicleDataType::VEHICLEDATA_GPS;
+  }
+  if ("speed" == vd) {
+    return mobile_apis::VehicleDataType::VEHICLEDATA_SPEED;
+  }
+  return mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA;
+}
+
+smart_objects::SmartObject CreateVDError(const uint32_t correlation_id,
+                                         const int32_t result_code,
+                                         const std::string& info) {
+  namespace strings = application_manager::strings;
+  namespace hmi_response = application_manager::hmi_response;
+  smart_objects::SmartObject message(smart_objects::SmartType_Map);
+
+  message[strings::params][strings::function_id] =
+      VehicleInfo_SubscribeVehicleData;
+  const auto hmi_protocol_type = 1;
+  message[strings::params][strings::protocol_type] = hmi_protocol_type;
+  message[strings::params][strings::correlation_id] = correlation_id;
+
+  const auto message_type_response = 1;
+  message[strings::params][strings::message_type] = message_type_response;
+  message[strings::params][hmi_response::code] = result_code;
+  message[strings::params][strings::error_msg] = info;
+
+  return message;
+}
+
+smart_objects::SmartObjectSPtr CreateHMIResponseMessage(
+    const hmi_apis::Common_Result::eType common_result,
+    uint32_t correlation_id) {
+  namespace strings = application_manager::strings;
+  namespace hmi_response = application_manager::hmi_response;
+  smart_objects::SmartObject params(smart_objects::SmartType_Map);
+  params[strings::function_id] = VehicleInfo_SubscribeVehicleData;
+  params[strings::message_type] = application_manager::MessageType::kResponse;
+  params[strings::correlation_id] = correlation_id;
+  const auto hmi_protocol_type = 1;
+  params[strings::protocol_type] = hmi_protocol_type;
+  params[hmi_response::code] = common_result;
+
+  smart_objects::SmartObjectSPtr response =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  auto& message = *response;
+  message[strings::params] = params;
+  message[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  return response;
+}
+
+typedef std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+    VDResponseMap;
+smart_objects::SmartObject CreateVDResponse(
+    const hmi_apis::Common_Result::eType common_result,
+    const VDResponseMap& subscriptions_result,
+    uint32_t correleation_id) {
+  namespace strings = application_manager::strings;
+  namespace hmi_response = application_manager::hmi_response;
+
+  smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
+  for (const auto& subscription : subscriptions_result) {
+    smart_objects::SmartObject subscription_result(
+        smart_objects::SmartType_Map);
+    subscription_result[strings::data_type] = ToVDType(subscription.first);
+    subscription_result[strings::result_code] = subscription.second;
+    msg_params[subscription.first] = subscription_result;
+  }
+  auto response = CreateHMIResponseMessage(common_result, correleation_id);
+  (*response)[strings::msg_params] = msg_params;
+  return *response;
+}
+
+enum class ContainsPolicy { Strict, Nice };
+
+bool CheckThatMessageContainsVD(
+    const smart_objects::SmartObject& message,
+    const std::set<std::string>& vehicle_data,
+    ContainsPolicy policy = ContainsPolicy::Strict) {
+  using namespace application_manager;
+  auto& msg_params = message[strings::msg_params];
+  auto keys = msg_params.enumerate();
+  std::set<std::string> missed;
+  boost::set_difference(
+      vehicle_data, keys, std::inserter(missed, missed.end()));
+  if (missed.size() > 0) {
+    return false;
+  }
+  if (ContainsPolicy::Strict == policy) {
+    std::set<std::string> redundant;
+    boost::set_difference(
+        keys, vehicle_data, std::inserter(redundant, redundant.end()));
+    if (redundant.size() > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief EventCheck check that event contains apropriate vehicle data,
+ * check that is matched correlation id,
+ * check that function id is correct
+ */
+MATCHER_P2(EventCheck, expected_corr_id, vehicle_data, "") {
+  namespace strings = application_manager::strings;
+  const auto& response_message = arg.smart_object();
+  const bool vehicle_data_ok =
+      CheckThatMessageContainsVD(response_message, vehicle_data);
+  const auto cid =
+      response_message[strings::params][strings::correlation_id].asInt();
+  const bool cid_ok = (cid == expected_corr_id);
+  const auto fid =
+      response_message[strings::params][strings::function_id].asInt();
+  const bool fid_ok = (fid == VehicleInfo_SubscribeVehicleData);
+  return fid_ok && cid_ok && vehicle_data_ok;
+}
+
+// Replace correlation id in the message shared pointer with argument specified
+// in template
+ACTION_TEMPLATE(ReplaceCorrelationId,
+                HAS_1_TEMPLATE_PARAMS(int, k),
+                AND_1_VALUE_PARAMS(pointer)) {
+  namespace strings = application_manager::strings;
+  (**pointer)[strings::params][strings::correlation_id] =
+      ::std::tr1::get<k>(args);
+}
+
+class VehicleInfoPendingResumptionHandlerTest : public ::testing::Test {
+  // using namespace vehicle_info_plugin;
+ public:
+  VehicleInfoPendingResumptionHandlerTest()
+      : mock_message_helper_(
+            *application_manager::MockMessageHelper::message_helper_mock())
+
+  {}
+
+  void SetUp() OVERRIDE {
+    ON_CALL(app_manager_mock_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_mock_));
+    ON_CALL(app_manager_mock_, GetRPCService())
+        .WillByDefault(ReturnRef(mock_rpc_service_));
+    resumption_handler_.reset(
+        new vehicle_info_plugin::VehicleInfoPendingResumptionHandler(
+            app_manager_mock_, custom_vehicle_data_manager_mock_));
+    MessageHelperResponseCreateExpectation();
+  }
+
+  void MessageHelperResponseCreateExpectation() {
+    const int default_corr_id = 0;
+    static auto response = CreateHMIResponseMessage(
+        hmi_apis::Common_Result::SUCCESS, default_corr_id);
+
+    ON_CALL(mock_message_helper_,
+            CreateResponseMessageFromHmi(VehicleInfo_SubscribeVehicleData,
+                                         _,
+                                         hmi_apis::Common_Result::SUCCESS))
+        .WillByDefault(
+            DoAll(ReplaceCorrelationId<1>(&response), Return(response)));
+  }
+
+  MockAppPtr CreateApp(uint32_t app_id) {
+    auto mock_app = std::make_shared<MockApplication>();
+
+    ON_CALL(app_manager_mock_, application(app_id))
+        .WillByDefault(Return(mock_app));
+    ON_CALL(*mock_app, app_id()).WillByDefault(Return(app_id));
+    return mock_app;
+  }
+
+  VehicleInfoAppExtensionPtr CreateExtension(MockApplication& app) {
+    auto ext_ptr = std::make_shared<VehicleInfoAppExtension>(plugin_, app);
+    ON_CALL(app,
+            QueryInterface(VehicleInfoAppExtension::VehicleInfoAppExtensionUID))
+        .WillByDefault(Return(ext_ptr));
+    return ext_ptr;
+  }
+
+  resumption::Subscriber& get_subscriber() {
+    static resumption::Subscriber subscriber =
+        [this](const int32_t corr_id,
+               const resumption::ResumptionRequest resumption_request) {
+          this->subscribe_catcher_.subscribe(corr_id, resumption_request);
+        };
+    return subscriber;
+  }
+
+  SubscribeCatcher subscribe_catcher_;
+  MockMessageHelper& mock_message_helper_;
+  MockApplicationManager app_manager_mock_;
+  MockEventDispatcher event_dispatcher_mock_;
+  MockRPCService mock_rpc_service_;
+  NiceMock<MockCustomVehicleDataManager> custom_vehicle_data_manager_mock_;
+  vehicle_info_plugin::VehicleInfoPlugin plugin_;
+
+  std::unique_ptr<vehicle_info_plugin::VehicleInfoPendingResumptionHandler>
+      resumption_handler_;
+};
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest, NoSubscriptionNoAction) {
+  auto mock_app = CreateApp(1);
+  auto ext_ptr = CreateExtension(*mock_app);
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(0);
+  resumption::Subscriber& subscribe = get_subscriber();
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext_ptr, subscribe, *mock_app);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataSuccess) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  auto request = CreateVDRequest(1);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  uint32_t subscribed_correlation_id;
+  resumption::ResumptionRequest resumption_request;
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&subscribed_correlation_id),
+                      SaveArg<1>(&resumption_request)));
+
+  smart_objects::SmartObjectSPtr message_to_hmi;
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&message_to_hmi), Return(true)));
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+  EXPECT_EQ(resumption_request.request_ids.function_id,
+            VehicleInfo_SubscribeVehicleData);
+  EXPECT_TRUE(
+      CheckThatMessageContainsVD(resumption_request.message, {"gps", "speed"}));
+  EXPECT_TRUE(CheckThatMessageContainsVD(*message_to_hmi, {"gps", "speed"}));
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseSuccess) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  uint32_t subscribed_app_id;
+  resumption::ResumptionRequest resumption_request;
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&subscribed_app_id),
+                      SaveArg<1>(&resumption_request)));
+
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+          {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
+
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+
+  std::set<std::string> expected_data_in_event = {"gps", "speed"};
+  const auto subscribed_correlation_id =
+      resumption_request.request_ids.correlation_id;
+  EXPECT_CALL(event_dispatcher_mock_,
+              raise_event(EventCheck(subscribed_correlation_id,
+                                     expected_data_in_event)));
+
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseOneFailed) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  uint32_t subscribed_app_id;
+  resumption::ResumptionRequest resumption_request;
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&subscribed_app_id),
+                      SaveArg<1>(&resumption_request)));
+
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+          {"speed",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+      };
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  std::set<std::string> expected_data_in_event = {"gps", "speed"};
+  const auto subscribed_correlation_id =
+      resumption_request.request_ids.correlation_id;
+
+  EXPECT_CALL(event_dispatcher_mock_,
+              raise_event(EventCheck(subscribed_correlation_id,
+                                     expected_data_in_event)));
+
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseAllFailed) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  uint32_t subscribed_app_id;
+  resumption::ResumptionRequest resumption_request;
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&subscribed_app_id),
+                      SaveArg<1>(&resumption_request)));
+
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+          {"speed",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+      };
+
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseOveralResultFailed) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  uint32_t subscribed_app_id;
+  resumption::ResumptionRequest resumption_request;
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&subscribed_app_id),
+                      SaveArg<1>(&resumption_request)));
+
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+
+  auto response =
+      CreateVDError(corr_id, hmi_apis::Common_Result::ABORTED, "error message");
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest, TwoAppsOneSharedDataSuccess) {
+  auto mock_app = CreateApp(1);
+  auto mock_app2 = CreateApp(2);
+  auto ext = CreateExtension(*mock_app);
+  auto ext2 = CreateExtension(*mock_app2);
+  ext->AddPendingSubscription("gps");
+  ext2->AddPendingSubscription("gps");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(2);
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
+
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext2, get_subscriber(), *mock_app2);
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().GetData().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       TwoAppsMultipleSharedDataSuccessResumption) {
+  auto mock_app = CreateApp(1);
+  auto mock_app2 = CreateApp(2);
+  auto ext = CreateExtension(*mock_app);
+  auto ext2 = CreateExtension(*mock_app2);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+  ext2->AddPendingSubscription("gps");
+  ext2->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(2);
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+          {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
+
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext2, get_subscriber(), *mock_app2);
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().GetData().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       TwoAppsOneSharedDataFailRetryforSecondApp) {
+  auto mock_app = CreateApp(1);
+  auto mock_app2 = CreateApp(2);
+  auto ext = CreateExtension(*mock_app);
+  auto ext2 = CreateExtension(*mock_app2);
+  ext->AddPendingSubscription("gps");
+  ext2->AddPendingSubscription("gps");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(2);
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(2);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_AVAILABLE},
+      };
+
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext, get_subscriber(), *mock_app);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+      *ext2, get_subscriber(), *mock_app2);
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      second_subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
+  auto second_response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, second_subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event second_event(
+      VehicleInfo_SubscribeVehicleData);
+  second_event.set_smart_object(second_response);
+
+  resumption_handler_->on_event(second_event);
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().GetData().size(), 0u);
+}
+
+}  // namespace vehicle_info_plugin_test

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -207,12 +207,14 @@ DynamicApplicationDataImpl::DynamicApplicationDataImpl()
     , sub_menu_()
     , sub_menu_lock_ptr_(std::make_shared<sync_primitives::RecursiveLock>())
     , choice_set_map_()
-    , choice_set_map_lock_ptr_(std::make_shared<sync_primitives::Lock>())
+    , choice_set_map_lock_ptr_(
+          std::make_shared<sync_primitives::RecursiveLock>())
     , performinteraction_choice_set_map_()
     , performinteraction_choice_set_lock_ptr_(
           std::make_shared<sync_primitives::RecursiveLock>())
     , window_params_map_()
-    , window_params_map_lock_ptr_(std::make_shared<sync_primitives::Lock>())
+    , window_params_map_lock_ptr_(
+          std::make_shared<sync_primitives::RecursiveLock>())
     , is_perform_interaction_active_(false)
     , is_reset_global_properties_active_(false)
     , perform_interaction_mode_(-1)
@@ -402,27 +404,33 @@ smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::display_capabilities(
     const WindowID window_id) const {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  auto result_display_caps = std::make_shared<smart_objects::SmartObject>(
-      smart_objects::SmartType_Array);
-  const auto window_caps =
-      (*display_capabilities_)[0][strings::window_capabilities].asArray();
-  if (!window_caps) {
+  if (!display_capabilities_) {
     LOG4CXX_WARN(logger_, "Current window capabilities are empty");
     // SDL still needs to retreive display capabilities
     return display_capabilities_;
   }
-  auto find_res =
-      std::find_if(window_caps->begin(),
-                   window_caps->end(),
-                   [&window_id](const smart_objects::SmartObject& element) {
-                     if (window_id == element[strings::window_id].asInt()) {
-                       return true;
-                     }
 
-                     return false;
-                   });
+  smart_objects::SmartObject result_window_caps(
+      smart_objects::SmartType::SmartType_Map);
 
-  DCHECK(find_res != window_caps->end());
+  const auto window_caps =
+      (*display_capabilities_)[0][strings::window_capabilities].asArray();
+  if (window_caps) {
+    auto find_res = std::find_if(
+        window_caps->begin(),
+        window_caps->end(),
+        [&window_id](const smart_objects::SmartObject& element) {
+          return (window_id == element[strings::window_id].asInt());
+        });
+
+    if (find_res != window_caps->end()) {
+      result_window_caps = *find_res;
+    }
+  }
+
+  auto result_display_caps = std::make_shared<smart_objects::SmartObject>(
+      smart_objects::SmartType_Array);
+
   const auto disp_caps_keys = (*display_capabilities_)[0].enumerate();
   for (const auto& key : disp_caps_keys) {
     if (strings::window_capabilities == key) {
@@ -431,7 +439,8 @@ smart_objects::SmartObjectSPtr DynamicApplicationDataImpl::display_capabilities(
     (*result_display_caps)[0][key] = (*display_capabilities_)[0][key];
   }
 
-  (*result_display_caps)[0][strings::window_capabilities][0] = *find_res;
+  (*result_display_caps)[0][strings::window_capabilities][0] =
+      result_window_caps;
 
   return result_display_caps;
 }
@@ -629,6 +638,12 @@ void DynamicApplicationDataImpl::set_display_capabilities(
 void DynamicApplicationDataImpl::remove_window_capability(
     const WindowID window_id) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!display_capabilities_) {
+    LOG4CXX_ERROR(logger_,
+                  "Application display capabilities are not available");
+    return;
+  }
 
   auto window_capabilities =
       (*display_capabilities_)[0][strings::window_capabilities].asArray();

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -354,16 +354,17 @@ ApplicationSharedPtr ApplicationManagerImpl::get_full_or_limited_application()
   return FindApp(accessor, FullOrLimitedAppPredicate);
 }
 
-bool LimitedAppPredicate(const ApplicationSharedPtr app) {
-  return app ? app->hmi_level(mobile_api::PredefinedWindows::DEFAULT_WINDOW) ==
-                   mobile_api::HMILevel::HMI_LIMITED
+bool LimitedMediaAppPredicate(const ApplicationSharedPtr app) {
+  return app ? (app->is_media_application() &&
+                app->hmi_level(mobile_api::PredefinedWindows::DEFAULT_WINDOW) ==
+                    mobile_api::HMILevel::HMI_LIMITED)
              : false;
 }
 
 ApplicationSharedPtr ApplicationManagerImpl::get_limited_media_application()
     const {
   DataAccessor<ApplicationSet> accessor = applications();
-  return FindApp(accessor, LimitedAppPredicate);
+  return FindApp(accessor, LimitedMediaAppPredicate);
 }
 
 bool LimitedNaviAppPredicate(const ApplicationSharedPtr app) {
@@ -1741,7 +1742,7 @@ void ApplicationManagerImpl::SwitchApplication(ApplicationSharedPtr app,
                                       << ". Changing device id to "
                                       << device_id);
 
-  bool is_subscribed_to_way_points = IsAppSubscribedForWayPoints(app);
+  bool is_subscribed_to_way_points = IsAppSubscribedForWayPoints(*app);
   if (is_subscribed_to_way_points) {
     UnsubscribeAppFromWayPoints(app);
   }
@@ -3228,13 +3229,6 @@ void ApplicationManagerImpl::UnregisterApplication(
 
   GetAppServiceManager().UnpublishServices(app_id);
 
-  if (IsAppSubscribedForWayPoints(app_id)) {
-    UnsubscribeAppFromWayPoints(app_id);
-    if (!IsAnyAppSubscribedForWayPoints()) {
-      LOG4CXX_ERROR(logger_, "Send UnsubscribeWayPoints");
-      MessageHelper::SendUnsubscribedWayPoints(*this);
-    }
-  }
   EndNaviServices(app_id);
 
   {
@@ -3308,6 +3302,16 @@ void ApplicationManagerImpl::UnregisterApplication(
       resume_controller().SaveApplication(app_to_remove);
     } else {
       resume_controller().RemoveApplicationFromSaved(app_to_remove);
+    }
+
+    if (IsAppSubscribedForWayPoints(app_id)) {
+      UnsubscribeAppFromWayPoints(app_id);
+      if (!IsAnyAppSubscribedForWayPoints()) {
+        LOG4CXX_DEBUG(logger_, "Send UnsubscribeWayPoints");
+        auto request = MessageHelper::CreateUnsubscribeWayPointsRequest(
+            GetNextHMICorrelationID());
+        rpc_service_->ManageHMICommand(request);
+      }
     }
 
     (hmi_capabilities_->get_hmi_language_handler())
@@ -3856,6 +3860,73 @@ void ApplicationManagerImpl::ProcessApp(const uint32_t app_id,
   LOG4CXX_TRACE(logger_, "No actions required for app " << app_id);
 }
 
+bool ApplicationManagerImpl::ResetHelpPromt(ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+  const std::vector<std::string>& help_prompt = get_settings().help_prompt();
+
+  smart_objects::SmartObject so_help_prompt =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  for (size_t i = 0; i < help_prompt.size(); ++i) {
+    smart_objects::SmartObject help_prompt_item =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    help_prompt_item[strings::text] = help_prompt[i];
+    help_prompt_item[strings::type] =
+        hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+    so_help_prompt[i] = help_prompt_item;
+  }
+
+  app->set_help_prompt(so_help_prompt);
+  return true;
+}
+
+bool ApplicationManagerImpl::ResetTimeoutPromt(ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+
+  const std::vector<std::string>& time_out_promt =
+      get_settings().time_out_promt();
+
+  smart_objects::SmartObject so_time_out_promt =
+      smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+  for (uint32_t i = 0; i < time_out_promt.size(); ++i) {
+    smart_objects::SmartObject timeoutPrompt =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    timeoutPrompt[strings::text] = time_out_promt[i];
+    timeoutPrompt[strings::type] = hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+    so_time_out_promt[i] = timeoutPrompt;
+  }
+
+  app->set_timeout_prompt(so_time_out_promt);
+
+  return true;
+}
+
+bool ApplicationManagerImpl::ResetVrHelpTitleItems(
+    ApplicationSharedPtr app) const {
+  if (!app) {
+    LOG4CXX_ERROR(logger_, "Null pointer");
+    return false;
+  }
+
+  const std::string& vr_help_title = get_settings().vr_help_title();
+  smart_objects::SmartObject so_vr_help_title =
+      smart_objects::SmartObject(smart_objects::SmartType_String);
+  so_vr_help_title = vr_help_title;
+
+  app->reset_vr_help_title();
+  app->reset_vr_help();
+  app->set_vr_help_title(so_vr_help_title);
+
+  return true;
+}
+
 void ApplicationManagerImpl::StartEndStreamTimer(const uint32_t app_id) {
   LOG4CXX_DEBUG(logger_, "Start end stream timer for app " << app_id);
   navi_app_to_end_stream_.push_back(app_id);
@@ -4188,6 +4259,107 @@ void ApplicationManagerImpl::RemoveAppFromTTSGlobalPropertiesList(
     }
   }
   tts_global_properties_app_list_lock_.Release();
+}
+
+ResetGlobalPropertiesResult ApplicationManagerImpl::ResetGlobalProperties(
+    const smart_objects::SmartObject& global_properties_ids,
+    const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  ApplicationSharedPtr application =
+      ApplicationManagerImpl::application(app_id);
+  // if application waits for sending ttsGlobalProperties need to remove this
+  // application from tts_global_properties_app_list_
+  LOG4CXX_DEBUG(logger_, "RemoveAppFromTTSGlobalPropertiesList");
+  RemoveAppFromTTSGlobalPropertiesList(app_id);
+
+  ResetGlobalPropertiesResult result;
+
+  for (size_t i = 0; i < global_properties_ids.length(); ++i) {
+    mobile_apis::GlobalProperty::eType global_property =
+        static_cast<mobile_apis::GlobalProperty::eType>(
+            global_properties_ids[i].asInt());
+    switch (global_property) {
+      case mobile_apis::GlobalProperty::HELPPROMPT: {
+        result.help_prompt = ResetHelpPromt(application);
+        break;
+      }
+      case mobile_apis::GlobalProperty::TIMEOUTPROMPT: {
+        result.timeout_prompt = ResetTimeoutPromt(application);
+        break;
+      }
+      case mobile_apis::GlobalProperty::VRHELPTITLE:
+      case mobile_apis::GlobalProperty::VRHELPITEMS: {
+        if (0 == result.number_of_reset_vr) {
+          result.number_of_reset_vr++;
+          result.vr_help_title_items = ResetVrHelpTitleItems(application);
+        }
+        break;
+      }
+      case mobile_apis::GlobalProperty::MENUNAME: {
+        result.menu_name = true;
+        break;
+      }
+      case mobile_apis::GlobalProperty::MENUICON: {
+        result.menu_icon = true;
+        break;
+      }
+      case mobile_apis::GlobalProperty::KEYBOARDPROPERTIES: {
+        result.keyboard_properties = true;
+        break;
+      }
+      default: {
+        LOG4CXX_TRACE(logger_, "Unknown global property: " << global_property);
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+ResetGlobalPropertiesResult
+ApplicationManagerImpl::ResetAllApplicationGlobalProperties(
+    const uint32_t app_id) {
+  const smart_objects::SmartObjectSPtr application_gl_props =
+      CreateAllAppGlobalPropsIDList(app_id);
+  return ResetGlobalProperties(*application_gl_props, app_id);
+}
+
+const smart_objects::SmartObjectSPtr
+ApplicationManagerImpl::CreateAllAppGlobalPropsIDList(
+    const uint32_t app_id) const {
+  auto global_properties = std::make_shared<smart_objects::SmartObject>(
+      smart_objects::SmartType_Array);
+  using namespace mobile_apis;
+
+  ApplicationConstSharedPtr application =
+      ApplicationManagerImpl::application(app_id);
+  int32_t i = 0;
+
+  if (application->help_prompt()) {
+    (*global_properties)[i++] = GlobalProperty::HELPPROMPT;
+  }
+  if (application->timeout_prompt()) {
+    (*global_properties)[i++] = GlobalProperty::TIMEOUTPROMPT;
+  }
+  if (application->vr_help_title()) {
+    (*global_properties)[i++] = GlobalProperty::VRHELPTITLE;
+  }
+  if (application->vr_help()) {
+    (*global_properties)[i++] = GlobalProperty::VRHELPITEMS;
+  }
+  if (application->menu_title()) {
+    (*global_properties)[i++] = GlobalProperty::MENUNAME;
+  }
+  if (application->menu_icon()) {
+    (*global_properties)[i++] = GlobalProperty::MENUICON;
+  }
+  if (application->keyboard_props()) {
+    (*global_properties)[i++] = GlobalProperty::KEYBOARDPROPERTIES;
+  }
+
+  return global_properties;
 }
 
 mobile_apis::AppHMIType::eType ApplicationManagerImpl::StringToAppHMIType(
@@ -4662,8 +4834,8 @@ bool ApplicationManagerImpl::IsAppSubscribedForWayPoints(
 }
 
 bool ApplicationManagerImpl::IsAppSubscribedForWayPoints(
-    ApplicationSharedPtr app) const {
-  return IsAppSubscribedForWayPoints(app->app_id());
+    Application& app) const {
+  return IsAppSubscribedForWayPoints(app.app_id());
 }
 
 void ApplicationManagerImpl::SubscribeAppForWayPoints(uint32_t app_id) {

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -354,7 +354,8 @@ std::string MessageHelper::MobileLanguageToString(
 }
 
 smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
-    hmi_apis::messageType::eType message_type, const uint32_t correlation_id) {
+    const hmi_apis::messageType::eType message_type,
+    const uint32_t correlation_id) {
   using namespace smart_objects;
 
   SmartObjectSPtr message = std::make_shared<SmartObject>(SmartType_Map);
@@ -367,6 +368,89 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
       commands::CommandImpl::hmi_protocol_type_;
   ref[strings::params][strings::correlation_id] = correlation_id;
   return message;
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
+    const hmi_apis::FunctionID::eType function_id,
+    const uint32_t correlation_id) {
+  using namespace smart_objects;
+
+  SmartObjectSPtr message = std::make_shared<SmartObject>(SmartType_Map);
+  SmartObject& ref = *message;
+
+  ref[strings::params][strings::function_id] = static_cast<int>(function_id);
+  ref[strings::params][strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  ref[strings::params][strings::protocol_type] =
+      commands::CommandImpl::hmi_protocol_type_;
+  ref[strings::params][strings::correlation_id] = correlation_id;
+  return message;
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    const ApplicationSharedPtr application) {
+  smart_objects::SmartObjectSPtr ui_reset_global_prop_request =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  if (reset_result.help_prompt) {
+    (*ui_reset_global_prop_request)[strings::help_prompt] =
+        *(application->help_prompt());
+  }
+
+  if (reset_result.timeout_prompt) {
+    (*ui_reset_global_prop_request)[strings::timeout_prompt] =
+        *(application->timeout_prompt());
+  }
+
+  (*ui_reset_global_prop_request)[strings::app_id] = application->app_id();
+
+  return ui_reset_global_prop_request;
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateUIResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    const ApplicationSharedPtr application) {
+  smart_objects::SmartObjectSPtr tts_reset_global_prop_request =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  if (reset_result.vr_help_title_items) {
+    smart_objects::SmartObjectSPtr vr_help = CreateAppVrHelp(application);
+    if (!vr_help.get()) {
+      LOG4CXX_WARN(logger_, "Failed to create vr_help");
+      return smart_objects::SmartObjectSPtr();
+    } else {
+      tts_reset_global_prop_request = vr_help;
+    }
+  }
+  if (reset_result.menu_name) {
+    (*tts_reset_global_prop_request)[hmi_request::menu_title] = "";
+    application->set_menu_title(
+        (*tts_reset_global_prop_request)[hmi_request::menu_title]);
+  }
+
+  if (reset_result.keyboard_properties) {
+    smart_objects::SmartObject key_board_properties =
+        smart_objects::SmartObject(smart_objects::SmartType_Map);
+    key_board_properties[strings::language] =
+        static_cast<int32_t>(hmi_apis::Common_Language::EN_US);
+    key_board_properties[hmi_request::keyboard_layout] =
+        static_cast<int32_t>(hmi_apis::Common_KeyboardLayout::QWERTY);
+    key_board_properties[hmi_request::auto_complete_list] =
+        smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+    key_board_properties[strings::auto_complete_text] = "";
+    (*tts_reset_global_prop_request)[hmi_request::keyboard_properties] =
+        key_board_properties;
+  }
+
+  (*tts_reset_global_prop_request)[strings::app_id] = application->app_id();
+
+  return tts_reset_global_prop_request;
 }
 
 smart_objects::SmartObjectSPtr
@@ -530,20 +614,23 @@ MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
   return notification;
 }
 
-void MessageHelper::SendDeleteCommandRequest(smart_objects::SmartObject* cmd,
-                                             ApplicationSharedPtr application,
-                                             ApplicationManager& app_mngr) {
+smart_objects::SmartObjectSPtr MessageHelper::CreateDeleteUICommandRequest(
+    smart_objects::SmartObject* cmd,
+    const uint32_t app_id,
+    const uint32_t corr_id) {
   LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK_OR_RETURN_VOID(cmd);
+
   using namespace smart_objects;
+  DCHECK_OR_RETURN(cmd, nullptr);
+
   SmartObject msg_params = SmartObject(smart_objects::SmartType_Map);
 
   msg_params[strings::cmd_id] = (*cmd)[strings::cmd_id];
-  msg_params[strings::app_id] = application->app_id();
+  msg_params[strings::app_id] = app_id;
 
   if ((*cmd).keyExists(strings::menu_params)) {
-    SmartObjectSPtr message = CreateMessageForHMI(
-        hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
+    SmartObjectSPtr message =
+        CreateMessageForHMI(hmi_apis::messageType::request, corr_id);
     DCHECK(message);
 
     SmartObject& object = *message;
@@ -551,16 +638,31 @@ void MessageHelper::SendDeleteCommandRequest(smart_objects::SmartObject* cmd,
         hmi_apis::FunctionID::UI_DeleteCommand;
 
     object[strings::msg_params] = msg_params;
-
-    app_mngr.GetRPCService().ManageHMICommand(message);
+    return message;
   }
+  return nullptr;
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateDeleteVRCommandRequest(
+    smart_objects::SmartObject* cmd,
+    ApplicationSharedPtr application,
+    const uint32_t corr_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  using namespace smart_objects;
+  DCHECK_OR_RETURN(cmd, nullptr);
+
+  SmartObject msg_params = SmartObject(smart_objects::SmartType_Map);
+
+  msg_params[strings::cmd_id] = (*cmd)[strings::cmd_id];
+  msg_params[strings::app_id] = application->app_id();
 
   if ((*cmd).keyExists(strings::vr_commands)) {
     msg_params[strings::grammar_id] = application->get_grammar_id();
     msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
 
-    SmartObjectSPtr message = CreateMessageForHMI(
-        hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
+    SmartObjectSPtr message =
+        CreateMessageForHMI(hmi_apis::messageType::request, corr_id);
     DCHECK(message);
 
     SmartObject& object = *message;
@@ -568,9 +670,9 @@ void MessageHelper::SendDeleteCommandRequest(smart_objects::SmartObject* cmd,
         hmi_apis::FunctionID::VR_DeleteCommand;
 
     object[strings::msg_params] = msg_params;
-
-    app_mngr.GetRPCService().ManageHMICommand(message);
+    return message;
   }
+  return nullptr;
 }
 
 void MessageHelper::SendDeleteSubmenuRequest(smart_objects::SmartObject* cmd,
@@ -635,8 +737,6 @@ void MessageHelper::SendDeleteChoiceSetRequest(smart_objects::SmartObject* cmd,
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN_VOID(cmd);
   using namespace smart_objects;
-
-  // Same is deleted with SendDeleteCommandRequest?
 
   SmartObject msg_params = SmartObject(smart_objects::SmartType_Map);
 
@@ -810,16 +910,14 @@ hmi_apis::Common_Result::eType MessageHelper::MobileToHMIResult(
   return HMIResultFromString(result);
 }
 
-void MessageHelper::SendHMIStatusNotification(
-    ApplicationSharedPtr application,
-    const WindowID window_id,
-    ApplicationManager& application_manager) {
+smart_objects::SmartObjectSPtr MessageHelper::CreateHMIStatusNotification(
+    ApplicationSharedPtr application, const WindowID window_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObjectSPtr notification =
       std::make_shared<smart_objects::SmartObject>();
   if (!notification) {
     LOG4CXX_ERROR(logger_, "Failed to create smart object");
-    return;
+    return notification;
   }
   smart_objects::SmartObject& message = *notification;
 
@@ -845,9 +943,7 @@ void MessageHelper::SendHMIStatusNotification(
 
   message[strings::msg_params][strings::system_context] =
       static_cast<int32_t>(application->system_context(window_id));
-
-  application_manager.GetRPCService().ManageMobileCommand(
-      notification, commands::Command::SOURCE_SDL);
+  return notification;
 }
 
 void MessageHelper::SendActivateAppToHMI(
@@ -1128,6 +1224,65 @@ void MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
   }
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateOnButtonSubscriptionNotification(
+    uint32_t app_id,
+    hmi_apis::Common_ButtonName::eType button,
+    bool is_subscribed) {
+  using namespace smart_objects;
+  using namespace hmi_apis;
+  LOG4CXX_AUTO_TRACE(logger_);
+  SmartObjectSPtr notification_ptr =
+      std::make_shared<SmartObject>(SmartType_Map);
+  if (!notification_ptr) {
+    LOG4CXX_ERROR(logger_, "Memory allocation failed.");
+    return SmartObjectSPtr(nullptr);
+  }
+  SmartObject& notification = *notification_ptr;
+  SmartObject msg_params = SmartObject(SmartType_Map);
+  msg_params[strings::app_id] = app_id;
+  msg_params[strings::name] = button;
+  msg_params[strings::is_suscribed] = is_subscribed;
+  notification[strings::params][strings::message_type] =
+      static_cast<int32_t>(application_manager::MessageType::kNotification);
+  notification[strings::params][strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  notification[strings::params][strings::protocol_type] =
+      commands::CommandImpl::hmi_protocol_type_;
+  notification[strings::params][strings::function_id] =
+      hmi_apis::FunctionID::Buttons_OnButtonSubscription;
+  notification[strings::msg_params] = msg_params;
+  return notification_ptr;
+}
+
+smart_objects::SmartObjectList
+MessageHelper::CreateOnButtonSubscriptionNotificationsForApp(
+    ApplicationConstSharedPtr app,
+    ApplicationManager& app_mngr,
+    const ButtonSubscriptions& button_subscriptions) {
+  using namespace smart_objects;
+  using namespace hmi_apis;
+  using namespace mobile_apis;
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  SmartObjectList button_subscription_requests;
+
+  if (app.use_count() == 0) {
+    LOG4CXX_ERROR(logger_, "Invalid application pointer ");
+    return button_subscription_requests;
+  }
+
+  for (auto& it : button_subscriptions) {
+    const Common_ButtonName::eType btn =
+        static_cast<Common_ButtonName::eType>(it);
+
+    button_subscription_requests.push_back(
+        CreateOnButtonSubscriptionNotification(app->hmi_app_id(), btn, true));
+  }
+
+  return button_subscription_requests;
+}
+
 void MessageHelper::SendSetAppIcon(
     const uint32_t app_id,
     const std::string& icon_path,
@@ -1172,8 +1327,8 @@ void MessageHelper::SendGlobalPropertiesToHMI(ApplicationConstSharedPtr app,
     return;
   }
 
-  smart_objects::SmartObjectList requests = CreateGlobalPropertiesRequestsToHMI(
-      app, app_mngr.GetNextHMICorrelationID());
+  smart_objects::SmartObjectList requests =
+      CreateGlobalPropertiesRequestsToHMI(app, app_mngr);
   for (smart_objects::SmartObjectList::const_iterator it = requests.begin();
        it != requests.end();
        ++it) {
@@ -1183,8 +1338,10 @@ void MessageHelper::SendGlobalPropertiesToHMI(ApplicationConstSharedPtr app,
 
 smart_objects::SmartObjectList
 MessageHelper::CreateGlobalPropertiesRequestsToHMI(
-    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
+    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
   LOG4CXX_AUTO_TRACE(logger_);
+
+  uint32_t correlation_id = app_mngr.GetNextHMICorrelationID();
 
   smart_objects::SmartObjectList requests;
   if (app.use_count() == 0) {
@@ -1204,8 +1361,8 @@ MessageHelper::CreateGlobalPropertiesRequestsToHMI(
   // UI global properties
 
   if (can_send_ui && (app->vr_help_title() || app->vr_help())) {
-    smart_objects::SmartObjectSPtr ui_global_properties =
-        CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
+    smart_objects::SmartObjectSPtr ui_global_properties = CreateMessageForHMI(
+        hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
     if (!ui_global_properties) {
       return requests;
     }
@@ -1245,6 +1402,7 @@ MessageHelper::CreateGlobalPropertiesRequestsToHMI(
 
   // TTS global properties
   if (can_send_vr && (app->help_prompt() || app->timeout_prompt())) {
+    correlation_id = app_mngr.GetNextHMICorrelationID();
     smart_objects::SmartObjectSPtr tts_global_properties =
         CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
     if (!tts_global_properties) {
@@ -1412,20 +1570,6 @@ void MessageHelper::SendShowConstantTBTRequestToHMI(
   }
 }
 
-void MessageHelper::SendAddCommandRequestToHMI(ApplicationConstSharedPtr app,
-                                               ApplicationManager& app_man) {
-  if (!app) {
-    return;
-  }
-  smart_objects::SmartObjectList requests =
-      CreateAddCommandRequestToHMI(app, app_man);
-  for (smart_objects::SmartObjectList::iterator it = requests.begin();
-       it != requests.end();
-       ++it) {
-    DCHECK(app_man.GetRPCService().ManageHMICommand(*it));
-  }
-}
-
 smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
     ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
   smart_objects::SmartObjectList requests;
@@ -1442,42 +1586,44 @@ smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
     if ((*i->second).keyExists(strings::menu_params)) {
       smart_objects::SmartObjectSPtr ui_command = CreateMessageForHMI(
           hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
-      if (!ui_command) {
-        return requests;
+      if (ui_command) {
+        (*ui_command)[strings::params][strings::function_id] =
+            static_cast<int>(hmi_apis::FunctionID::UI_AddCommand);
+
+        smart_objects::SmartObject msg_params =
+            smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+        if ((*i->second).keyExists(strings::cmd_id)) {
+          msg_params[strings::cmd_id] = (*i->second)[strings::cmd_id].asUInt();
+        } else {
+          LOG4CXX_ERROR(logger_, "Command ID is missing.");
+          continue;
+        }
+        msg_params[strings::menu_params] = (*i->second)[strings::menu_params];
+        msg_params[strings::app_id] = app->app_id();
+
+        if (((*i->second).keyExists(strings::cmd_icon)) &&
+            (0 < (*i->second)[strings::cmd_icon][strings::value].length())) {
+          msg_params[strings::cmd_icon] = (*i->second)[strings::cmd_icon];
+          msg_params[strings::cmd_icon][strings::value] =
+              (*i->second)[strings::cmd_icon][strings::value].asString();
+        }
+        (*ui_command)[strings::msg_params] = msg_params;
+        requests.push_back(ui_command);
       }
-
-      (*ui_command)[strings::params][strings::function_id] =
-          static_cast<int>(hmi_apis::FunctionID::UI_AddCommand);
-
-      smart_objects::SmartObject msg_params =
-          smart_objects::SmartObject(smart_objects::SmartType_Map);
-
-      if ((*i->second).keyExists(strings::cmd_id)) {
-        msg_params[strings::cmd_id] = (*i->second)[strings::cmd_id].asUInt();
-      } else {
-        LOG4CXX_ERROR(logger_, "Command ID is missing.");
-        continue;
-      }
-      msg_params[strings::menu_params] = (*i->second)[strings::menu_params];
-      msg_params[strings::app_id] = app->app_id();
-
-      if (((*i->second).keyExists(strings::cmd_icon)) &&
-          (0 < (*i->second)[strings::cmd_icon][strings::value].length())) {
-        msg_params[strings::cmd_icon] = (*i->second)[strings::cmd_icon];
-        msg_params[strings::cmd_icon][strings::value] =
-            (*i->second)[strings::cmd_icon][strings::value].asString();
-      }
-      (*ui_command)[strings::msg_params] = msg_params;
-      requests.push_back(ui_command);
     }
 
     // VR Interface
     if ((*i->second).keyExists(strings::vr_commands) &&
         (*i->second).keyExists(strings::cmd_id)) {
-      SendAddVRCommandToHMI((*i->second)[strings::cmd_id].asUInt(),
-                            (*i->second)[strings::vr_commands],
-                            app->app_id(),
-                            app_mngr);
+      auto vr_command =
+          CreateAddVRCommandToHMI((*i->second)[strings::cmd_id].asUInt(),
+                                  (*i->second)[strings::vr_commands],
+                                  app->app_id(),
+                                  app_mngr);
+      if (vr_command) {
+        requests.push_back(vr_command);
+      }
     }
   }
   return requests;
@@ -1576,16 +1722,6 @@ void MessageHelper::SendUIChangeRegistrationRequestToHMI(
   }
 }
 
-void MessageHelper::SendAddVRCommandToHMI(
-    const uint32_t cmd_id,
-    const smart_objects::SmartObject& vr_commands,
-    const uint32_t app_id,
-    ApplicationManager& app_mngr) {
-  smart_objects::SmartObjectSPtr request =
-      CreateAddVRCommandToHMI(cmd_id, vr_commands, app_id, app_mngr);
-  DCHECK(app_mngr.GetRPCService().ManageHMICommand(request));
-}
-
 smart_objects::SmartObjectSPtr MessageHelper::CreateAddVRCommandToHMI(
     const uint32_t cmd_id,
     const smart_objects::SmartObject& vr_commands,
@@ -1651,7 +1787,34 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateUICreateWindowRequestToHMI(
         window_info[strings::duplicate_updates_from_window_id].asInt();
   }
 
-  msg_params[strings::app_id] = application->hmi_app_id();
+  msg_params[strings::app_id] = application->app_id();
+
+  (*ui_request)[strings::msg_params] = msg_params;
+
+  return ui_request;
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateUIDeleteWindowRequestToHMI(
+    ApplicationSharedPtr application,
+    ApplicationManager& app_mngr,
+    const WindowID window_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto ui_request = CreateMessageForHMI(hmi_apis::messageType::request,
+                                        app_mngr.GetNextHMICorrelationID());
+
+  (*ui_request)[strings::params][strings::function_id] =
+      static_cast<int>(hmi_apis::FunctionID::UI_DeleteWindow);
+
+  (*ui_request)[strings::correlation_id] =
+      (*ui_request)[strings::params][strings::correlation_id];
+  (*ui_request)[strings::function_id] =
+      (*ui_request)[strings::params][strings::function_id];
+
+  smart_objects::SmartObject msg_params(
+      smart_objects::SmartObject(smart_objects::SmartType_Map));
+
+  msg_params[strings::window_id] = window_id;
+  msg_params[strings::app_id] = application->app_id();
 
   (*ui_request)[strings::msg_params] = msg_params;
 
@@ -1853,7 +2016,7 @@ void MessageHelper::SendAddSubMenuRequestToHMI(ApplicationConstSharedPtr app,
   }
 
   smart_objects::SmartObjectList requests =
-      CreateAddSubMenuRequestToHMI(app, app_mngr.GetNextHMICorrelationID());
+      CreateAddSubMenuRequestsToHMI(app, app_mngr);
   for (smart_objects::SmartObjectList::iterator it = requests.begin();
        it != requests.end();
        ++it) {
@@ -1861,15 +2024,15 @@ void MessageHelper::SendAddSubMenuRequestToHMI(ApplicationConstSharedPtr app,
   }
 }
 
-smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestToHMI(
-    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
+smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestsToHMI(
+    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
   smart_objects::SmartObjectList requsets;
   const DataAccessor<SubMenuMap> accessor = app->sub_menu_map();
   const SubMenuMap& sub_menu = accessor.GetData();
   SubMenuMap::const_iterator i = sub_menu.begin();
   for (; sub_menu.end() != i; ++i) {
-    smart_objects::SmartObjectSPtr ui_sub_menu =
-        CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
+    smart_objects::SmartObjectSPtr ui_sub_menu = CreateMessageForHMI(
+        hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
     if (!ui_sub_menu) {
       return requsets;
     }
@@ -2318,6 +2481,51 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponse(
   return std::make_shared<smart_objects::SmartObject>(response_data);
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponseFromHmi(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const int32_t result_code,
+    const std::string& info) {
+  smart_objects::SmartObjectSPtr message =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  (*message)[strings::params][strings::function_id] = function_id;
+  (*message)[strings::params][strings::protocol_type] =
+      commands::CommandImpl::hmi_protocol_type_;
+  (*message)[strings::params][strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  (*message)[strings::params][strings::correlation_id] = correlation_id;
+
+  (*message)[strings::params][strings::message_type] =
+      MessageType::kErrorResponse;
+  (*message)[strings::params][hmi_response::code] = result_code;
+  (*message)[strings::params][strings::error_msg] = info;
+
+  return message;
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateResponseMessageFromHmi(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const int32_t result_code) {
+  smart_objects::SmartObject params(smart_objects::SmartType_Map);
+  params[strings::function_id] = function_id;
+  params[strings::message_type] = MessageType::kResponse;
+  params[strings::correlation_id] = correlation_id;
+  params[strings::protocol_type] = commands::CommandImpl::hmi_protocol_type_;
+  params[hmi_response::code] = result_code;
+
+  smart_objects::SmartObjectSPtr response =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  auto& message = *response;
+  message[strings::params] = params;
+  message[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  return response;
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateOnServiceUpdateNotification(
     const hmi_apis::Common_ServiceType::eType service_type,
     const hmi_apis::Common_ServiceEvent::eType service_event,
@@ -2514,16 +2722,16 @@ bool MessageHelper::SendStopAudioPathThru(ApplicationManager& app_mngr) {
   return app_mngr.GetRPCService().ManageHMICommand(result);
 }
 
-bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
-  LOG4CXX_INFO(logger_, "MessageHelper::SendUnsubscribedWayPoints");
+smart_objects::SmartObjectSPtr MessageHelper::CreateUnsubscribeWayPointsRequest(
+    const uint32_t correlation_id) {
+  LOG4CXX_INFO(logger_, "MessageHelper::CreateUnsubscribeWayPointsRequest");
 
-  smart_objects::SmartObjectSPtr result = CreateMessageForHMI(
-      hmi_apis::messageType::request, app_mngr.GetNextHMICorrelationID());
+  smart_objects::SmartObjectSPtr result =
+      CreateMessageForHMI(hmi_apis::messageType::request, correlation_id);
 
   (*result)[strings::params][strings::function_id] =
       hmi_apis::FunctionID::Navigation_UnsubscribeWayPoints;
-
-  return app_mngr.GetRPCService().ManageHMICommand(result);
+  return result;
 }
 
 void MessageHelper::SendPolicySnapshotNotification(

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -2752,10 +2752,10 @@ void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
       // Set application hmi level
       application_manager_.ChangeAppsHMILevel(app->app_id(), level);
       // If hmi Level is full, it will be seted after ActivateApp response
-      MessageHelper::SendHMIStatusNotification(
-          app,
-          mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
-          application_manager_);
+      auto notification = MessageHelper::CreateHMIStatusNotification(
+          app, mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+      application_manager_.GetRPCService().ManageMobileCommand(
+          notification, commands::Command::SOURCE_SDL);
     }
   }
 }
@@ -2798,10 +2798,10 @@ void PolicyHandler::OnUpdateHMIStatus(const std::string& device_id,
                    << app->app_id() << " to default hmi level " << level);
   // Set application hmi level
   application_manager_.ChangeAppsHMILevel(app->app_id(), level);
-  MessageHelper::SendHMIStatusNotification(
-      app,
-      mobile_apis::PredefinedWindows::DEFAULT_WINDOW,
-      application_manager_);
+  auto notification = MessageHelper::CreateHMIStatusNotification(
+      app, mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+  application_manager_.GetRPCService().ManageMobileCommand(
+      notification, commands::Command::SOURCE_SDL);
 }
 
 bool PolicyHandler::GetModuleTypes(const std::string& policy_app_id,

--- a/src/components/application_manager/src/resumption/extension_pending_resumption_handler.cc
+++ b/src/components/application_manager/src/resumption/extension_pending_resumption_handler.cc
@@ -1,0 +1,61 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "smart_objects/smart_object.h"
+
+namespace resumption {
+
+namespace app_mngr = application_manager;
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "ExtensionPenndingResumptionHandler")
+
+ExtensionPendingResumptionHandler::ExtensionPendingResumptionHandler(
+    app_mngr::ApplicationManager& application_manager)
+    : application_manager::event_engine::EventObserver(
+          application_manager.event_dispatcher())
+    , application_manager_(application_manager) {}
+
+ResumptionRequest ExtensionPendingResumptionHandler::MakeResumptionRequest(
+    const uint32_t corr_id,
+    const hmi_apis::FunctionID::eType function_id,
+    const smart_objects::SmartObject& message) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  resumption::ResumptionRequest resumption_request;
+  resumption_request.request_ids.correlation_id = corr_id;
+  resumption_request.request_ids.function_id = function_id;
+  resumption_request.message = message;
+  return resumption_request;
+}
+
+}  //  namespace resumption

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -64,8 +64,7 @@ static mobile_api::HMILevel::eType ConvertHmiLevelString(const std::string str);
 CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
 
 ResumeCtrlImpl::ResumeCtrlImpl(ApplicationManager& application_manager)
-    : event_engine::EventObserver(application_manager.event_dispatcher())
-    , restore_hmi_level_timer_(
+    : restore_hmi_level_timer_(
           "RsmCtrlRstore",
           new timer::TimerTaskImpl<ResumeCtrlImpl>(
               this, &ResumeCtrlImpl::ApplicationResumptiOnTimer))
@@ -78,7 +77,8 @@ ResumeCtrlImpl::ResumeCtrlImpl(ApplicationManager& application_manager)
     , launch_time_(time(nullptr))
     , low_voltage_time_(0)
     , wake_up_time_(0)
-    , application_manager_(application_manager) {}
+    , application_manager_(application_manager)
+    , resumption_data_processor_(application_manager) {}
 #ifdef BUILD_TESTS
 void ResumeCtrlImpl::set_resumption_storage(
     std::shared_ptr<ResumptionData> mock_storage) {
@@ -159,16 +159,6 @@ void ResumeCtrlImpl::SaveApplication(ApplicationSharedPtr application) {
   resumption_storage_->SaveApplication(application);
 }
 
-void ResumeCtrlImpl::on_event(const event_engine::Event& event) {
-  LOG4CXX_DEBUG(logger_, "Event received: " << event.id());
-
-  if (hmi_apis::FunctionID::UI_CreateWindow == event.id()) {
-    LOG4CXX_INFO(logger_, "Received UI_CreateWindow event");
-    const auto& response_message = event.smart_object();
-    RestoreWidgetsHMIState(response_message);
-  }
-}
-
 bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
   using namespace mobile_apis;
   LOG4CXX_AUTO_TRACE(logger_);
@@ -217,14 +207,8 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
       const bool app_exists_in_full_or_limited =
           application_manager_.get_full_or_limited_application().use_count() !=
           0;
-      const bool app_hmi_state_is_set =
-          SetAppHMIState(application, saved_hmi_level, true);
-      size_t restored_widgets = 0;
-      if (app_hmi_state_is_set &&
-          application->is_app_data_resumption_allowed()) {
-        restored_widgets = RestoreAppWidgets(application, saved_app);
-      }
-      if (0 == restored_widgets && app_exists_in_full_or_limited) {
+      SetAppHMIState(application, saved_hmi_level, true);
+      if (app_exists_in_full_or_limited) {
         LOG4CXX_DEBUG(logger_, "App exists in full or limited. Do not resume");
         return false;
       }
@@ -238,77 +222,6 @@ bool ResumeCtrlImpl::RestoreAppHMIState(ApplicationSharedPtr application) {
   return result;
 }
 
-void ResumeCtrlImpl::RestoreWidgetsHMIState(
-    const smart_objects::SmartObject& response_message) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  const auto correlation_id =
-      response_message[strings::params][strings::correlation_id].asInt();
-  const auto& request = requests_msg_.find(correlation_id);
-  if (requests_msg_.end() == request) {
-    LOG4CXX_ERROR(logger_,
-                  "Request UI_CreateWindow for correlation id: "
-                      << correlation_id << " not found");
-    return;
-  }
-
-  const auto& msg_params = (*request->second)[strings::msg_params];
-  const auto hmi_app_id = msg_params[strings::app_id].asInt();
-  auto application = application_manager_.application_by_hmi_app(hmi_app_id);
-  if (!application) {
-    LOG4CXX_ERROR(logger_,
-                  "Application is not registered by hmi id: " << hmi_app_id);
-    requests_msg_.erase(request);
-    return;
-  }
-  const WindowID window_id = msg_params[strings::window_id].asInt();
-
-  const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
-      response_message[strings::params][hmi_response::code].asInt());
-  if (hmi_apis::Common_Result::SUCCESS != result_code) {
-    LOG4CXX_ERROR(logger_,
-                  "UI_CreateWindow for correlation id: "
-                      << correlation_id
-                      << " failed with code: " << result_code);
-    requests_msg_.erase(request);
-    auto& builder = application->display_capabilities_builder();
-    builder.StopWaitingForWindow(window_id);
-    return;
-  }
-
-  smart_objects::SmartObject window_info(smart_objects::SmartType_Map);
-  auto fill_optional_param = [&window_info,
-                              &msg_params](const std::string& key) {
-    if (msg_params.keyExists(key)) {
-      window_info[key] = msg_params[key].asString();
-    }
-  };
-  fill_optional_param(strings::associated_service_type);
-  fill_optional_param(strings::duplicate_updates_from_window_id);
-
-  const auto window_name = msg_params[strings::window_name].asString();
-  window_info[strings::window_name] = window_name;
-  application->SetWindowInfo(window_id, window_info);
-
-  const auto window_type = static_cast<mobile_apis::WindowType::eType>(
-      msg_params[strings::window_type].asInt());
-  // State should be initialized with INVALID_ENUM value to let state controller
-  // trigger OnHmiStatus notifiation sending
-  auto initial_state = application_manager_.CreateRegularState(
-      application,
-      window_type,
-      mobile_apis::HMILevel::INVALID_ENUM,
-      mobile_apis::AudioStreamingState::INVALID_ENUM,
-      mobile_apis::VideoStreamingState::INVALID_ENUM,
-      mobile_api::SystemContext::INVALID_ENUM);
-  application->SetInitialState(window_id, window_name, initial_state);
-
-  // Default HMI level for all windows except the main one is always NONE
-  application_manager_.state_controller().OnAppWindowAdded(
-      application, window_id, window_type, mobile_apis::HMILevel::HMI_NONE);
-
-  requests_msg_.erase(request);
-}
-
 void ResumeCtrlImpl::ProcessSystemCapabilityUpdated(
     Application& app, const smart_objects::SmartObject& display_capabilities) {
   LOG4CXX_AUTO_TRACE(logger_);
@@ -318,7 +231,6 @@ void ResumeCtrlImpl::ProcessSystemCapabilityUpdated(
 
   application_manager_.GetRPCService().ManageMobileCommand(
       notification, commands::Command::SOURCE_SDL);
-  app.set_is_resuming(false);
 }
 
 bool ResumeCtrlImpl::SetupDefaultHMILevel(ApplicationSharedPtr application) {
@@ -408,29 +320,6 @@ bool ResumeCtrlImpl::SetAppHMIState(
                                              << " got HMI level " << hmi_level);
 
   return true;
-}
-
-size_t ResumeCtrlImpl::RestoreAppWidgets(
-    application_manager::ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  using namespace mobile_apis;
-  LOG4CXX_AUTO_TRACE(logger_);
-  DCHECK(application);
-  if (!saved_app.keyExists(strings::windows_info)) {
-    LOG4CXX_ERROR(logger_, "windows_info section does not exist");
-    return 0;
-  }
-  const auto& windows_info = saved_app[strings::windows_info];
-  auto request_list = MessageHelper::CreateUICreateWindowRequestsToHMI(
-      application, application_manager_, windows_info);
-
-  requests_msg_.clear();
-  for (auto& request : request_list) {
-    requests_msg_.insert(std::make_pair(
-        (*request)[strings::params][strings::correlation_id].asInt(), request));
-  }
-  ProcessHMIRequests(request_list);
-  return request_list.size();
 }
 
 bool ResumeCtrlImpl::IsHMIApplicationIdExist(uint32_t hmi_app_id) {
@@ -524,7 +413,8 @@ void ResumeCtrlImpl::StopSavePersistentDataTimer() {
 }
 
 bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
-                                     const std::string& hash) {
+                                     const std::string& hash,
+                                     ResumptionCallBack callback) {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN(application, false);
   LOG4CXX_DEBUG(
@@ -535,24 +425,22 @@ bool ResumeCtrlImpl::StartResumption(ApplicationSharedPtr application,
                           << " received hash = " << hash);
   application->set_is_resuming(true);
 
-  if (!application->is_cloud_app()) {
-    // Default HMI Level is already set before resumption in
-    // ApplicationManager::OnApplicationRegistered, and handling low bandwidth
-    // transports doesn't apply to cloud apps, so this step can be skipped for
-    // such apps
-    SetupDefaultHMILevel(application);
-  }
   smart_objects::SmartObject saved_app;
   const std::string& device_mac = application->mac_address();
   bool result = resumption_storage_->GetSavedApplication(
       application->policy_app_id(), device_mac, saved_app);
   if (result) {
     const std::string& saved_hash = saved_app[strings::hash_id].asString();
-    result = saved_hash == hash ? RestoreApplicationData(application) : false;
-    application->UpdateHash();
-    AddToResumptionTimerQueue(application->app_id());
+    result = saved_hash == hash ? RestoreApplicationData(application, callback)
+                                : false;
   }
   return result;
+}
+
+void ResumeCtrlImpl::HandleOnTimeOut(
+    const uint32_t cor_id, const hmi_apis::FunctionID::eType function_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  resumption_data_processor_.HandleOnTimeOut(cor_id, function_id);
 }
 
 bool ResumeCtrlImpl::StartResumptionOnlyHMILevel(
@@ -744,7 +632,8 @@ bool ResumeCtrlImpl::IsDeviceMacAddressEqual(
   return device_mac == saved_device_mac;
 }
 
-bool ResumeCtrlImpl::RestoreApplicationData(ApplicationSharedPtr application) {
+bool ResumeCtrlImpl::RestoreApplicationData(ApplicationSharedPtr application,
+                                            ResumptionCallBack callback) {
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN(application, false);
   LOG4CXX_DEBUG(logger_, "app_id : " << application->app_id());
@@ -757,13 +646,7 @@ bool ResumeCtrlImpl::RestoreApplicationData(ApplicationSharedPtr application) {
     if (saved_app.keyExists(strings::grammar_id)) {
       const uint32_t app_grammar_id = saved_app[strings::grammar_id].asUInt();
       application->set_grammar_id(app_grammar_id);
-      AddFiles(application, saved_app);
-      AddSubmenues(application, saved_app);
-      AddCommands(application, saved_app);
-      AddChoicesets(application, saved_app);
-      SetGlobalProperties(application, saved_app);
-      AddSubscriptions(application, saved_app);
-      AddWayPointsSubscription(application, saved_app);
+      resumption_data_processor_.Restore(application, saved_app, callback);
       result = true;
     } else {
       LOG4CXX_WARN(logger_,
@@ -777,7 +660,7 @@ bool ResumeCtrlImpl::RestoreApplicationData(ApplicationSharedPtr application) {
 }
 
 void ResumeCtrlImpl::StartWaitingForDisplayCapabilitiesUpdate(
-    app_mngr::ApplicationSharedPtr application) {
+    app_mngr::ApplicationSharedPtr application, const bool is_resume_app) {
   LOG4CXX_AUTO_TRACE(logger_);
   smart_objects::SmartObject saved_app(smart_objects::SmartType_Map);
   resumption_storage_->GetSavedApplication(
@@ -791,158 +674,10 @@ void ResumeCtrlImpl::StartWaitingForDisplayCapabilitiesUpdate(
   auto& builder = application->display_capabilities_builder();
 
   smart_objects::SmartObject windows_info(smart_objects::SmartType_Null);
-  if (saved_app.keyExists(strings::windows_info)) {
+  if (is_resume_app && saved_app.keyExists(strings::windows_info)) {
     windows_info = saved_app[strings::windows_info];
   }
   builder.InitBuilder(resume_callback, windows_info);
-}
-
-void ResumeCtrlImpl::AddFiles(ApplicationSharedPtr application,
-                              const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_files)) {
-    const smart_objects::SmartObject& application_files =
-        saved_app[strings::application_files];
-    for (size_t i = 0; i < application_files.length(); ++i) {
-      const smart_objects::SmartObject& file_data = application_files[i];
-      const bool is_persistent =
-          file_data.keyExists(strings::persistent_file) &&
-          file_data[strings::persistent_file].asBool();
-      if (is_persistent) {
-        AppFile file;
-        file.is_persistent = is_persistent;
-        file.is_download_complete =
-            file_data[strings::is_download_complete].asBool();
-        file.file_name = file_data[strings::sync_file_name].asString();
-        file.file_type = static_cast<mobile_apis::FileType::eType>(
-            file_data[strings::file_type].asInt());
-        application->AddFile(file);
-      }
-    }
-  } else {
-    LOG4CXX_FATAL(logger_, "application_files section is not exists");
-  }
-}
-
-void ResumeCtrlImpl::AddSubmenues(ApplicationSharedPtr application,
-                                  const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_submenus)) {
-    const smart_objects::SmartObject& app_submenus =
-        saved_app[strings::application_submenus];
-    for (size_t i = 0; i < app_submenus.length(); ++i) {
-      const smart_objects::SmartObject& submenu = app_submenus[i];
-      application->AddSubMenu(submenu[strings::menu_id].asUInt(), submenu);
-    }
-    ProcessHMIRequests(MessageHelper::CreateAddSubMenuRequestToHMI(
-        application, application_manager_.GetNextHMICorrelationID()));
-  } else {
-    LOG4CXX_FATAL(logger_, "application_submenus section is not exists");
-  }
-}
-
-void ResumeCtrlImpl::AddCommands(ApplicationSharedPtr application,
-                                 const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_commands)) {
-    const smart_objects::SmartObject& app_commands =
-        saved_app[strings::application_commands];
-
-    for (size_t cmd_num = 0; cmd_num < app_commands.length(); ++cmd_num) {
-      const smart_objects::SmartObject& command = app_commands[cmd_num];
-      const uint32_t cmd_id = command[strings::cmd_id].asUInt();
-      const bool is_resumption = true;
-      application->AddCommand(
-          commands::CommandImpl::CalcCommandInternalConsecutiveNumber(
-              application),
-          command);
-      application->help_prompt_manager().OnVrCommandAdded(
-          cmd_id, command, is_resumption);
-    }
-
-    ProcessHMIRequests(MessageHelper::CreateAddCommandRequestToHMI(
-        application, application_manager_));
-  } else {
-    LOG4CXX_FATAL(logger_, "application_commands section is not exists");
-  }
-}
-
-void ResumeCtrlImpl::AddChoicesets(
-    ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_choice_sets)) {
-    const smart_objects::SmartObject& app_choice_sets =
-        saved_app[strings::application_choice_sets];
-    for (size_t i = 0; i < app_choice_sets.length(); ++i) {
-      const smart_objects::SmartObject& choice_set = app_choice_sets[i];
-      const int32_t choice_set_id =
-          choice_set[strings::interaction_choice_set_id].asInt();
-      application->AddChoiceSet(choice_set_id, choice_set);
-    }
-    ProcessHMIRequests(MessageHelper::CreateAddVRCommandRequestFromChoiceToHMI(
-        application, application_manager_));
-  } else {
-    LOG4CXX_FATAL(logger_, "There is no any choicesets");
-  }
-}
-
-void ResumeCtrlImpl::SetGlobalProperties(
-    ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::application_global_properties)) {
-    const smart_objects::SmartObject& properties_so =
-        saved_app[strings::application_global_properties];
-    application->load_global_properties(properties_so);
-    MessageHelper::SendGlobalPropertiesToHMI(application, application_manager_);
-  }
-}
-
-void ResumeCtrlImpl::AddWayPointsSubscription(
-    app_mngr::ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-
-  if (saved_app.keyExists(strings::subscribed_for_way_points)) {
-    const smart_objects::SmartObject& subscribed_for_way_points_so =
-        saved_app[strings::subscribed_for_way_points];
-    if (true == subscribed_for_way_points_so.asBool()) {
-      application_manager_.SubscribeAppForWayPoints(application);
-    }
-  }
-}
-
-void ResumeCtrlImpl::AddSubscriptions(
-    ApplicationSharedPtr application,
-    const smart_objects::SmartObject& saved_app) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (saved_app.keyExists(strings::application_subscriptions)) {
-    const smart_objects::SmartObject& subscriptions =
-        saved_app[strings::application_subscriptions];
-
-    if (subscriptions.keyExists(strings::application_buttons)) {
-      const smart_objects::SmartObject& subscriptions_buttons =
-          subscriptions[strings::application_buttons];
-      mobile_apis::ButtonName::eType btn;
-      for (size_t i = 0; i < subscriptions_buttons.length(); ++i) {
-        btn = static_cast<mobile_apis::ButtonName::eType>(
-            (subscriptions_buttons[i]).asInt());
-        application->SubscribeToButton(btn);
-      }
-    }
-    MessageHelper::SendAllOnButtonSubscriptionNotificationsForApp(
-        application, application_manager_);
-
-    for (auto& extension : application->Extensions()) {
-      extension->ProcessResumption(subscriptions);
-    }
-  }
 }
 
 bool ResumeCtrlImpl::CheckIgnCycleRestrictions(
@@ -1165,36 +900,6 @@ time_t ResumeCtrlImpl::LaunchTime() const {
 
 time_t ResumeCtrlImpl::GetIgnOffTime() const {
   return resumption_storage_->GetIgnOffTime();
-}
-
-bool ResumeCtrlImpl::ProcessHMIRequest(smart_objects::SmartObjectSPtr request,
-                                       bool use_events) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  if (use_events) {
-    const hmi_apis::FunctionID::eType function_id =
-        static_cast<hmi_apis::FunctionID::eType>(
-            (*request)[strings::function_id].asInt());
-
-    const int32_t hmi_correlation_id =
-        (*request)[strings::correlation_id].asInt();
-    subscribe_on_event(function_id, hmi_correlation_id);
-  }
-  if (!application_manager_.GetRPCService().ManageHMICommand(
-          request, commands::Command::SOURCE_SDL_TO_HMI)) {
-    LOG4CXX_ERROR(logger_, "Unable to send request");
-    return false;
-  }
-  return true;
-}
-
-void ResumeCtrlImpl::ProcessHMIRequests(
-    const smart_objects::SmartObjectList& requests) {
-  for (smart_objects::SmartObjectList::const_iterator it = requests.begin(),
-                                                      total = requests.end();
-       it != total;
-       ++it) {
-    ProcessHMIRequest(*it, true);
-  }
 }
 
 void ResumeCtrlImpl::AddToResumptionTimerQueue(const uint32_t app_id) {

--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -2619,7 +2619,7 @@ bool ResumptionDataDB::InsertApplicationData(
   const mobile_apis::HMILevel::eType hmi_level = application.m_hmi_level;
   bool is_media_application = application.m_is_media_application;
   bool is_subscribed_for_way_points =
-      application_manager_.IsAppSubscribedForWayPoints(application.app_ptr);
+      application_manager_.IsAppSubscribedForWayPoints(*(application.app_ptr));
 
   if (!query.Prepare(kInsertApplication)) {
     LOG4CXX_WARN(logger_,

--- a/src/components/application_manager/src/resumption/resumption_data_json.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_json.cc
@@ -68,7 +68,7 @@ void ResumptionDataJson::SaveApplication(
   const mobile_apis::HMILevel::eType hmi_level =
       application->hmi_level(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
   const bool is_subscribed_for_way_points =
-      application_manager_.IsAppSubscribedForWayPoints(application);
+      application_manager_.IsAppSubscribedForWayPoints(*application);
 
   Json::Value tmp;
   resumption::LastStateAccessor accessor = last_state_wrapper_->get_accessor();

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -1,0 +1,1125 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+
+#include "application_manager/application_manager.h"
+#include "application_manager/commands/command_impl.h"
+#include "application_manager/display_capabilities_builder.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+#include "application_manager/smart_object_keys.h"
+
+namespace resumption {
+
+using app_mngr::AppFile;
+using app_mngr::ApplicationSharedPtr;
+using app_mngr::ButtonSubscriptions;
+using app_mngr::ChoiceSetMap;
+using app_mngr::MessageHelper;
+namespace strings = app_mngr::strings;
+namespace event_engine = app_mngr::event_engine;
+namespace commands = app_mngr::commands;
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
+
+ResumptionDataProcessor::ResumptionDataProcessor(
+    app_mngr::ApplicationManager& application_manager)
+    : event_engine::EventObserver(application_manager.event_dispatcher())
+    , application_manager_(application_manager)
+    , resumption_status_lock_()
+    , register_callbacks_lock_()
+    , request_app_ids_lock_() {}
+
+ResumptionDataProcessor::~ResumptionDataProcessor() {}
+
+void ResumptionDataProcessor::Restore(ApplicationSharedPtr application,
+                                      smart_objects::SmartObject& saved_app,
+                                      ResumeCtrl::ResumptionCallBack callback) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!HasDataToRestore(saved_app) &&
+      !HasGlobalPropertiesToRestore(saved_app) &&
+      !HasSubscriptionsToRestore(saved_app)) {
+    LOG4CXX_DEBUG(logger_, "No data to restore, resumption is successful");
+    callback(mobile_apis::Result::SUCCESS, "Data resumption succesful");
+    return;
+  }
+
+  AddFiles(application, saved_app);
+  AddSubmenues(application, saved_app);
+  AddCommands(application, saved_app);
+  AddChoicesets(application, saved_app);
+  SetGlobalProperties(application, saved_app);
+  AddSubscriptions(application, saved_app);
+  AddWindows(application, saved_app);
+
+  resumption_status_lock_.AcquireForReading();
+  const auto app_id = application->app_id();
+  bool is_requests_list_empty = true;
+  if (resumption_status_.find(app_id) != resumption_status_.end()) {
+    is_requests_list_empty =
+        resumption_status_[app_id].list_of_sent_requests.empty();
+  }
+  resumption_status_lock_.Release();
+
+  if (!is_requests_list_empty) {
+    sync_primitives::AutoWriteLock lock(register_callbacks_lock_);
+    register_callbacks_[app_id] = callback;
+  } else {
+    LOG4CXX_DEBUG(
+        logger_,
+        "No requests to HMI for " << app_id << " , resumption is successful");
+    callback(mobile_apis::Result::SUCCESS, "Data resumption successful");
+  }
+}
+
+bool ResumptionDataProcessor::HasDataToRestore(
+    const smart_objects::SmartObject& saved_app) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const bool has_data_to_restore =
+      !saved_app[strings::application_submenus].empty() ||
+      !saved_app[strings::application_commands].empty() ||
+      !saved_app[strings::application_choice_sets].empty() ||
+      !saved_app[strings::windows_info].empty();
+
+  LOG4CXX_DEBUG(logger_,
+                std::boolalpha << "Application has data to restore: "
+                               << has_data_to_restore);
+
+  return has_data_to_restore;
+}
+
+bool ResumptionDataProcessor::HasGlobalPropertiesToRestore(
+    const smart_objects::SmartObject& saved_app) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const smart_objects::SmartObject& global_properties =
+      saved_app[strings::application_global_properties];
+
+  const bool has_gl_props_to_restore =
+      !global_properties[strings::help_prompt].empty() ||
+      !global_properties[strings::keyboard_properties].empty() ||
+      !global_properties[strings::menu_icon].empty() ||
+      !global_properties[strings::menu_title].empty() ||
+      !global_properties[strings::timeout_prompt].empty() ||
+      !global_properties[strings::vr_help].empty() ||
+      !global_properties[strings::vr_help_title].empty();
+
+  LOG4CXX_DEBUG(logger_,
+                std::boolalpha
+                    << "Application has global properties to restore: "
+                    << has_gl_props_to_restore);
+
+  return has_gl_props_to_restore;
+}
+
+bool ResumptionDataProcessor::HasSubscriptionsToRestore(
+    const smart_objects::SmartObject& saved_app) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const smart_objects::SmartObject& subscriptions =
+      saved_app[strings::application_subscriptions];
+
+  const bool has_ivi_subscriptions =
+      !subscriptions[strings::application_vehicle_info].empty();
+
+  const bool has_button_subscriptions =
+      !(subscriptions[strings::application_buttons].length() == 1 &&
+        static_cast<hmi_apis::Common_ButtonName::eType>(
+            subscriptions[strings::application_buttons][0].asInt()) ==
+            hmi_apis::Common_ButtonName::CUSTOM_BUTTON);
+
+  const bool has_waypoints_subscriptions =
+      subscriptions[strings::subscribed_for_way_points].asBool();
+
+  const bool has_appservice_subscriptions =
+      subscriptions.keyExists(app_mngr::hmi_interface::app_service) &&
+      !subscriptions[app_mngr::hmi_interface::app_service].empty();
+
+  const bool has_system_capability_subscriptions =
+      subscriptions.keyExists(strings::system_capability) &&
+      !subscriptions[strings::system_capability].empty();
+
+  const bool has_subscriptions_to_restore =
+      has_ivi_subscriptions || has_button_subscriptions ||
+      has_waypoints_subscriptions || has_appservice_subscriptions ||
+      has_system_capability_subscriptions;
+
+  LOG4CXX_DEBUG(logger_,
+                std::boolalpha << "Application has subscriptions to restore: "
+                               << has_subscriptions_to_restore);
+
+  return has_subscriptions_to_restore;
+}
+
+bool ResumptionRequestIDs::operator<(const ResumptionRequestIDs& other) const {
+  return correlation_id < other.correlation_id ||
+         function_id < other.function_id;
+}
+
+utils::Optional<uint32_t> ResumptionDataProcessor::GetAppIdWaitingForResponse(
+    const hmi_apis::FunctionID::eType function_id, const int32_t corr_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto predicate =
+      [function_id,
+       corr_id](const std::pair<ResumptionRequestIDs, std::uint32_t>& item) {
+        return item.first.function_id == function_id &&
+               item.first.correlation_id == corr_id;
+      };
+
+  sync_primitives::AutoReadLock lock(request_app_ids_lock_);
+  auto app_id_ptr =
+      std::find_if(request_app_ids_.begin(), request_app_ids_.end(), predicate);
+
+  if (app_id_ptr == request_app_ids_.end()) {
+    LOG4CXX_ERROR(logger_,
+                  "application id for correlation id "
+                      << corr_id << " and function id: " << function_id
+                      << " was not found.");
+    return utils::Optional<uint32_t>::OptionalEmpty::EMPTY;
+  }
+  return utils::Optional<uint32_t>(app_id_ptr->second);
+}
+
+utils::Optional<ResumptionRequest> ResumptionDataProcessor::GetRequest(
+    const uint32_t app_id,
+    const hmi_apis::FunctionID::eType function_id,
+    const int32_t corr_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  sync_primitives::AutoWriteLock lock(resumption_status_lock_);
+  std::vector<ResumptionRequest>& list_of_sent_requests =
+      resumption_status_[app_id].list_of_sent_requests;
+
+  if (resumption_status_.find(app_id) == resumption_status_.end()) {
+    LOG4CXX_ERROR(logger_,
+                  "No resumption status info found for app_id: " << app_id);
+    return utils::Optional<ResumptionRequest>::OptionalEmpty::EMPTY;
+  }
+
+  auto request_iter =
+      std::find_if(list_of_sent_requests.begin(),
+                   list_of_sent_requests.end(),
+                   [function_id, corr_id](const ResumptionRequest& request) {
+                     return request.request_ids.correlation_id == corr_id &&
+                            request.request_ids.function_id == function_id;
+                   });
+
+  if (list_of_sent_requests.end() == request_iter) {
+    LOG4CXX_ERROR(logger_,
+                  "Request with function id " << function_id << " and corr id "
+                                              << corr_id << " not found");
+    return utils::Optional<ResumptionRequest>::OptionalEmpty::EMPTY;
+  }
+  return utils::Optional<ResumptionRequest>(*request_iter);
+}
+
+void ResumptionDataProcessor::ProcessResumptionStatus(
+    const uint32_t app_id,
+    const smart_objects::SmartObject& response,
+    const ResumptionRequest& found_request) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  sync_primitives::AutoWriteLock lock(resumption_status_lock_);
+  ApplicationResumptionStatus& status = resumption_status_[app_id];
+
+  if (IsResponseSuccessful(response)) {
+    status.successful_requests.push_back(found_request);
+  } else {
+    status.error_requests.push_back(found_request);
+  }
+
+  if (hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData ==
+      found_request.request_ids.function_id) {
+    CheckVehicleDataResponse(found_request.message, response, status);
+  }
+
+  if (hmi_apis::FunctionID::UI_CreateWindow ==
+      found_request.request_ids.function_id) {
+    CheckCreateWindowResponse(found_request.message, response);
+  }
+}
+
+bool ResumptionDataProcessor::IsResumptionFinished(
+    const uint32_t app_id, const ResumptionRequest& found_request) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  sync_primitives::AutoWriteLock lock(resumption_status_lock_);
+  auto& list_of_sent_requests =
+      resumption_status_[app_id].list_of_sent_requests;
+  auto request_iter =
+      std::find_if(list_of_sent_requests.begin(),
+                   list_of_sent_requests.end(),
+                   [found_request](const ResumptionRequest& request) {
+                     return request.request_ids.correlation_id ==
+                                found_request.request_ids.correlation_id &&
+                            request.request_ids.function_id ==
+                                found_request.request_ids.function_id;
+                   });
+  list_of_sent_requests.erase(request_iter);
+
+  if (!list_of_sent_requests.empty()) {
+    LOG4CXX_DEBUG(logger_,
+                  "Resumption app "
+                      << app_id << " not finished . Amount of requests left : "
+                      << list_of_sent_requests.size());
+    return false;
+  }
+  return true;
+}
+
+utils::Optional<ResumeCtrl::ResumptionCallBack>
+ResumptionDataProcessor::GetResumptionCallback(const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  sync_primitives::AutoReadLock lock(register_callbacks_lock_);
+  auto it = register_callbacks_.find(app_id);
+  if (it == register_callbacks_.end()) {
+    LOG4CXX_WARN(logger_, "Callback for app_id: " << app_id << " not found");
+    return utils::Optional<
+        ResumeCtrl::ResumptionCallBack>::OptionalEmpty::EMPTY;
+  }
+  return utils::Optional<ResumeCtrl::ResumptionCallBack>(it->second);
+}
+
+bool ResumptionDataProcessor::IsResumptionSuccessful(const uint32_t app_id) {
+  sync_primitives::AutoWriteLock lock(resumption_status_lock_);
+  ApplicationResumptionStatus& status = resumption_status_[app_id];
+  return status.error_requests.empty() &&
+         status.unsuccessful_vehicle_data_subscriptions_.empty();
+}
+
+void ResumptionDataProcessor::EraseAppResumptionData(
+    const uint32_t app_id,
+    const hmi_apis::FunctionID::eType function_id,
+    const int32_t corr_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  resumption_status_lock_.AcquireForWriting();
+  resumption_status_.erase(app_id);
+  resumption_status_lock_.Release();
+
+  request_app_ids_lock_.AcquireForWriting();
+  request_app_ids_.erase({function_id, corr_id});
+  request_app_ids_lock_.Release();
+
+  register_callbacks_lock_.AcquireForWriting();
+  register_callbacks_.erase(app_id);
+  register_callbacks_lock_.Release();
+}
+
+void ResumptionDataProcessor::ProcessResponseFromHMI(
+    const smart_objects::SmartObject& response,
+    const hmi_apis::FunctionID::eType function_id,
+    const int32_t corr_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_TRACE(logger_,
+                "Now processing event with function id: "
+                    << function_id << " correlation id: " << corr_id);
+
+  auto found_app_id = GetAppIdWaitingForResponse(function_id, corr_id);
+  if (!found_app_id) {
+    return;
+  }
+  const uint32_t app_id = *found_app_id;
+  LOG4CXX_DEBUG(logger_, "app_id is: " << app_id);
+
+  auto found_request = GetRequest(app_id, function_id, corr_id);
+  if (!found_request) {
+    return;
+  }
+  auto request = *found_request;
+
+  ProcessResumptionStatus(app_id, response, request);
+
+  if (!IsResumptionFinished(app_id, request)) {
+    return;
+  }
+
+  auto found_callback = GetResumptionCallback(app_id);
+  if (!found_callback) {
+    return;
+  }
+  auto callback = *found_callback;
+
+  if (IsResumptionSuccessful(app_id)) {
+    LOG4CXX_DEBUG(logger_, "Resumption for app " << app_id << " successful");
+    callback(mobile_apis::Result::SUCCESS, "Data resumption successful");
+    application_manager_.state_controller().ResumePostponedWindows(app_id);
+  } else {
+    LOG4CXX_ERROR(logger_, "Resumption for app " << app_id << " failed");
+    callback(mobile_apis::Result::RESUME_FAILED, "Data resumption failed");
+    RevertRestoredData(application_manager_.application(app_id));
+    application_manager_.state_controller().DropPostponedWindows(app_id);
+  }
+
+  EraseAppResumptionData(app_id, function_id, corr_id);
+}
+
+void ResumptionDataProcessor::HandleOnTimeOut(
+    const uint32_t corr_id, const hmi_apis::FunctionID::eType function_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_,
+                "Handling timeout with corr id: "
+                    << corr_id << " and function_id: " << function_id);
+
+  auto error_response = MessageHelper::CreateNegativeResponseFromHmi(
+      function_id,
+      corr_id,
+      hmi_apis::Common_Result::GENERIC_ERROR,
+      std::string());
+  ProcessResponseFromHMI(*error_response, function_id, corr_id);
+}
+
+void ResumptionDataProcessor::on_event(const event_engine::Event& event) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(
+      logger_,
+      "Handling response message from HMI "
+          << event.id() << " "
+          << event.smart_object()[strings::params][strings::correlation_id]
+                 .asInt());
+  ProcessResponseFromHMI(
+      event.smart_object(), event.id(), event.smart_object_correlation_id());
+}
+
+std::vector<ResumptionRequest> GetAllFailedRequests(
+    uint32_t app_id,
+    const std::map<std::int32_t, ApplicationResumptionStatus>&
+        resumption_status,
+    sync_primitives::RWLock& resumption_status_lock) {
+  resumption_status_lock.AcquireForReading();
+  std::vector<ResumptionRequest> failed_requests;
+  std::vector<ResumptionRequest> missed_requests;
+  auto it = resumption_status.find(app_id);
+  if (it != resumption_status.end()) {
+    failed_requests = it->second.error_requests;
+    missed_requests = it->second.list_of_sent_requests;
+  }
+  resumption_status_lock.Release();
+
+  failed_requests.insert(
+      failed_requests.end(), missed_requests.begin(), missed_requests.end());
+  return failed_requests;
+}
+
+void ResumptionDataProcessor::RevertRestoredData(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_, "Reverting for app: " << application->app_id());
+  DeleteSubmenues(application);
+  DeleteCommands(application);
+  DeleteChoicesets(application);
+  DeleteGlobalProperties(application);
+  DeleteSubscriptions(application);
+  DeleteWindowsSubscriptions(application);
+
+  resumption_status_lock_.AcquireForWriting();
+  resumption_status_.erase(application->app_id());
+  resumption_status_lock_.Release();
+
+  register_callbacks_lock_.AcquireForWriting();
+  register_callbacks_.erase(application->app_id());
+  register_callbacks_lock_.Release();
+}
+
+void ResumptionDataProcessor::SubscribeToResponse(
+    const int32_t app_id, const ResumptionRequest& request) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_,
+                "App " << app_id << " subscribe on "
+                       << request.request_ids.function_id << " "
+                       << request.request_ids.correlation_id);
+  subscribe_on_event(request.request_ids.function_id,
+                     request.request_ids.correlation_id);
+
+  resumption_status_lock_.AcquireForWriting();
+  resumption_status_[app_id].list_of_sent_requests.push_back(request);
+  resumption_status_lock_.Release();
+
+  request_app_ids_lock_.AcquireForWriting();
+  request_app_ids_.insert(std::make_pair(request.request_ids, app_id));
+  request_app_ids_lock_.Release();
+}
+
+void ResumptionDataProcessor::ProcessMessageToHMI(
+    smart_objects::SmartObjectSPtr message, bool subscribe_on_response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (subscribe_on_response) {
+    auto function_id = static_cast<hmi_apis::FunctionID::eType>(
+        (*message)[strings::params][strings::function_id].asInt());
+
+    const int32_t hmi_correlation_id =
+        (*message)[strings::params][strings::correlation_id].asInt();
+
+    const int32_t app_id =
+        (*message)[strings::msg_params][strings::app_id].asInt();
+
+    ResumptionRequest wait_for_response;
+    wait_for_response.request_ids.correlation_id = hmi_correlation_id;
+    wait_for_response.request_ids.function_id = function_id;
+    wait_for_response.message = *message;
+
+    SubscribeToResponse(app_id, wait_for_response);
+  }
+  if (!application_manager_.GetRPCService().ManageHMICommand(message)) {
+    LOG4CXX_ERROR(logger_, "Unable to send request");
+  }
+}
+
+void ResumptionDataProcessor::ProcessMessagesToHMI(
+    const smart_objects::SmartObjectList& messages) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  for (const auto& message : messages) {
+    const bool is_request_message =
+        application_manager::MessageType::kRequest ==
+        (*message)[strings::params][strings::message_type].asInt();
+
+    ProcessMessageToHMI(message, is_request_message);
+  }
+}
+
+void ResumptionDataProcessor::AddFiles(
+    app_mngr::ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_files)) {
+    LOG4CXX_ERROR(logger_, "application_files section is not exists");
+    return;
+  }
+
+  const auto application_files =
+      saved_app[strings::application_files].asArray();
+
+  for (const auto file_data : *application_files) {
+    const bool is_persistent = file_data.keyExists(strings::persistent_file) &&
+                               file_data[strings::persistent_file].asBool();
+    if (is_persistent) {
+      AppFile file;
+      file.is_persistent = is_persistent;
+      file.is_download_complete =
+          file_data[strings::is_download_complete].asBool();
+      file.file_name = file_data[strings::sync_file_name].asString();
+      file.file_type = static_cast<mobile_apis::FileType::eType>(
+          file_data[strings::file_type].asInt());
+      application->AddFile(file);
+    }
+  }
+}
+
+void ResumptionDataProcessor::AddWindows(
+    application_manager::ApplicationSharedPtr application,
+    const ns_smart_device_link::ns_smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!saved_app.keyExists(strings::windows_info)) {
+    LOG4CXX_ERROR(logger_, "windows_info section does not exist");
+    return;
+  }
+
+  const auto& windows_info = saved_app[strings::windows_info];
+  auto request_list = MessageHelper::CreateUICreateWindowRequestsToHMI(
+      application, application_manager_, windows_info);
+
+  ProcessMessagesToHMI(request_list);
+}
+
+void ResumptionDataProcessor::AddSubmenues(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!saved_app.keyExists(strings::application_submenus)) {
+    LOG4CXX_ERROR(logger_, "application_submenus section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& app_submenus =
+      saved_app[strings::application_submenus];
+
+  for (size_t i = 0; i < app_submenus.length(); ++i) {
+    const smart_objects::SmartObject& submenu = app_submenus[i];
+    application->AddSubMenu(submenu[strings::menu_id].asUInt(), submenu);
+  }
+
+  ProcessMessagesToHMI(MessageHelper::CreateAddSubMenuRequestsToHMI(
+      application, application_manager_));
+}
+
+utils::Optional<ResumptionRequest> FindResumptionSubmenuRequest(
+    uint32_t menu_id, std::vector<ResumptionRequest>& requests) {
+  using namespace utils;
+
+  auto request_it = std::find_if(
+      requests.begin(),
+      requests.end(),
+      [menu_id](const ResumptionRequest& request) {
+        auto& msg_params = request.message[strings::msg_params];
+        if (hmi_apis::FunctionID::UI_AddSubMenu ==
+            request.request_ids.function_id) {
+          uint32_t failed_menu_id = msg_params[strings::menu_id].asUInt();
+          return failed_menu_id == menu_id;
+        }
+        return false;
+      });
+  if (requests.end() != request_it) {
+    return Optional<ResumptionRequest>(*request_it);
+  }
+  return Optional<ResumptionRequest>::OptionalEmpty::EMPTY;
+}
+
+void ResumptionDataProcessor::DeleteSubmenues(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto failed_requests = GetAllFailedRequests(
+      application->app_id(), resumption_status_, resumption_status_lock_);
+
+  auto accessor = application->sub_menu_map();
+  const auto& sub_menu_map = accessor.GetData();
+
+  for (const auto& smenu : sub_menu_map) {
+    auto failed_submenu_request =
+        FindResumptionSubmenuRequest(smenu.first, failed_requests);
+    if (!failed_submenu_request) {
+      MessageHelper::SendDeleteSubmenuRequest(
+          smenu.second, application, application_manager_);
+    }
+    application->RemoveSubMenu(smenu.first);
+  }
+}
+
+void ResumptionDataProcessor::AddCommands(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_commands)) {
+    LOG4CXX_ERROR(logger_, "application_commands section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& app_commands =
+      saved_app[strings::application_commands];
+
+  for (size_t cmd_num = 0; cmd_num < app_commands.length(); ++cmd_num) {
+    const smart_objects::SmartObject& command = app_commands[cmd_num];
+    const uint32_t cmd_id = command[strings::cmd_id].asUInt();
+    const uint32_t consecutive_num =
+        commands::CommandImpl::CalcCommandInternalConsecutiveNumber(
+            application);
+
+    application->AddCommand(consecutive_num, command);
+    application->help_prompt_manager().OnVrCommandAdded(
+        cmd_id, command, true);  // is_resumption =true
+  }
+
+  ProcessMessagesToHMI(MessageHelper::CreateAddCommandRequestToHMI(
+      application, application_manager_));
+}
+
+utils::Optional<ResumptionRequest> FindCommandResumptionRequest(
+    uint32_t command_id, std::vector<ResumptionRequest>& requests) {
+  using namespace utils;
+
+  auto request_it = std::find_if(
+      requests.begin(),
+      requests.end(),
+      [command_id](const ResumptionRequest& request) {
+        auto& msg_params = request.message[strings::msg_params];
+        const bool is_vr_command = hmi_apis::FunctionID::VR_AddCommand ==
+                                       request.request_ids.function_id &&
+                                   hmi_apis::Common_VRCommandType::Command ==
+                                       msg_params[strings::type].asInt();
+        const bool is_ui_command = hmi_apis::FunctionID::UI_AddCommand ==
+                                   request.request_ids.function_id;
+
+        if (is_vr_command || is_ui_command) {
+          uint32_t cmd_id = msg_params[strings::cmd_id].asUInt();
+          return cmd_id == command_id;
+        }
+
+        return false;
+      });
+
+  if (requests.end() != request_it) {
+    return Optional<ResumptionRequest>(*request_it);
+  }
+  return Optional<ResumptionRequest>::OptionalEmpty::EMPTY;
+}
+
+void ResumptionDataProcessor::DeleteCommands(ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto failed_requests = GetAllFailedRequests(
+      application->app_id(), resumption_status_, resumption_status_lock_);
+
+  auto is_vr_command_failed = [](const ResumptionRequest& failed_command) {
+    return failed_command.message[strings::msg_params].keyExists(
+        strings::vr_commands);
+  };
+
+  auto extract_cmd_id =
+      [](const smart_objects::SmartObject* const so_ptr) -> uint32_t {
+    if (so_ptr->keyExists(strings::cmd_id)) {
+      return so_ptr->getElement(strings::cmd_id).asUInt();
+    }
+
+    return 0;
+  };
+
+  auto accessor = application->commands_map();
+  const auto& commands_map = accessor.GetData();
+
+  for (const auto& cmd : commands_map) {
+    const auto cmd_id = extract_cmd_id(cmd.second);
+    if (0 == cmd_id) {
+      LOG4CXX_ERROR(logger_,
+                    "Can't extract cmd_id for command with internal number: "
+                        << cmd.first);
+      continue;
+    }
+
+    auto failed_command = FindCommandResumptionRequest(cmd_id, failed_requests);
+
+    LOG4CXX_DEBUG(logger_,
+                  std::boolalpha << "Command with internal ID: " << cmd.first
+                                 << " and cmdID: " << cmd_id << " was failed: "
+                                 << static_cast<bool>(failed_command));
+    if (!failed_command || (!is_vr_command_failed(*failed_command))) {
+      auto delete_VR_command_msg = MessageHelper::CreateDeleteVRCommandRequest(
+          cmd.second,
+          application,
+          application_manager_.GetNextHMICorrelationID());
+      application_manager_.GetRPCService().ManageHMICommand(
+          delete_VR_command_msg);
+    }
+
+    if (!failed_command || (is_vr_command_failed(*failed_command))) {
+      auto delete_UI_command_msg = MessageHelper::CreateDeleteUICommandRequest(
+          cmd.second,
+          application->app_id(),
+          application_manager_.GetNextHMICorrelationID());
+      application_manager_.GetRPCService().ManageHMICommand(
+          delete_UI_command_msg);
+    }
+
+    application->RemoveCommand(cmd_id);
+    application->help_prompt_manager().OnVrCommandDeleted(cmd_id, true);
+  }
+}
+
+void ResumptionDataProcessor::AddChoicesets(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_choice_sets)) {
+    LOG4CXX_ERROR(logger_, "There is no any choicesets");
+    return;
+  }
+
+  const smart_objects::SmartObject& app_choice_sets =
+      saved_app[strings::application_choice_sets];
+
+  for (size_t i = 0; i < app_choice_sets.length(); ++i) {
+    const smart_objects::SmartObject& choice_set = app_choice_sets[i];
+    const int32_t choice_set_id =
+        choice_set[strings::interaction_choice_set_id].asInt();
+    application->AddChoiceSet(choice_set_id, choice_set);
+  }
+
+  ProcessMessagesToHMI(MessageHelper::CreateAddVRCommandRequestFromChoiceToHMI(
+      application, application_manager_));
+}
+
+utils::Optional<ResumptionRequest> FindResumptionChoiceSetRequest(
+    uint32_t command_id, std::vector<ResumptionRequest>& requests) {
+  using namespace utils;
+
+  auto request_it =
+      std::find_if(requests.begin(),
+                   requests.end(),
+                   [command_id](const ResumptionRequest& request) {
+                     auto& msg_params = request.message[strings::msg_params];
+                     if (msg_params.keyExists(strings::cmd_id) &&
+                         (msg_params[strings::type] ==
+                          hmi_apis::Common_VRCommandType::Choice)) {
+                       uint32_t cmd_id = msg_params[strings::cmd_id].asUInt();
+                       return cmd_id == command_id;
+                     }
+                     return false;
+                   });
+  if (requests.end() != request_it) {
+    return Optional<ResumptionRequest>(*request_it);
+  }
+  return Optional<ResumptionRequest>::OptionalEmpty::EMPTY;
+}
+
+void ResumptionDataProcessor::DeleteChoicesets(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto failed_requests = GetAllFailedRequests(
+      application->app_id(), resumption_status_, resumption_status_lock_);
+
+  auto accessor = application->choice_set_map();
+  const auto& choices = accessor.GetData();
+  for (const auto& choice : choices) {
+    auto failed_choice_set =
+        FindResumptionChoiceSetRequest(choice.first, failed_requests);
+    if (!failed_choice_set) {
+      MessageHelper::SendDeleteChoiceSetRequest(
+          choice.second, application, application_manager_);
+    }
+    application->RemoveChoiceSet(choice.first);
+  }
+}
+
+void ResumptionDataProcessor::SetGlobalProperties(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (!saved_app.keyExists(strings::application_global_properties)) {
+    LOG4CXX_DEBUG(logger_,
+                  "application_global_properties section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& properties_so =
+      saved_app[strings::application_global_properties];
+  application->load_global_properties(properties_so);
+
+  ProcessMessagesToHMI(MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+      application, application_manager_));
+}
+
+void ResumptionDataProcessor::DeleteGlobalProperties(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const uint32_t app_id = application->app_id();
+  const auto result =
+      application_manager_.ResetAllApplicationGlobalProperties(app_id);
+
+  resumption_status_lock_.AcquireForReading();
+  std::vector<ResumptionRequest> requests;
+  if (resumption_status_.find(app_id) != resumption_status_.end()) {
+    requests = resumption_status_[app_id].successful_requests;
+  }
+  resumption_status_lock_.Release();
+
+  auto check_if_successful =
+      [requests](hmi_apis::FunctionID::eType function_id) {
+        for (auto& resumption_request : requests) {
+          auto request_func =
+              resumption_request.message[strings::params][strings::function_id]
+                  .asInt();
+          if (request_func == function_id) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+  if (result.HasUIPropertiesReset() &&
+      check_if_successful(hmi_apis::FunctionID::UI_SetGlobalProperties)) {
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateUIResetGlobalPropertiesRequest(result,
+                                                            application);
+    auto msg = MessageHelper::CreateMessageForHMI(
+        hmi_apis::messageType::request,
+        application_manager_.GetNextHMICorrelationID());
+    (*msg)[strings::params][strings::function_id] =
+        hmi_apis::FunctionID::UI_SetGlobalProperties;
+    (*msg)[strings::msg_params] = *msg_params;
+    ProcessMessageToHMI(msg, false);
+  }
+
+  if (result.HasTTSPropertiesReset() &&
+      check_if_successful(hmi_apis::FunctionID::TTS_SetGlobalProperties)) {
+    smart_objects::SmartObjectSPtr msg_params =
+        MessageHelper::CreateTTSResetGlobalPropertiesRequest(result,
+                                                             application);
+    auto msg = MessageHelper::CreateMessageForHMI(
+        hmi_apis::messageType::request,
+        application_manager_.GetNextHMICorrelationID());
+    (*msg)[strings::params][strings::function_id] =
+        hmi_apis::FunctionID::TTS_SetGlobalProperties;
+
+    (*msg)[strings::msg_params] = *msg_params;
+    ProcessMessageToHMI(msg, false);
+  }
+}
+
+void ResumptionDataProcessor::AddSubscriptions(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  AddButtonsSubscriptions(application, saved_app);
+  AddPluginsSubscriptions(application, saved_app);
+}
+
+void ResumptionDataProcessor::AddButtonsSubscriptions(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  if (!saved_app.keyExists(strings::application_subscriptions)) {
+    LOG4CXX_DEBUG(logger_, "application_subscriptions section is not exists");
+    return;
+  }
+
+  const smart_objects::SmartObject& subscriptions =
+      saved_app[strings::application_subscriptions];
+
+  if (subscriptions.keyExists(strings::application_buttons)) {
+    const smart_objects::SmartObject& subscriptions_buttons =
+        subscriptions[strings::application_buttons];
+    mobile_apis::ButtonName::eType btn;
+    for (size_t i = 0; i < subscriptions_buttons.length(); ++i) {
+      btn = static_cast<mobile_apis::ButtonName::eType>(
+          (subscriptions_buttons[i]).asInt());
+      application->SubscribeToButton(btn);
+    }
+
+    ButtonSubscriptions button_subscriptions =
+        GetButtonSubscriptionsToResume(application);
+
+    ProcessMessagesToHMI(
+        MessageHelper::CreateOnButtonSubscriptionNotificationsForApp(
+            application, application_manager_, button_subscriptions));
+  }
+}
+
+ButtonSubscriptions ResumptionDataProcessor::GetButtonSubscriptionsToResume(
+    ApplicationSharedPtr application) const {
+  ButtonSubscriptions button_subscriptions =
+      application->SubscribedButtons().GetData();
+  auto it = button_subscriptions.find(mobile_apis::ButtonName::CUSTOM_BUTTON);
+
+  if (it != button_subscriptions.end()) {
+    button_subscriptions.erase(it);
+  }
+
+  return button_subscriptions;
+}
+
+void ResumptionDataProcessor::AddPluginsSubscriptions(
+    ApplicationSharedPtr application,
+    const smart_objects::SmartObject& saved_app) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  for (auto& extension : application->Extensions()) {
+    extension->ProcessResumption(
+        saved_app,
+        [this](const int32_t app_id, const ResumptionRequest request) {
+          this->SubscribeToResponse(app_id, request);
+        });
+  }
+}
+
+void ResumptionDataProcessor::DeleteSubscriptions(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  DeleteButtonsSubscriptions(application);
+  DeletePluginsSubscriptions(application);
+}
+
+void ResumptionDataProcessor::DeleteButtonsSubscriptions(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const ButtonSubscriptions button_subscriptions =
+      application->SubscribedButtons().GetData();
+  for (auto& btn : button_subscriptions) {
+    const auto hmi_btn = static_cast<hmi_apis::Common_ButtonName::eType>(btn);
+    if (hmi_apis::Common_ButtonName::CUSTOM_BUTTON == hmi_btn) {
+      continue;
+    }
+    auto notification = MessageHelper::CreateOnButtonSubscriptionNotification(
+        application->hmi_app_id(), hmi_btn, false);
+    // is_subscribed = false
+    ProcessMessageToHMI(notification, false);
+    application->UnsubscribeFromButton(btn);
+  }
+}
+
+void ResumptionDataProcessor::DeleteWindowsSubscriptions(
+    ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const auto window_ids = application->GetWindowIds();
+  for (const auto& window_id : window_ids) {
+    const auto hmi_state = application->CurrentHmiState(window_id);
+    if (mobile_apis::WindowType::WIDGET != hmi_state->window_type()) {
+      continue;
+    }
+
+    LOG4CXX_DEBUG(logger_, "Reverting CreateWindow for: " << window_id);
+
+    auto delete_request = MessageHelper::CreateUIDeleteWindowRequestToHMI(
+        application, application_manager_, window_id);
+    const bool subscribe_on_request_events = false;
+    ProcessMessageToHMI(delete_request, subscribe_on_request_events);
+
+    application->RemoveWindowInfo(window_id);
+    application->RemoveHMIState(window_id,
+                                app_mngr::HmiState::StateID::STATE_ID_REGULAR);
+    application->remove_window_capability(window_id);
+  }
+}
+
+void ResumptionDataProcessor::DeletePluginsSubscriptions(
+    application_manager::ApplicationSharedPtr application) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  resumption_status_lock_.AcquireForReading();
+  auto it = resumption_status_.find(application->app_id());
+  if (it == resumption_status_.end()) {
+    resumption_status_lock_.Release();
+    return;
+  }
+
+  const ApplicationResumptionStatus& status = it->second;
+  smart_objects::SmartObject extension_subscriptions;
+  for (auto ivi : status.successful_vehicle_data_subscriptions_) {
+    LOG4CXX_DEBUG(logger_, "ivi " << ivi << " should be deleted");
+    extension_subscriptions[ivi] = true;
+  }
+  resumption_status_lock_.Release();
+
+  for (auto& extension : application->Extensions()) {
+    extension->RevertResumption(extension_subscriptions);
+  }
+}
+
+bool IsResponseSuccessful(const smart_objects::SmartObject& response) {
+  if (!response[strings::params].keyExists(strings::error_msg)) {
+    return true;
+  }
+  return false;
+}
+
+void ResumptionDataProcessor::CheckVehicleDataResponse(
+    const smart_objects::SmartObject& request,
+    const smart_objects::SmartObject& response,
+    ApplicationResumptionStatus& status) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto request_keys = request[strings::msg_params].enumerate();
+
+  if (!IsResponseSuccessful(response)) {
+    LOG4CXX_TRACE(logger_, "Vehicle data request not succesfull");
+    for (const auto key : request_keys) {
+      status.unsuccessful_vehicle_data_subscriptions_.push_back(key);
+    }
+    return;
+  }
+
+  const auto& response_params = response[strings::msg_params];
+  const auto response_keys = response_params.enumerate();
+  for (auto& ivi : request_keys) {
+    const auto it = response_keys.find(ivi);
+    const auto kSuccess = hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+    const auto vd_result_code =
+        (response_keys.end() == it)
+            ? kSuccess
+            : response_params[ivi][strings::result_code].asInt();
+    if (kSuccess != vd_result_code) {
+      LOG4CXX_TRACE(logger_,
+                    "ivi " << ivi << " was NOT successfuly subscribed");
+
+      status.unsuccessful_vehicle_data_subscriptions_.push_back(ivi);
+    } else {
+      LOG4CXX_TRACE(logger_, "ivi " << ivi << " was successfuly subscribed");
+      status.successful_vehicle_data_subscriptions_.push_back(ivi);
+    }
+  }
+}
+
+void ResumptionDataProcessor::CheckCreateWindowResponse(
+    const smart_objects::SmartObject& request,
+    const smart_objects::SmartObject& response) const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto correlation_id =
+      response[strings::params][strings::correlation_id].asInt();
+
+  const auto& msg_params = request[strings::msg_params];
+  const auto app_id = msg_params[strings::app_id].asInt();
+
+  auto application = application_manager_.application(app_id);
+  if (!application) {
+    LOG4CXX_ERROR(logger_,
+                  "Application is not registered by hmi id: " << app_id);
+    return;
+  }
+
+  const auto window_id = msg_params[strings::window_id].asInt();
+  if (!IsResponseSuccessful(response)) {
+    LOG4CXX_ERROR(logger_,
+                  "UI_CreateWindow for correlation id: " << correlation_id
+                                                         << " has failed");
+    auto& builder = application->display_capabilities_builder();
+    builder.ResetDisplayCapabilities();
+    return;
+  }
+
+  smart_objects::SmartObject window_info(smart_objects::SmartType_Map);
+  auto fill_optional_param = [&window_info,
+                              &msg_params](const std::string& key) {
+    if (msg_params.keyExists(key)) {
+      window_info[key] = msg_params[key].asString();
+    }
+  };
+  fill_optional_param(strings::associated_service_type);
+  fill_optional_param(strings::duplicate_updates_from_window_id);
+
+  const auto window_name = msg_params[strings::window_name].asString();
+  window_info[strings::window_name] = window_name;
+  application->SetWindowInfo(window_id, window_info);
+
+  const auto window_type = static_cast<mobile_apis::WindowType::eType>(
+      msg_params[strings::window_type].asInt());
+
+  // State should be initialized with INVALID_ENUM value to let state
+  // controller trigger OnHmiStatus notifiation sending
+  auto initial_state = application_manager_.CreateRegularState(
+      application,
+      window_type,
+      mobile_apis::HMILevel::INVALID_ENUM,
+      mobile_apis::AudioStreamingState::INVALID_ENUM,
+      mobile_apis::VideoStreamingState::INVALID_ENUM,
+      mobile_apis::SystemContext::INVALID_ENUM);
+  application->SetInitialState(window_id, window_name, initial_state);
+
+  // Default HMI level for all windows except the main one is always NONE
+  application_manager_.state_controller().OnAppWindowAdded(
+      application, window_id, window_type, mobile_apis::HMILevel::HMI_NONE);
+}
+
+}  // namespace resumption

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -402,7 +402,11 @@ void StateControllerImpl::HmiLevelConflictResolver::operator()(
           result_audio_state,
           mobile_apis::AudioStreamingState::AUDIBLE,
           mobile_apis::AudioStreamingState::ATTENUATED)) {
-    result_hmi_level = mobile_apis::HMILevel::HMI_LIMITED;
+    result_hmi_level =
+        mobile_apis::PredefinedWindows::DEFAULT_WINDOW == window_id_ &&
+                applied_->IsFullscreen()
+            ? mobile_apis::HMILevel::HMI_LIMITED
+            : to_resolve_hmi_level;
   } else {
     result_hmi_level = mobile_apis::HMILevel::HMI_BACKGROUND;
   }
@@ -490,13 +494,13 @@ bool StateControllerImpl::IsResumptionAllowed(ApplicationSharedPtr app,
 }
 
 mobile_apis::HMILevel::eType StateControllerImpl::GetAvailableHmiLevel(
-    ApplicationSharedPtr app, mobile_apis::HMILevel::eType hmi_level) const {
+    ApplicationSharedPtr app,
+    mobile_apis::HMILevel::eType desired_hmi_level) const {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  mobile_apis::HMILevel::eType result = hmi_level;
-  LOG4CXX_DEBUG(logger_, "HMI Level: " << hmi_level);
+  mobile_apis::HMILevel::eType result = desired_hmi_level;
 
-  if (!IsStreamableHMILevel(hmi_level)) {
+  if (!IsStreamableHMILevel(desired_hmi_level)) {
     return result;
   }
 
@@ -504,8 +508,11 @@ mobile_apis::HMILevel::eType StateControllerImpl::GetAvailableHmiLevel(
   const bool does_audio_app_with_same_type_exist =
       app_mngr_.IsAppTypeExistsInFullOrLimited(app);
 
-  if (mobile_apis::HMILevel::HMI_LIMITED == hmi_level) {
+  if (mobile_apis::HMILevel::HMI_LIMITED == desired_hmi_level) {
     if (!is_audio_app || does_audio_app_with_same_type_exist) {
+      LOG4CXX_DEBUG(logger_,
+                    "Not audio application trying to resume in limited or "
+                    "audio application with the same type active");
       result = app_mngr_.GetDefaultHmiLevel(app);
     }
     return result;
@@ -516,6 +523,7 @@ mobile_apis::HMILevel::eType StateControllerImpl::GetAvailableHmiLevel(
       (active_app.use_count() != 0) && active_app->app_id() != app->app_id();
   if (is_audio_app) {
     if (does_audio_app_with_same_type_exist) {
+      LOG4CXX_DEBUG(logger_, "Audio application with the same type active");
       result = app_mngr_.GetDefaultHmiLevel(app);
     } else if (is_active_app_exist) {
       result = mobile_apis::HMILevel::HMI_LIMITED;
@@ -701,7 +709,10 @@ void StateControllerImpl::UpdateAppWindowsStreamingState(
       new_window_state->set_window_type(window_hmi_state->window_type());
       app->SetRegularState(window_id, new_window_state);
 
-      MessageHelper::SendHMIStatusNotification(app, window_id, app_mngr_);
+      auto notification =
+          MessageHelper::CreateHMIStatusNotification(app, window_id);
+      app_mngr_.GetRPCService().ManageMobileCommand(
+          notification, commands::Command::SOURCE_SDL);
     }
   }
 }
@@ -868,7 +879,10 @@ void StateControllerImpl::OnStateChanged(ApplicationSharedPtr app,
     return;
   }
 
-  MessageHelper::SendHMIStatusNotification(app, window_id, app_mngr_);
+  auto notification =
+      MessageHelper::CreateHMIStatusNotification(app, window_id);
+  app_mngr_.GetRPCService().ManageMobileCommand(notification,
+                                                commands::Command::SOURCE_SDL);
 
   if (mobile_apis::PredefinedWindows::DEFAULT_WINDOW != window_id) {
     LOG4CXX_DEBUG(logger_,
@@ -888,6 +902,48 @@ void StateControllerImpl::OnStateChanged(ApplicationSharedPtr app,
 bool StateControllerImpl::IsTempStateActive(HmiState::StateID id) const {
   sync_primitives::AutoLock autolock(active_states_lock_);
   return helpers::in_range(active_states_, id);
+}
+
+void StateControllerImpl::ResumePostponedWindows(const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto it_postponed_windows = postponed_app_widgets_.find(app_id);
+  if (it_postponed_windows != postponed_app_widgets_.end()) {
+    const WindowStatePairs& window_pairs = it_postponed_windows->second;
+    LOG4CXX_DEBUG(logger_,
+                  "Application " << app_id << " has " << window_pairs.size()
+                                 << " postponed windows. Restoring...");
+
+    auto application = app_mngr_.application(app_id);
+    if (!application) {
+      LOG4CXX_ERROR(logger_, "Application " << app_id << " is not registered");
+      postponed_app_widgets_.erase(it_postponed_windows);
+      return;
+    }
+
+    for (const WindowStatePair& pair : window_pairs) {
+      const WindowID window_id = pair.first;
+      HmiStatePtr postponed_state = pair.second;
+
+      OnAppWindowAdded(application,
+                       window_id,
+                       postponed_state->window_type(),
+                       postponed_state->hmi_level());
+    }
+
+    postponed_app_widgets_.erase(it_postponed_windows);
+  }
+}
+
+void StateControllerImpl::DropPostponedWindows(const uint32_t app_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto it_postponed_windows = postponed_app_widgets_.find(app_id);
+  if (it_postponed_windows != postponed_app_widgets_.end()) {
+    LOG4CXX_DEBUG(
+        logger_,
+        "Dropping postponed windows information for application " << app_id);
+    postponed_app_widgets_.erase(it_postponed_windows);
+  }
 }
 
 void StateControllerImpl::OnApplicationRegistered(
@@ -912,6 +968,26 @@ void StateControllerImpl::OnAppWindowAdded(
   namespace SystemContext = mobile_apis::SystemContext;
   LOG4CXX_AUTO_TRACE(logger_);
   DCHECK_OR_RETURN_VOID(app);
+
+  if (mobile_apis::WindowType::WIDGET == window_type) {
+    auto main_state =
+        app->CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+    if (mobile_apis::HMILevel::INVALID_ENUM == main_state->hmi_level()) {
+      LOG4CXX_DEBUG(logger_,
+                    "Application " << app->app_id()
+                                   << " is not registered. Widget with ID: "
+                                   << window_id << " has been postponed");
+
+      HmiStatePtr postponed_state =
+          CreateHmiState(app, HmiState::StateID::STATE_ID_REGULAR);
+      postponed_state->set_window_type(window_type);
+      postponed_state->set_hmi_level(default_level);
+
+      WindowStatePair pair = std::make_pair(window_id, postponed_state);
+      postponed_app_widgets_[app->app_id()].push_back(pair);
+      return;
+    }
+  }
 
   {
     sync_primitives::AutoLock lck(active_states_lock_);

--- a/src/components/application_manager/test/app_launch/app_launch_ctrl_test.cc
+++ b/src/components/application_manager/test/app_launch/app_launch_ctrl_test.cc
@@ -162,7 +162,7 @@ class AppLaunchCtrlTest : public ::testing::Test {
   NiceMock<am_test::MockApplicationManager> app_mngr_mock_;
   NiceMock<app_launch_test::AppLaunchDataMock> app_launch_data_mock_;
   NiceMock<ch_test::MockConnectionHandler> connection_handler_mock_;
-  NiceMock<resumprion_test::MockResumeCtrl> resume_ctrl_mock_;
+  NiceMock<resumption_test::MockResumeCtrl> resume_ctrl_mock_;
   NiceMock<app_launch_test::MockAppLaunchSettings> settings_;
   std::unique_ptr<app_launch::AppLaunchCtrlImpl> app_launch_ctrl_;
 };

--- a/src/components/application_manager/test/application_helper_test.cc
+++ b/src/components/application_manager/test/application_helper_test.cc
@@ -204,6 +204,15 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectAppDataReset) {
   EXPECT_TRUE(NULL != file_ptr);
   EXPECT_TRUE(file_ptr->file_name == filename);
 
+  EXPECT_CALL(*mock_message_helper_, CreateUnsubscribeWayPointsRequest(_))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+
+  EXPECT_CALL(*mock_message_helper_, CreateDeleteUICommandRequest(_, _, _))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+
+  EXPECT_CALL(*mock_message_helper_, CreateDeleteVRCommandRequest(_, _, _))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+
   // Act
   application_manager::DeleteApplicationData(app_impl_, app_manager_impl_);
   EXPECT_FALSE(NULL != app_impl_->FindCommand(cmd_id));
@@ -243,9 +252,14 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectHMICleanupRequests) {
   app_impl_->AddChoiceSet(choice_set_id, cmd[strings::msg_params]);
   app_impl_->SubscribeToButton(mobile_apis::ButtonName::AC);
 
-  EXPECT_CALL(*mock_message_helper_, SendUnsubscribedWayPoints(_));
+  EXPECT_CALL(*mock_message_helper_, CreateUnsubscribeWayPointsRequest(_))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
 
-  EXPECT_CALL(*mock_message_helper_, SendDeleteCommandRequest(_, _, _));
+  EXPECT_CALL(*mock_message_helper_, CreateDeleteUICommandRequest(_, _, _))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+
+  EXPECT_CALL(*mock_message_helper_, CreateDeleteVRCommandRequest(_, _, _))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
 
   EXPECT_CALL(*mock_message_helper_, SendDeleteSubmenuRequest(_, _, _));
 

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -680,7 +680,7 @@ TEST_F(ApplicationImplTest, UpdateHash_AppMngrNotSuspended) {
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendHashUpdateNotification(app_id, _))
       .Times(1);
-  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
   EXPECT_CALL(mock_application_manager_, resume_controller())
       .WillOnce(ReturnRef(mock_resume_ctrl));
   EXPECT_CALL(mock_resume_ctrl, is_suspended()).WillOnce(Return(false));
@@ -693,7 +693,7 @@ TEST_F(ApplicationImplTest, UpdateHash_AppMngrSuspended) {
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendHashUpdateNotification(app_id, _))
       .Times(0);
-  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  resumption_test::MockResumeCtrl mock_resume_ctrl;
   EXPECT_CALL(mock_application_manager_, resume_controller())
       .WillOnce(ReturnRef(mock_resume_ctrl));
   EXPECT_CALL(mock_resume_ctrl, is_suspended()).WillOnce(Return(true));

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -463,16 +463,16 @@ TEST_F(ApplicationManagerImplTest,
        SubscribeAppForWayPoints_ExpectSubscriptionApp) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
   app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
-  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
+  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
 }
 
 TEST_F(ApplicationManagerImplTest,
        UnsubscribeAppForWayPoints_ExpectUnsubscriptionApp) {
   auto app_ptr = std::static_pointer_cast<am::Application>(mock_app_ptr_);
   app_manager_impl_->SubscribeAppForWayPoints(app_ptr);
-  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
+  EXPECT_TRUE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
   app_manager_impl_->UnsubscribeAppFromWayPoints(app_ptr);
-  EXPECT_FALSE(app_manager_impl_->IsAppSubscribedForWayPoints(app_ptr));
+  EXPECT_FALSE(app_manager_impl_->IsAppSubscribedForWayPoints(*app_ptr));
   const std::set<uint32_t> result =
       app_manager_impl_->GetAppsSubscribedForWayPoints();
   EXPECT_TRUE(result.empty());

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -129,10 +129,17 @@ class MockMessageHelper {
   MOCK_METHOD2(CreateMessageForHMI,
                smart_objects::SmartObjectSPtr(hmi_apis::messageType::eType,
                                               const uint32_t));
-  MOCK_METHOD3(SendHMIStatusNotification,
-               void(ApplicationSharedPtr application,
-                    const WindowID window_id,
-                    ApplicationManager& application_manager));
+  MOCK_METHOD2(CreateMessageForHMI,
+               smart_objects::SmartObjectSPtr(hmi_apis::FunctionID::eType,
+                                              const uint32_t));
+  MOCK_METHOD2(CreateHMIStatusNotification,
+               smart_objects::SmartObjectSPtr(ApplicationSharedPtr application,
+                                              const WindowID window_id));
+  MOCK_METHOD3(CreateOnButtonSubscriptionNotificationsForApp,
+               smart_objects::SmartObjectList(
+                   ApplicationConstSharedPtr application,
+                   ApplicationManager& app_mngr,
+                   const ButtonSubscriptions& button_subscriptions));
   MOCK_METHOD4(SendPolicyUpdate,
                void(const std::string& file_path,
                     const uint32_t timeout,
@@ -184,17 +191,39 @@ class MockMessageHelper {
   MOCK_METHOD2(SendAllOnButtonSubscriptionNotificationsForApp,
                void(ApplicationConstSharedPtr app,
                     ApplicationManager& app_mngr));
+  MOCK_METHOD2(CreateUIResetGlobalPropertiesRequest,
+               smart_objects::SmartObjectSPtr(
+                   const ResetGlobalPropertiesResult& reset_result,
+                   ApplicationSharedPtr application));
+
+  MOCK_METHOD2(CreateTTSResetGlobalPropertiesRequest,
+               smart_objects::SmartObjectSPtr(
+                   const ResetGlobalPropertiesResult& reset_result,
+                   ApplicationSharedPtr application));
+  MOCK_METHOD2(CreateGlobalPropertiesRequestsToHMI,
+               smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
+                                              ApplicationManager& app_mngr));
+  MOCK_METHOD1(CreateSubscribeWayPointsMessageToHMI,
+               smart_objects::SmartObjectSPtr(const uint32_t correlation_id));
+
+  MOCK_METHOD3(
+      CreateOnButtonSubscriptionNotification,
+      smart_objects::SmartObjectSPtr(uint32_t app_id,
+                                     hmi_apis::Common_ButtonName::eType button,
+                                     bool is_subscribed));
   MOCK_METHOD2(SendOnResumeAudioSourceToHMI,
                void(uint32_t app_id, ApplicationManager& app_mngr));
-  MOCK_METHOD2(CreateAddSubMenuRequestToHMI,
+  MOCK_METHOD2(CreateAddSubMenuRequestsToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
-                                              const uint32_t correlation_id));
+                                              ApplicationManager& app_mngr));
   MOCK_METHOD2(CreateAddCommandRequestToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_mngr));
   MOCK_METHOD1(CreateAddVRCommandRequestFromChoiceToHMI,
                smart_objects::SmartObjectList(ApplicationConstSharedPtr app));
-  MOCK_METHOD1(SendGlobalPropertiesToHMI, void(ApplicationConstSharedPtr app));
+  MOCK_METHOD2(SendGlobalPropertiesToHMI,
+               void(ApplicationConstSharedPtr app,
+                    ApplicationManager& app_mngr));
   MOCK_METHOD3(VerifyTtsFiles,
                mobile_apis::Result::eType(smart_objects::SmartObject& message,
                                           ApplicationConstSharedPtr app,
@@ -282,7 +311,8 @@ class MockMessageHelper {
                     const std::string& urlSchema,
                     const std::string& packageName,
                     ApplicationManager& app_man));
-  MOCK_METHOD1(SendUnsubscribedWayPoints, bool(ApplicationManager& app_mngr));
+  MOCK_METHOD1(CreateUnsubscribeWayPointsRequest,
+               smart_objects::SmartObjectSPtr(const uint32_t correlation_id));
 
   MOCK_METHOD2(SendQueryApps,
                void(const uint32_t connection_key,
@@ -315,10 +345,14 @@ class MockMessageHelper {
   MOCK_METHOD2(GetDeviceMacAddressForHandle,
                std::string(const transport_manager::DeviceHandle device_handle,
                            const ApplicationManager& app_mngr));
-  MOCK_METHOD3(SendDeleteCommandRequest,
-               void(smart_objects::SmartObject* cmd,
-                    ApplicationSharedPtr application,
-                    ApplicationManager& app_mngr));
+  MOCK_METHOD3(CreateDeleteUICommandRequest,
+               smart_objects::SmartObjectSPtr(smart_objects::SmartObject* cmd,
+                                              const uint32_t app_id,
+                                              const uint32_t corr_id));
+  MOCK_METHOD3(CreateDeleteVRCommandRequest,
+               smart_objects::SmartObjectSPtr(smart_objects::SmartObject* cmd,
+                                              ApplicationSharedPtr application,
+                                              const uint32_t corr_id));
   MOCK_METHOD3(SendDeleteSubmenuRequest,
                void(smart_objects::SmartObject* cmd,
                     ApplicationSharedPtr application,
@@ -356,6 +390,21 @@ class MockMessageHelper {
                    const hmi_apis::Common_ServiceStatusUpdateReason::eType
                        service_update_reason,
                    const uint32_t app_id));
+  MOCK_METHOD4(CreateNegativeResponseFromHmi,
+               smart_objects::SmartObjectSPtr(const int32_t function_id,
+                                              const uint32_t correlation_id,
+                                              const int32_t result_code,
+                                              const std::string& info));
+
+  MOCK_METHOD3(CreateResponseMessageFromHmi,
+               smart_objects::SmartObjectSPtr(const int32_t function_id,
+                                              const uint32_t correlation_id,
+                                              const int32_t result_code));
+  MOCK_METHOD3(CreateUIDeleteWindowRequestToHMI,
+               smart_objects::SmartObjectSPtr(
+                   application_manager::ApplicationSharedPtr application,
+                   application_manager::ApplicationManager& app_mngr,
+                   const application_manager::WindowID window_id));
 
   static MockMessageHelper* message_helper_mock();
 };

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -38,7 +38,7 @@
 
 namespace test {
 namespace components {
-namespace resumprion_test {
+namespace resumption_test {
 
 class MockResumeCtrl : public resumption::ResumeCtrl {
  public:
@@ -59,12 +59,16 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_CONST_METHOD0(is_suspended, bool());
   MOCK_METHOD0(StopSavePersistentDataTimer, void());
   MOCK_METHOD0(StartSavePersistentDataTimer, void());
-  MOCK_METHOD2(StartResumption,
+  MOCK_METHOD3(StartResumption,
                bool(app_mngr::ApplicationSharedPtr application,
-                    const std::string& hash));
+                    const std::string& hash,
+                    resumption::ResumeCtrl::ResumptionCallBack));
   MOCK_METHOD1(StartResumptionOnlyHMILevel,
                bool(app_mngr::ApplicationSharedPtr application));
   MOCK_METHOD1(RetryResumption, void(const uint32_t app_id));
+  MOCK_METHOD2(HandleOnTimeOut,
+               void(const uint32_t correlation_id,
+                    const hmi_apis::FunctionID::eType));
   MOCK_METHOD1(CheckPersistenceFilesForResumption,
                bool(app_mngr::ApplicationSharedPtr application));
   MOCK_METHOD2(CheckApplicationHash,
@@ -103,15 +107,9 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
                     bool check_policy));
   MOCK_CONST_METHOD0(LaunchTime, time_t());
 
-  MOCK_METHOD2(RestoreAppWidgets,
-               size_t(app_mngr::ApplicationSharedPtr application,
-                      const smart_objects::SmartObject& saved_app));
-
-  MOCK_METHOD1(RestoreWidgetsHMIState,
-               void(const smart_objects::SmartObject& response_message));
-
-  MOCK_METHOD1(StartWaitingForDisplayCapabilitiesUpdate,
-               void(application_manager::ApplicationSharedPtr application));
+  MOCK_METHOD2(StartWaitingForDisplayCapabilitiesUpdate,
+               void(application_manager::ApplicationSharedPtr application,
+                    const bool is_resume_app));
 
 #ifdef BUILD_TESTS
   MOCK_METHOD1(set_resumption_storage,
@@ -120,7 +118,7 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
 #endif  // BUILD_TESTS
 };
 
-}  // namespace resumprion_test
+}  // namespace resumption_test
 }  // namespace components
 }  // namespace test
 

--- a/src/components/application_manager/test/message_helper/message_helper_test.cc
+++ b/src/components/application_manager/test/message_helper/message_helper_test.cc
@@ -167,8 +167,10 @@ TEST(MessageHelperTestCreate,
   EXPECT_CALL(*mock_help_prompt_manager, GetSendingType())
       .WillRepeatedly(Return(HelpPromptManager::SendingType::kSendBoth));
 
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateGlobalPropertiesRequestsToHMI(appSharedMock, 0u);
+      MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+          appSharedMock, mock_application_manager);
 
   EXPECT_TRUE(ptr.empty());
 }
@@ -217,8 +219,10 @@ TEST(MessageHelperTestCreate,
   EXPECT_CALL(*mock_help_prompt_manager, GetSendingType())
       .WillRepeatedly(Return(HelpPromptManager::SendingType::kSendBoth));
 
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateGlobalPropertiesRequestsToHMI(appSharedMock, 0u);
+      MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+          appSharedMock, mock_application_manager);
 
   EXPECT_FALSE(ptr.empty());
 
@@ -407,9 +411,10 @@ TEST(MessageHelperTestCreate, CreateAddSubMenuRequestToHMI_SendObject_Equal) {
   EXPECT_CALL(*appSharedMock, sub_menu_map()).WillOnce(Return(data_accessor));
   EXPECT_CALL(*appSharedMock, app_id()).Times(AtLeast(1)).WillOnce(Return(1u));
 
-  const uint32_t cor_id = 0u;
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateAddSubMenuRequestToHMI(appSharedMock, cor_id);
+      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock,
+                                                   mock_application_manager);
 
   EXPECT_FALSE(ptr.empty());
 
@@ -437,9 +442,10 @@ TEST(MessageHelperTestCreate,
 
   EXPECT_CALL(*appSharedMock, sub_menu_map()).WillOnce(Return(data_accessor));
 
-  const uint32_t cor_id = 0u;
+  application_manager_test::MockApplicationManager mock_application_manager;
   smart_objects::SmartObjectList ptr =
-      MessageHelper::CreateAddSubMenuRequestToHMI(appSharedMock, cor_id);
+      MessageHelper::CreateAddSubMenuRequestsToHMI(appSharedMock,
+                                                   mock_application_manager);
 
   EXPECT_TRUE(ptr.empty());
 }

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -267,12 +267,16 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
       message_type, correlation_id);
 }
 
-void MessageHelper::SendHMIStatusNotification(
-    ApplicationSharedPtr application,
-    const WindowID window_id,
-    ApplicationManager& application_manager) {
-  MockMessageHelper::message_helper_mock()->SendHMIStatusNotification(
-      application, window_id, application_manager);
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
+    hmi_apis::FunctionID::eType function_id, const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()->CreateMessageForHMI(
+      function_id, correlation_id);
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateHMIStatusNotification(
+    ApplicationSharedPtr application, const WindowID window_id) {
+  return MockMessageHelper::message_helper_mock()->CreateHMIStatusNotification(
+      application, window_id);
 }
 
 void MessageHelper::SendUpdateSDLResponse(const std::string& result,
@@ -316,10 +320,10 @@ void MessageHelper::SendOnResumeAudioSourceToHMI(const uint32_t app_id,
       app_id, app_mngr);
 }
 
-smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestToHMI(
-    ApplicationConstSharedPtr app, const uint32_t correlation_id) {
-  return MockMessageHelper::message_helper_mock()->CreateAddSubMenuRequestToHMI(
-      app, correlation_id);
+smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestsToHMI(
+    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateAddSubMenuRequestsToHMI(app, app_mngr);
 }
 
 smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
@@ -338,7 +342,7 @@ MessageHelper::CreateAddVRCommandRequestFromChoiceToHMI(
 void MessageHelper::SendGlobalPropertiesToHMI(ApplicationConstSharedPtr app,
                                               ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()->SendGlobalPropertiesToHMI(
-      app);
+      app, app_mngr);
 }
 
 mobile_apis::Result::eType MessageHelper::VerifyTtsFiles(
@@ -517,9 +521,10 @@ void MessageHelper::SendLaunchApp(const uint32_t connection_key,
       connection_key, urlSchema, packageName, app_man);
 }
 
-bool MessageHelper::SendUnsubscribedWayPoints(ApplicationManager& app_mngr) {
-  return MockMessageHelper::message_helper_mock()->SendUnsubscribedWayPoints(
-      app_mngr);
+smart_objects::SmartObjectSPtr MessageHelper::CreateUnsubscribeWayPointsRequest(
+    const uint32_t correlation_id) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateUnsubscribeWayPointsRequest(correlation_id);
 }
 
 void MessageHelper::SendQueryApps(const uint32_t connection_key,
@@ -582,11 +587,20 @@ std::string MessageHelper::GetDeviceMacAddressForHandle(
       device_handle, app_mngr);
 }
 
-void MessageHelper::SendDeleteCommandRequest(smart_objects::SmartObject* cmd,
-                                             ApplicationSharedPtr application,
-                                             ApplicationManager& app_mngr) {
-  return MockMessageHelper::message_helper_mock()->SendDeleteCommandRequest(
-      cmd, application, app_mngr);
+smart_objects::SmartObjectSPtr MessageHelper::CreateDeleteUICommandRequest(
+    smart_objects::SmartObject* cmd,
+    const uint32_t app_id,
+    const uint32_t corr_id) {
+  return MockMessageHelper::message_helper_mock()->CreateDeleteUICommandRequest(
+      cmd, app_id, corr_id);
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateDeleteVRCommandRequest(
+    smart_objects::SmartObject* cmd,
+    ApplicationSharedPtr application,
+    const uint32_t corr_id) {
+  return MockMessageHelper::message_helper_mock()->CreateDeleteVRCommandRequest(
+      cmd, application, corr_id);
 }
 
 void MessageHelper::SendDeleteSubmenuRequest(smart_objects::SmartObject* cmd,
@@ -607,6 +621,48 @@ void MessageHelper::SendResetPropertiesRequest(ApplicationSharedPtr application,
                                                ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()->SendResetPropertiesRequest(
       application, app_mngr);
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateUIResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    ApplicationSharedPtr application) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateUIResetGlobalPropertiesRequest(reset_result, application);
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateTTSResetGlobalPropertiesRequest(
+    const ResetGlobalPropertiesResult& reset_result,
+    ApplicationSharedPtr application) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateTTSResetGlobalPropertiesRequest(reset_result, application);
+}
+
+smart_objects::SmartObjectList
+MessageHelper::CreateGlobalPropertiesRequestsToHMI(
+    ApplicationConstSharedPtr app, ApplicationManager& app_mngr) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateGlobalPropertiesRequestsToHMI(app, app_mngr);
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateOnButtonSubscriptionNotification(
+    uint32_t app_id,
+    hmi_apis::Common_ButtonName::eType button,
+    bool is_subscribed) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateOnButtonSubscriptionNotification(app_id, button, is_subscribed);
+}
+
+smart_objects::SmartObjectList
+MessageHelper::CreateOnButtonSubscriptionNotificationsForApp(
+    ApplicationConstSharedPtr application,
+    ApplicationManager& app_mngr,
+    const ButtonSubscriptions& button_subscriptions) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateOnButtonSubscriptionNotificationsForApp(
+          application, app_mngr, button_subscriptions);
 }
 
 void MessageHelper::SendUnsubscribeButtonNotification(
@@ -653,5 +709,31 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateOnServiceUpdateNotification(
   return MockMessageHelper::message_helper_mock()
       ->CreateOnServiceUpdateNotification(
           service_type, service_event, service_update_reason, app_id);
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateUIDeleteWindowRequestToHMI(
+    ApplicationSharedPtr application,
+    ApplicationManager& app_mngr,
+    const WindowID window_id) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateUIDeleteWindowRequestToHMI(application, app_mngr, window_id);
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponseFromHmi(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const int32_t result_code,
+    const std::string& info) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateNegativeResponseFromHmi(
+          function_id, correlation_id, result_code, info);
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateResponseMessageFromHmi(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const int32_t result_code) {
+  return MockMessageHelper::message_helper_mock()->CreateResponseMessageFromHmi(
+      function_id, correlation_id, result_code);
 }
 }  // namespace application_manager

--- a/src/components/application_manager/test/rc_policy_handler_test.cc
+++ b/src/components/application_manager/test/rc_policy_handler_test.cc
@@ -211,7 +211,7 @@ TEST_F(RCPolicyHandlerTest, OnUpdateHMILevel_HmiLevelChanged_SUCCESS) {
   EXPECT_CALL(app_manager_,
               ChangeAppsHMILevel(kAppId1_, mobile_apis::HMILevel::HMI_LIMITED));
 
-  EXPECT_CALL(mock_message_helper_, SendHMIStatusNotification(_, _));
+  EXPECT_CALL(mock_message_helper_, CreateHMIStatusNotification(_, _));
 
   policy_handler_.OnUpdateHMILevel(kDeviceId_, kPolicyAppId_, hmi_level);
 }
@@ -276,7 +276,7 @@ TEST_F(RCPolicyHandlerTest, OnUpdateHMIStatus_ValidAppAndHmiLevel_SUCCESS) {
 
   EXPECT_CALL(app_manager_,
               ChangeAppsHMILevel(kAppId1_, mobile_apis::HMILevel::HMI_NONE));
-  EXPECT_CALL(mock_message_helper_, SendHMIStatusNotification(_, _));
+  EXPECT_CALL(mock_message_helper_, CreateHMIStatusNotification(_, _));
 
   policy_handler_.OnUpdateHMIStatus(kDeviceId_, kPolicyAppId_, hmi_level);
 }
@@ -307,7 +307,7 @@ TEST_F(RCPolicyHandlerTest, OnUpdateHMIStatus_ValidParams_SUCCESS) {
   EXPECT_CALL(*mock_app_, app_id()).WillRepeatedly(Return(kAppId1_));
   EXPECT_CALL(app_manager_,
               ChangeAppsHMILevel(kAppId1_, mobile_apis::HMILevel::HMI_NONE));
-  EXPECT_CALL(mock_message_helper_, SendHMIStatusNotification(_, _));
+  EXPECT_CALL(mock_message_helper_, CreateHMIStatusNotification(_, _));
 
   policy_handler_.OnUpdateHMIStatus(kDeviceId_, kPolicyAppId_, hmi_level);
 }

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -35,7 +35,6 @@
 
 #include "application_manager/application.h"
 #include "application_manager/application_manager_impl.h"
-#include "application_manager/display_capabilities_builder.h"
 #include "application_manager/mock_app_extension.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_help_prompt_manager.h"
@@ -154,6 +153,9 @@ class ResumeCtrlTest : public ::testing::Test {
     EXPECT_CALL(*mock_app_, deferred_resumption_hmi_level())
         .Times(AtLeast(0))
         .WillRepeatedly(Return(kDefaultDeferredTestLevel_));
+
+    callback_ = [](mobile_apis::Result::eType result_code,
+                   const std::string& info) {};
   }
   void TearDown() OVERRIDE {
     Mock::VerifyAndClearExpectations(&mock_app_mngr_);
@@ -242,6 +244,7 @@ class ResumeCtrlTest : public ::testing::Test {
   const std::string kProjectionLowbandwidthLevel_;
   const std::string kMediaLowbandwidthLevel_;
   NiceMock<application_manager_test::MockRPCService> mock_rpc_service_;
+  resumption::ResumeCtrl::ResumptionCallBack callback_;
 };
 
 /**
@@ -260,10 +263,20 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGrammarId) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
-  EXPECT_CALL(*mock_app_, UpdateHash());
+
+  smart_objects::SmartObjectList requests;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -285,10 +298,9 @@ TEST_F(ResumeCtrlTest, StartResumption_WithoutGrammarId) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
-  EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_)).Times(0);
 
-  bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_FALSE(res);
 }
 
@@ -332,7 +344,17 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithFiles) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
-  EXPECT_CALL(*mock_app_, UpdateHash());
+
+  smart_objects::SmartObjectList requests;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
   for (uint32_t i = 0; i < count_of_files; ++i) {
     EXPECT_CALL(*mock_app_,
@@ -343,7 +365,7 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithFiles) {
                     static_cast<mobile_apis::FileType::eType>(file_types[i]))));
   }
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -376,16 +398,23 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubmenues) {
   for (uint32_t i = 0; i < count_of_submenues; ++i) {
     EXPECT_CALL(*mock_app_, AddSubMenu(i, test_application_submenues[i]));
   }
-  smart_objects::SmartObjectList requests;
 
-  EXPECT_CALL(mock_app_mngr_, GetNextHMICorrelationID())
-      .WillRepeatedly(Return(kCorId_));
+  smart_objects::SmartObjectList requests;
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateAddSubMenuRequestToHMI(_, kCorId_))
+              CreateAddSubMenuRequestsToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
       .WillRepeatedly(Return(requests));
 
-  EXPECT_CALL(*mock_app_, UpdateHash());
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -412,7 +441,6 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithCommands) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
-  EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
   ON_CALL(*mock_app_, help_prompt_manager())
       .WillByDefault(ReturnRef(*mock_help_prompt_manager_));
@@ -451,7 +479,14 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithCommands) {
               CreateAddCommandRequestToHMI(_, _))
       .WillRepeatedly(Return(requests));
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddVRCommandRequestFromChoiceToHMI(_))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -491,7 +526,6 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithChoiceSet) {
   ON_CALL(*mock_storage_,
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
-  EXPECT_CALL(*mock_app_, UpdateHash());
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
   for (uint32_t i = 0; i < count_of_choice_sets; ++i) {
@@ -502,8 +536,15 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithChoiceSet) {
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
               CreateAddVRCommandRequestFromChoiceToHMI(_))
       .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -526,13 +567,19 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithGlobalProperties) {
 
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
-  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              SendGlobalPropertiesToHMI(_));
-
   EXPECT_CALL(*mock_app_, load_global_properties(test_global_properties));
 
-  EXPECT_CALL(*mock_app_, UpdateHash());
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  smart_objects::SmartObjectList requests;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateGlobalPropertiesRequestsToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateAddCommandRequestToHMI(_, _))
+      .WillRepeatedly(Return(requests));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -563,6 +610,19 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
 
+  std::shared_ptr<sync_primitives::Lock> button_lock_ptr =
+      std::make_shared<sync_primitives::Lock>();
+  ButtonSubscriptions button_subscriptions;
+  DataAccessor<ButtonSubscriptions> button_subscription_accessor(
+      button_subscriptions, button_lock_ptr);
+  ON_CALL(*mock_app_, SubscribedButtons())
+      .WillByDefault(Return(button_subscription_accessor));
+
+  smart_objects::SmartObjectList button_subscription_notifications;
+  ON_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+          CreateOnButtonSubscriptionNotificationsForApp(_, _, _))
+      .WillByDefault(Return(button_subscription_notifications));
+
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
   for (uint32_t i = 0; i < count_of_buttons; ++i) {
@@ -570,20 +630,17 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
         *mock_app_,
         SubscribeToButton(static_cast<mobile_apis::ButtonName::eType>(i)));
   }
-  EXPECT_CALL(*mock_app_, UpdateHash());
 
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions));
-
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app, _));
   EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              SendAllOnButtonSubscriptionNotificationsForApp(_, _))
-      .Times(2);
+              CreateOnButtonSubscriptionNotificationsForApp(_, _, _));
 
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
@@ -620,19 +677,19 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToIVI) {
 
   smart_objects::SmartObjectList requests;
 
-  EXPECT_CALL(*mock_app_, UpdateHash());
   std::list<application_manager::AppExtensionPtr> extensions;
 
   extensions.insert(extensions.begin(), mock_app_extension_);
 
   EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
 
-  EXPECT_CALL(*mock_app_extension_, ProcessResumption(test_subscriptions));
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_);
+  EXPECT_CALL(*mock_app_extension_, ProcessResumption(saved_app, _));
+  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(res);
 }
 
-TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
+TEST_F(ResumeCtrlTest,
+       DISABLED_StartResumption_AppWithSubscriptionToWayPoints) {
   smart_objects::SmartObject saved_app;
   saved_app[application_manager::strings::hash_id] = kHash_;
   saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
@@ -644,6 +701,16 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
           GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
       .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
+
+  smart_objects::SmartObjectSPtr subscribe_waypoints_msg;
+  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
+              CreateSubscribeWayPointsMessageToHMI(_))
+      .WillRepeatedly(Return(subscribe_waypoints_msg));
+  std::list<application_manager::AppExtensionPtr> extensions;
+  // It will work only for SDLAppExtension, need to rework this test
+  extensions.insert(extensions.begin(), mock_app_extension_);
+  EXPECT_CALL(*mock_app_, Extensions()).WillOnce(ReturnRef(extensions));
+
   EXPECT_CALL(
       mock_app_mngr_,
       SubscribeAppForWayPoints(A<application_manager::ApplicationSharedPtr>()));
@@ -654,226 +721,8 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscriptionToWayPoints) {
   EXPECT_CALL(mock_state_controller_,
               SetRegularState(_, kDefaultWindowId, hmi_test_level));
 
-  const bool result = res_ctrl_->StartResumption(mock_app_, kHash_);
+  const bool result = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
   EXPECT_TRUE(result);
-}
-
-TEST_F(ResumeCtrlTest,
-       RestoreAppWidgets_AppWithWidgets_SendCreateWindowRequests) {
-  using namespace smart_objects;
-  using namespace application_manager;
-  GetInfoFromApp();
-  const uint32_t count_of_widgets = 10u;
-
-  auto create_window_info_so = []() -> SmartObject {
-    SmartObject widgets_info(SmartType_Array);
-    for (uint32_t i = 0; i < count_of_widgets; ++i) {
-      SmartObject widget_info(SmartType_Map);
-      widget_info[strings::associated_service_type] = "ServiceType";
-      widget_info[strings::duplicate_updates_from_window_id] = 0;
-      widget_info[strings::window_name] =
-          std::string("Widget ") + std::to_string(i + 1);
-      widget_info[strings::window_type] =
-          static_cast<int32_t>(mobile_apis::WindowType::WIDGET);
-      widget_info[strings::window_id] = i + 1;
-      widgets_info[widgets_info.length()] = widget_info;
-    }
-    return widgets_info;
-  };
-
-  auto create_saved_app_so = [&create_window_info_so, this]() -> SmartObject {
-    smart_objects::SmartObject saved_app;
-    const auto test_app_widgets = create_window_info_so();
-    saved_app[strings::hash_id] = kHash_;
-    saved_app[strings::windows_info] = test_app_widgets;
-    saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
-    saved_app[application_manager::strings::hmi_level] = eType::HMI_FULL;
-    return saved_app;
-  };
-
-  const auto saved_app = create_saved_app_so();
-
-  const auto hmi_request = std::make_shared<smart_objects::SmartObject>(
-      smart_objects::SmartType_Map);
-  const auto hmi_requests =
-      smart_objects::SmartObjectList(count_of_widgets, hmi_request);
-
-  DisplayCapabilitiesBuilder builder(*mock_app_);
-  ON_CALL(*mock_app_, display_capabilities_builder())
-      .WillByDefault(ReturnRef(builder));
-  EXPECT_CALL(
-      *application_manager::MockMessageHelper::message_helper_mock(),
-      CreateUICreateWindowRequestsToHMI(_, _, saved_app[strings::windows_info]))
-      .WillOnce(Return(hmi_requests));
-
-  ON_CALL(mock_app_mngr_, GetRPCService())
-      .WillByDefault(ReturnRef(mock_rpc_service_));
-
-  EXPECT_CALL(mock_rpc_service_,
-              ManageHMICommand(_, commands::Command::SOURCE_SDL_TO_HMI))
-      .Times(count_of_widgets)
-      .WillRepeatedly(Return(true));
-
-  res_ctrl_->RestoreAppWidgets(mock_app_, saved_app);
-}
-
-TEST_F(ResumeCtrlTest,
-       RestoreWidgetsHMIState_AppWithWidgets_AddWidgetsInternally) {
-  const uint32_t count_of_widgets = 10u;
-
-  smart_objects::SmartObject saved_app;
-  saved_app[strings::hash_id] = kHash_;
-  saved_app[strings::windows_info] = smart_objects::SmartObject();
-  saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
-  saved_app[application_manager::strings::hmi_level] = eType::HMI_FULL;
-
-  ON_CALL(mock_app_mngr_, application_by_hmi_app(kDefaultHmiAppId))
-      .WillByDefault(Return(mock_app_));
-  DisplayCapabilitiesBuilder builder(*mock_app_);
-  ON_CALL(*mock_app_, display_capabilities_builder())
-      .WillByDefault(ReturnRef(builder));
-
-  smart_objects::SmartObjectList requests;
-  smart_objects::SmartObjectList responses;
-  for (uint32_t i = 0; i < count_of_widgets; ++i) {
-    const auto window_type = mobile_apis::WindowType::WIDGET;
-    const WindowID window_id = i + 1;
-    const auto window_name = std::string("Widget ") + std::to_string(window_id);
-    requests.push_back(
-        CreateStubCreateWindowRequest(window_name, window_id, window_type));
-    responses.push_back(CreateStubCreateWindowResponse(
-        window_id, hmi_apis::Common_Result::SUCCESS));
-    EXPECT_CALL(mock_app_mngr_, CreateRegularState(_, window_type, _, _, _, _))
-        .WillRepeatedly(Return(nullptr));
-    EXPECT_CALL(*mock_app_, SetInitialState(window_id, window_name, _));
-    EXPECT_CALL(mock_state_controller_,
-                OnAppWindowAdded(_, window_id, window_type, _));
-  }
-
-  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateUICreateWindowRequestsToHMI(_, _, _))
-      .WillOnce(Return(requests));
-
-  ON_CALL(mock_app_mngr_, GetRPCService())
-      .WillByDefault(ReturnRef(mock_rpc_service_));
-  EXPECT_CALL(mock_rpc_service_,
-              ManageHMICommand(_, commands::Command::SOURCE_SDL_TO_HMI))
-      .Times(count_of_widgets)
-      .WillRepeatedly(Return(true));
-  res_ctrl_->RestoreAppWidgets(mock_app_, saved_app);
-  for (const auto& response : responses) {
-    res_ctrl_->RestoreWidgetsHMIState(*response);
-  }
-}
-
-TEST_F(ResumeCtrlTest,
-       RestoreAppWidgets_AppWithoutWidgets_NoCreateWindowRqSent) {
-  smart_objects::SmartObject saved_app;
-  saved_app[strings::hash_id] = kHash_;
-  saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
-  saved_app[application_manager::strings::hmi_level] = eType::HMI_FULL;
-
-  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateUICreateWindowRequestsToHMI(_, _, _))
-      .Times(0);
-
-  res_ctrl_->RestoreAppWidgets(mock_app_, saved_app);
-}
-
-TEST_F(ResumeCtrlTest, RestoreWidgetsHMIState_HMIResponseWith_InvalidCorrId) {
-  smart_objects::SmartObject saved_app;
-  saved_app[strings::hash_id] = kHash_;
-  saved_app[strings::windows_info] = smart_objects::SmartObject();
-  saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
-  saved_app[application_manager::strings::hmi_level] = eType::HMI_FULL;
-
-  const int32_t invalid_corr_id = -1;
-  auto response = CreateStubCreateWindowResponse(
-      invalid_corr_id, hmi_apis::Common_Result::SUCCESS);
-
-  ON_CALL(mock_app_mngr_, application_by_hmi_app(kDefaultHmiAppId))
-      .WillByDefault(Return(mock_app_));
-
-  DisplayCapabilitiesBuilder builder(*mock_app_);
-  ON_CALL(*mock_app_, display_capabilities_builder())
-      .WillByDefault(ReturnRef(builder));
-
-  smart_objects::SmartObjectList requests;
-
-  const auto window_type = mobile_apis::WindowType::WIDGET;
-  const WindowID window_id = 1;
-  const auto window_name = std::string("Widget ") + std::to_string(window_id);
-  requests.push_back(
-      CreateStubCreateWindowRequest(window_name, window_id, window_type));
-
-  EXPECT_CALL(mock_app_mngr_, CreateRegularState(_, window_type, _, _, _, _))
-      .Times(0);
-  EXPECT_CALL(*mock_app_, SetInitialState(window_id, window_name, _)).Times(0);
-  EXPECT_CALL(mock_state_controller_,
-              OnAppWindowAdded(_, window_id, window_type, _))
-      .Times(0);
-
-  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateUICreateWindowRequestsToHMI(_, _, _))
-      .WillOnce(Return(requests));
-
-  ON_CALL(mock_app_mngr_, GetRPCService())
-      .WillByDefault(ReturnRef(mock_rpc_service_));
-  EXPECT_CALL(mock_rpc_service_,
-              ManageHMICommand(_, commands::Command::SOURCE_SDL_TO_HMI))
-      .WillRepeatedly(Return(true));
-  res_ctrl_->RestoreAppWidgets(mock_app_, saved_app);
-  res_ctrl_->RestoreWidgetsHMIState(*response);
-}
-
-TEST_F(ResumeCtrlTest, RestoreWidgetsHMIState_HMIResponseWith_Unsuccess) {
-  smart_objects::SmartObject saved_app;
-  saved_app[strings::hash_id] = kHash_;
-  saved_app[strings::windows_info] = smart_objects::SmartObject();
-  saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
-  saved_app[application_manager::strings::hmi_level] = eType::HMI_FULL;
-
-  const int32_t correlation_id = 1;
-  auto response = CreateStubCreateWindowResponse(
-      correlation_id, hmi_apis::Common_Result::GENERIC_ERROR);
-
-  ON_CALL(mock_app_mngr_, application_by_hmi_app(kDefaultHmiAppId))
-      .WillByDefault(Return(mock_app_));
-
-  DisplayCapabilitiesBuilder builder(*mock_app_);
-  smart_objects::SmartObject stub_window_info(smart_objects::SmartType_Null);
-  auto stub_resume_cb = [](Application&, const smart_objects::SmartObject&) {};
-  builder.InitBuilder(stub_resume_cb, stub_window_info);
-  ON_CALL(*mock_app_, display_capabilities_builder())
-      .WillByDefault(ReturnRef(builder));
-
-  smart_objects::SmartObjectList requests;
-  smart_objects::SmartObjectList responses;
-
-  const auto window_type = mobile_apis::WindowType::WIDGET;
-  const WindowID window_id = 1;
-  const auto window_name = std::string("Widget ") + std::to_string(window_id);
-  requests.push_back(
-      CreateStubCreateWindowRequest(window_name, window_id, window_type));
-
-  EXPECT_CALL(mock_app_mngr_, CreateRegularState(_, window_type, _, _, _, _))
-      .Times(0);
-  EXPECT_CALL(*mock_app_, SetInitialState(window_id, window_name, _)).Times(0);
-  EXPECT_CALL(mock_state_controller_,
-              OnAppWindowAdded(_, window_id, window_type, _))
-      .Times(0);
-
-  EXPECT_CALL(*application_manager::MockMessageHelper::message_helper_mock(),
-              CreateUICreateWindowRequestsToHMI(_, _, _))
-      .WillOnce(Return(requests));
-
-  ON_CALL(mock_app_mngr_, GetRPCService())
-      .WillByDefault(ReturnRef(mock_rpc_service_));
-  EXPECT_CALL(mock_rpc_service_,
-              ManageHMICommand(_, commands::Command::SOURCE_SDL_TO_HMI))
-      .WillRepeatedly(Return(true));
-  res_ctrl_->RestoreAppWidgets(mock_app_, saved_app);
-  res_ctrl_->RestoreWidgetsHMIState(*response);
 }
 
 TEST_F(ResumeCtrlTest, StartResumptionOnlyHMILevel) {

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -1021,6 +1021,11 @@ class StateControllerImplTest : public ::testing::Test {
     CheckAppConfiguration();
     FillStatesLists();
     SetConnection();
+
+    ON_CALL(message_helper_mock_, CreateHMIStatusNotification(_, _))
+        .WillByDefault(Return(std::make_shared<smart_objects::SmartObject>()));
+    ON_CALL(app_manager_mock_, GetRPCService())
+        .WillByDefault(ReturnRef(mock_rpc_service_));
   }
 
   void TearDown() OVERRIDE {
@@ -1089,12 +1094,14 @@ class StateControllerImplTest : public ::testing::Test {
     EXPECT_CALL(*app_mock, CurrentHmiState(window_id))
         .WillOnce(Return(old_state))
         .WillOnce(Return(new_state));
+    ON_CALL(*app_mock, IsFullscreen()).WillByDefault(Return(true));
     EXPECT_CALL(
         *app_mock,
         SetRegularState(window_id, Truly(HmiStatesComparator(new_state))));
     if (!HmiStatesComparator(old_state)(new_state)) {
       EXPECT_CALL(message_helper_mock_,
-                  SendHMIStatusNotification(app, window_id, _));
+                  CreateHMIStatusNotification(app, window_id))
+          .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
       if (kDefaultWindowId == window_id) {
         EXPECT_CALL(app_manager_mock_,
                     OnHMIStateChanged(app->app_id(), _, new_state));
@@ -1110,6 +1117,7 @@ class StateControllerImplTest : public ::testing::Test {
     EXPECT_CALL(*app_mock, RegularHmiState(kDefaultWindowId))
         .WillOnce(Return(old_state))
         .WillOnce(Return(old_state));
+    ON_CALL(*app_mock, IsFullscreen()).WillByDefault(Return(true));
     ExpectSuccessfulSetHmiState(app, app_mock, old_state, new_state);
   }
 
@@ -1120,7 +1128,7 @@ class StateControllerImplTest : public ::testing::Test {
       am::HmiStatePtr state) {
     ON_CALL(*app_mock, RegularHmiState(window_id)).WillByDefault(Return(state));
     EXPECT_CALL(message_helper_mock_,
-                SendHMIStatusNotification(app, window_id, _))
+                CreateHMIStatusNotification(app, window_id))
         .Times(0);
     EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(app->app_id(), _, _))
         .Times(0);
@@ -1364,7 +1372,6 @@ class StateControllerImplTest : public ::testing::Test {
 };
 
 TEST_F(StateControllerImplTest, OnStateChangedWithEqualStates) {
-  EXPECT_CALL(app_manager_mock_, SendHMIStatusNotification(_)).Times(0);
   EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(_, _, _)).Times(0);
   EXPECT_CALL(*simple_app_ptr_, ResetDataInNone()).Times(0);
 
@@ -1381,9 +1388,9 @@ TEST_F(StateControllerImplTest, OnStateChangedWithDifferentStates) {
     for (uint32_t j = 0; j < valid_states_for_not_audio_app_.size(); ++j) {
       HmiStatesComparator comp(valid_states_for_not_audio_app_[i]);
       if (!comp(valid_states_for_not_audio_app_[j])) {
-        EXPECT_CALL(
-            message_helper_mock_,
-            SendHMIStatusNotification(simple_app_, kDefaultWindowId, _));
+        EXPECT_CALL(message_helper_mock_,
+                    CreateHMIStatusNotification(simple_app_, kDefaultWindowId))
+            .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
         EXPECT_CALL(app_manager_mock_,
                     OnHMIStateChanged(simple_app_id_,
                                       valid_states_for_not_audio_app_[i],
@@ -1398,7 +1405,7 @@ TEST_F(StateControllerImplTest, OnStateChangedWithDifferentStates) {
                                     valid_states_for_not_audio_app_[i],
                                     valid_states_for_not_audio_app_[j]);
 
-        EXPECT_CALL(message_helper_mock_, SendHMIStatusNotification(_, _, _))
+        EXPECT_CALL(message_helper_mock_, CreateHMIStatusNotification(_, _))
             .Times(0);
         EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(_, _, _)).Times(0);
         EXPECT_CALL(*simple_app_ptr_, ResetDataInNone()).Times(0);
@@ -1421,11 +1428,18 @@ TEST_F(StateControllerImplTest, OnStateChangedToNone) {
                      VideoStreamingState::NOT_STREAMABLE,
                      SystemContext::SYSCTXT_MAIN);
 
+  EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _))
+      .Times(2)
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(_, _, _)).Times(2);
+
   EXPECT_CALL(*simple_app_ptr_, ResetDataInNone()).Times(0);
+
   state_ctrl_->OnStateChanged(
       simple_app_, kDefaultWindowId, none_state, not_none_state);
 
   EXPECT_CALL(*simple_app_ptr_, ResetDataInNone()).Times(1);
+
   state_ctrl_->OnStateChanged(
       simple_app_, kDefaultWindowId, not_none_state, none_state);
 }
@@ -1449,7 +1463,9 @@ TEST_F(StateControllerImplTest, MoveSimpleAppToValidStates) {
         .WillOnce(Return(initial_state))
         .WillOnce(Return(state_to_setup));
     EXPECT_CALL(message_helper_mock_,
-                SendHMIStatusNotification(simple_app_, kDefaultWindowId, _));
+                CreateHMIStatusNotification(simple_app_, kDefaultWindowId))
+        .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+
     EXPECT_CALL(app_manager_mock_,
                 OnHMIStateChanged(simple_app_id_,
                                   Truly(HmiStatesComparator(initial_state)),
@@ -1488,7 +1504,9 @@ TEST_F(StateControllerImplTest, MoveAudioNotResumeAppToValidStates) {
         .WillOnce(Return(initial_state))
         .WillOnce(Return(state_to_setup));
     EXPECT_CALL(message_helper_mock_,
-                SendHMIStatusNotification(audio_app, kDefaultWindowId, _));
+                CreateHMIStatusNotification(audio_app, kDefaultWindowId))
+        .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+    ;
     EXPECT_CALL(app_manager_mock_,
                 OnHMIStateChanged(audio_app->app_id(), _, state_to_setup));
 
@@ -1542,8 +1560,6 @@ TEST_F(StateControllerImplTest, MoveAudioResumeAppToValidStates) {
     }
     EXPECT_CALL(app_manager_mock_, active_application())
         .WillRepeatedly(Return(am::ApplicationSharedPtr()));
-    EXPECT_CALL(app_manager_mock_, SendHMIStatusNotification(audio_app))
-        .Times(AtLeast(0));
     EXPECT_CALL(app_manager_mock_,
                 OnHMIStateChanged(audio_app->app_id(), _, state_to_setup))
         .Times(AtLeast(0));
@@ -2147,8 +2163,6 @@ TEST_F(StateControllerImplTest, SendEventBCActivateApp_HMIReceivesError) {
     EXPECT_CALL(*simple_app_ptr_, SetRegularState(kDefaultWindowId, _))
         .Times(0);
 
-    EXPECT_CALL(app_manager_mock_, SendHMIStatusNotification(simple_app_))
-        .Times(0);
     EXPECT_CALL(app_manager_mock_,
                 OnHMIStateChanged(simple_app_->app_id(), _, _))
         .Times(0);
@@ -2172,8 +2186,6 @@ TEST_F(StateControllerImplTest, ActivateAppInvalidCorrelationId) {
   EXPECT_CALL(app_manager_mock_, application_by_hmi_app(hmi_app_id))
       .WillOnce(Return(am::ApplicationSharedPtr()));
   EXPECT_CALL(*simple_app_ptr_, SetRegularState(kDefaultWindowId, _)).Times(0);
-  EXPECT_CALL(app_manager_mock_, SendHMIStatusNotification(simple_app_))
-      .Times(0);
   EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(simple_app_->app_id(), _, _))
       .Times(0);
   SetBCActivateAppRequestToHMI(Common_HMILevel::FULL, corr_id);
@@ -3309,7 +3321,9 @@ TEST_F(StateControllerImplTest, OnApplicationRegisteredDifferentStates) {
 
   EXPECT_CALL(*simple_app_ptr_, ResetDataInNone()).Times(0);
   EXPECT_CALL(message_helper_mock_,
-              SendHMIStatusNotification(simple_app_, kDefaultWindowId, _));
+              CreateHMIStatusNotification(simple_app_, kDefaultWindowId))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+  ;
   EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(_, _, _));
 
   state_ctrl_->OnApplicationRegistered(simple_app_,
@@ -3360,7 +3374,6 @@ TEST_F(StateControllerImplTest, OnApplicationRegisteredEqualStates) {
       .WillRepeatedly(Return(default_state));
 
   EXPECT_CALL(*simple_app_ptr_, ResetDataInNone()).Times(0);
-  EXPECT_CALL(app_manager_mock_, SendHMIStatusNotification(_)).Times(0);
   EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(_, _, _)).Times(0);
 
   state_ctrl_->OnApplicationRegistered(simple_app_,
@@ -3611,7 +3624,9 @@ TEST_F(
       SetRegularState(kCustomWindowId,
                       Truly(HmiStatesComparator(expected_window_state))));
   EXPECT_CALL(message_helper_mock_,
-              SendHMIStatusNotification(media_app_, kCustomWindowId, _));
+              CreateHMIStatusNotification(media_app_, kCustomWindowId))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+  ;
 
   state_ctrl_->ActivateDefaultWindow(media_app_);
 }
@@ -3644,7 +3659,9 @@ TEST_F(StateControllerImplTest,
       SetRegularState(kCustomWindowId,
                       Truly(HmiStatesComparator(expected_window_state))));
   EXPECT_CALL(message_helper_mock_,
-              SendHMIStatusNotification(media_app_, kCustomWindowId, _));
+              CreateHMIStatusNotification(media_app_, kCustomWindowId))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+  ;
 
   state_ctrl_->ExitDefaultWindow(media_app_);
 }
@@ -3676,11 +3693,16 @@ TEST_F(StateControllerImplTest,
   EXPECT_CALL(*simple_app_ptr_,
               SetRegularState(kCustomWindowId,
                               Truly(HmiStatesComparator(expected_state))));
+  EXPECT_CALL(*simple_app_ptr_,
+              CurrentHmiState(mobile_apis::PredefinedWindows::DEFAULT_WINDOW))
+      .WillOnce(Return(expected_state));
   EXPECT_CALL(*simple_app_ptr_, CurrentHmiState(kCustomWindowId))
       .WillOnce(Return(initial_state))
       .WillOnce(Return(expected_state));
   EXPECT_CALL(message_helper_mock_,
-              SendHMIStatusNotification(simple_app_, kCustomWindowId, _));
+              CreateHMIStatusNotification(simple_app_, kCustomWindowId))
+      .WillOnce(Return(std::make_shared<smart_objects::SmartObject>()));
+  ;
   EXPECT_CALL(app_manager_mock_, OnHMIStateChanged(_, _, _)).Times(0);
 
   state_ctrl_->OnAppWindowAdded(simple_app_,

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -89,6 +89,7 @@ class Application;
 class AppServiceManager;
 class StateControllerImpl;
 struct CommandParametersPermissions;
+struct ResetGlobalPropertiesResult;
 using policy::RPCParams;
 typedef std::vector<ApplicationSharedPtr> AppSharedPtrs;
 struct ApplicationsSorter {
@@ -352,11 +353,11 @@ class ApplicationManager {
 
   /**
    * @brief Checks if Application is subscribed for way points
-   * @param Application pointer
+   * @param Application reference
    * @return true if Application is subscribed for way points
    * otherwise false
    */
-  virtual bool IsAppSubscribedForWayPoints(ApplicationSharedPtr app) const = 0;
+  virtual bool IsAppSubscribedForWayPoints(Application& app) const = 0;
 
   /**
    * @brief Subscribe Application for way points
@@ -584,6 +585,26 @@ class ApplicationManager {
   virtual bool IsStopping() const = 0;
 
   virtual void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) = 0;
+
+  /**
+   * @brief Resets application's global properties to default values
+   * @param global_properties_ids container with global properties IDs to reset
+   * @param app_id ID of app which properties to reset
+   * @return struct with flags indicating success global properties reset
+   */
+  virtual ResetGlobalPropertiesResult ResetGlobalProperties(
+      const smart_objects::SmartObject& global_properties_ids,
+      const uint32_t app_id) = 0;
+
+  /**
+   * @brief Resets all application's global properties to default values
+   * returning struct that indicates which properties have been
+   * successfully reset.
+   * @param app_id ID of app which properties to reset
+   * @return struct with flags indicating global properties reset
+   */
+  virtual ResetGlobalPropertiesResult ResetAllApplicationGlobalProperties(
+      const uint32_t app_id) = 0;
 
   virtual mobile_apis::Result::eType SaveBinary(
       const std::vector<uint8_t>& binary_data,

--- a/src/components/include/application_manager/state_controller.h
+++ b/src/components/include/application_manager/state_controller.h
@@ -223,6 +223,20 @@ class StateController {
    * @param app pointer to application to be exited
    */
   virtual void ExitDefaultWindow(ApplicationSharedPtr app) = 0;
+
+  /**
+   * @brief ResumePostponedWindows resumes adding of all postponed windows for a
+   * specified application, if exists
+   * @param app_id id of application to check
+   */
+  virtual void ResumePostponedWindows(const uint32_t app_id) = 0;
+
+  /**
+   * @brief DropPostponedWindows drops all postponed windows for a specified
+   * application, if exists
+   * @param app_id id of application to check
+   */
+  virtual void DropPostponedWindows(const uint32_t app_id) = 0;
 };
 
 }  // namespace application_manager

--- a/src/components/include/test/application_manager/mock_app_extension.h
+++ b/src/components/include/test/application_manager/mock_app_extension.h
@@ -50,9 +50,13 @@ class MockAppExtension : public application_manager::AppExtension {
   MOCK_METHOD1(SaveResumptionData,
                void(ns_smart_device_link::ns_smart_objects::SmartObject&
                         resumption_data));
-  MOCK_METHOD1(ProcessResumption,
+  MOCK_METHOD2(ProcessResumption,
                void(const ns_smart_device_link::ns_smart_objects::SmartObject&
-                        resumption_data));
+                        resumption_data,
+                    resumption::Subscriber subscriber));
+  MOCK_METHOD1(RevertResumption,
+               void(const ns_smart_device_link::ns_smart_objects::SmartObject&
+                        subscriptions));
 };
 
 }  // namespace application_manager_test

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -155,9 +155,6 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(const protocol_handler::ServiceType service_type,
                     const uint32_t app_id,
                     const bool streaming_data_available));
-  MOCK_METHOD1(
-      SendHMIStatusNotification,
-      void(const std::shared_ptr<application_manager::Application> app));
   MOCK_METHOD1(SendDriverDistractionState,
                void(application_manager::ApplicationSharedPtr app));
   MOCK_METHOD2(SendGetIconUrlNotifications,
@@ -232,6 +229,13 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(IsStopping, bool());
   MOCK_METHOD1(RemoveAppFromTTSGlobalPropertiesList,
                void(const uint32_t app_id));
+  MOCK_METHOD2(ResetGlobalProperties,
+               application_manager::ResetGlobalPropertiesResult(
+                   const smart_objects::SmartObject& global_properties_ids,
+                   const uint32_t app_id));
+  MOCK_METHOD1(
+      ResetAllApplicationGlobalProperties,
+      application_manager::ResetGlobalPropertiesResult(const uint32_t app_id));
   MOCK_METHOD4(
       SaveBinary,
       mobile_apis::Result::eType(const std::vector<uint8_t>& binary_data,
@@ -342,7 +346,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                     const smart_objects::SmartObject& display_capabilities));
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints, bool(uint32_t));
   MOCK_CONST_METHOD1(IsAppSubscribedForWayPoints,
-                     bool(application_manager::ApplicationSharedPtr));
+                     bool(application_manager::Application& app));
   MOCK_METHOD1(SubscribeAppForWayPoints, void(uint32_t));
   MOCK_METHOD1(SubscribeAppForWayPoints,
                void(application_manager::ApplicationSharedPtr));

--- a/src/components/include/test/application_manager/mock_state_controller.h
+++ b/src/components/include/test/application_manager/mock_state_controller.h
@@ -108,6 +108,8 @@ class MockStateController : public am::StateController {
   MOCK_CONST_METHOD1(IsStateActive, bool(am::HmiState::StateID state_id));
   MOCK_METHOD1(ActivateDefaultWindow, void(am::ApplicationSharedPtr app));
   MOCK_METHOD1(ExitDefaultWindow, void(am::ApplicationSharedPtr app));
+  MOCK_METHOD1(ResumePostponedWindows, void(const uint32_t app_id));
+  MOCK_METHOD1(DropPostponedWindows, void(const uint32_t app_id));
 };
 
 }  // namespace application_manager_test


### PR DESCRIPTION
Fixes #[6739](https://adc.luxoft.com/jira/browse/FORDTCN-6739)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test scripts provided in https://github.com/LuxoftSDL/sdl_atf_test_scripts/tree/feature/sdl_0190_resumption_data_error_handling

### Summary
Implemented logic of HMI erroneous responses handling during resumption process

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
