### PR TITLE
Add saving ModuleInfo into the resumption data and updating app hash after subscribe/unsubscribe on a VD

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
@@ -36,7 +36,9 @@
 #include <memory>
 #include <set>
 #include <string>
+
 #include "application_manager/app_extension.h"
+#include "application_manager/application.h"
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -139,7 +141,8 @@ struct Grid {
 
 class RCAppExtension : public application_manager::AppExtension {
  public:
-  explicit RCAppExtension(application_manager::AppExtensionUID uid);
+  explicit RCAppExtension(application_manager::AppExtensionUID uid,
+                          application_manager::Application& application);
   ~RCAppExtension();
 
   /**
@@ -197,9 +200,20 @@ class RCAppExtension : public application_manager::AppExtension {
   void SetUserLocation(const Grid& grid);
 
  private:
+  /**
+   * @brief Checks if the application's pointer is valid and update the
+   * application's hash in this case
+   */
+  void UpdateHash();
+
   std::set<ModuleUid> subscribed_interior_vehicle_data_;
 
   Grid user_location_;
+
+  /**
+   * ApplicationSharedPtr needed for updating application's hash
+   */
+  application_manager::Application& application_;
 
   // AppExtension interface
  public:

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -135,7 +135,9 @@ void GetInteriorVehicleDataRequest::ProcessResponseToMobileFromCache(
   if (AppShouldBeUnsubscribed()) {
     auto extension = RCHelpers::GetRCExtension(*app);
     DCHECK(extension);
-    extension->UnsubscribeFromInteriorVehicleData(module);
+    if (extension->IsSubscribedToInteriorVehicleData(module)) {
+      extension->UnsubscribeFromInteriorVehicleData(module);
+    }
   }
 }
 
@@ -260,6 +262,10 @@ void GetInteriorVehicleDataRequest::on_event(
     const ModuleUid module(module_type, module_id);
 
     if (TheLastAppShouldBeUnsubscribed(app)) {
+      LOG4CXX_DEBUG(logger_,
+                    "Removing module: [" << module.first << ":" << module.second
+                                         << "] "
+                                         << "from cache");
       interior_data_cache_.Remove(module);
     }
     ProccessSubscription(hmi_response);
@@ -378,11 +384,13 @@ void GetInteriorVehicleDataRequest::ProccessSubscription(
                                                       << module_id);
       extension->SubscribeToInteriorVehicleData(module);
     } else {
-      LOG4CXX_DEBUG(logger_,
-                    "UnsubscribeFromInteriorVehicleData "
-                        << app->app_id() << " " << module_type << " "
-                        << module_id);
-      extension->UnsubscribeFromInteriorVehicleData(module);
+      if (extension->IsSubscribedToInteriorVehicleData(module)) {
+        LOG4CXX_DEBUG(logger_,
+                      "UnsubscribeFromInteriorVehicleData "
+                          << app->app_id() << " [" << module_type << ":"
+                          << module_id << "]");
+        extension->UnsubscribeFromInteriorVehicleData(module);
+      }
     }
   }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -125,8 +125,8 @@ void RCRPCPlugin::OnApplicationEvent(
   }
   switch (event) {
     case plugins::kApplicationRegistered: {
-      auto extension =
-          std::shared_ptr<RCAppExtension>(new RCAppExtension(kRCPluginID));
+      auto extension = std::shared_ptr<RCAppExtension>(
+          new RCAppExtension(kRCPluginID, *application));
       application->AddExtension(extension);
       const auto driver_location =
           rc_capabilities_manager_

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/CMakeLists.txt
@@ -45,6 +45,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/interior_data_cache_test.cc
 ${CMAKE_CURRENT_SOURCE_DIR}/rc_consent_manager_impl_test.cc
 ${CMAKE_CURRENT_SOURCE_DIR}/grid_test.cc
 ${CMAKE_CURRENT_SOURCE_DIR}/rc_helpers_test.cc
+${CMAKE_CURRENT_SOURCE_DIR}/rc_app_extension_test.cc
 )
 
 set(RC_COMMANDS_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/commands)

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -82,8 +82,8 @@ class ButtonPressRequestTest
       : rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
             smart_objects::SmartType_Map))
       , mock_app_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(
-            std::make_shared<rc_rpc_plugin::RCAppExtension>(kModuleId)) {}
+      , rc_app_extention_(std::make_shared<rc_rpc_plugin::RCAppExtension>(
+            kModuleId, *mock_app_)) {}
 
   void SetUp() OVERRIDE {
     smart_objects::SmartObject control_caps((smart_objects::SmartType_Array));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -92,8 +92,10 @@ class GetInteriorVehicleDataRequestTest
   GetInteriorVehicleDataRequestTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
       , mock_app2_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kModuleId))
-      , rc_app_extention2_(std::make_shared<RCAppExtension>(kModuleId))
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kModuleId, *mock_app_))
+      , rc_app_extention2_(
+            std::make_shared<RCAppExtension>(kModuleId, *mock_app2_))
       , apps_lock_(std::make_shared<sync_primitives::Lock>())
       , apps_da_(apps_, apps_lock_)
       , rc_capabilities_(std::make_shared<smart_objects::SmartObject>(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_interior_vehicle_data_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_interior_vehicle_data_notification_test.cc
@@ -74,7 +74,8 @@ class OnInteriorVehicleDataNotificationTest
  public:
   OnInteriorVehicleDataNotificationTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kModuleId))
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kModuleId, *mock_app_))
       , apps_lock_(std::make_shared<sync_primitives::Lock>())
       , apps_da_(apps_, apps_lock_) {
     ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -119,7 +119,8 @@ class RCGetInteriorVehicleDataConsentTest
                      rpc_protection_manager_,
                      hmi_so_factory_,
                      mobile_so_factoy_)
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kPluginID))
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kPluginID, *mock_app_))
       , mock_rpc_plugin_manager(
             std::make_shared<NiceMock<MockRPCPluginManager> >())
       , rpc_plugin(mock_rpc_plugin)

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -73,7 +73,8 @@ class SetInteriorVehicleDataRequestTest
  public:
   SetInteriorVehicleDataRequestTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
-      , rc_app_extention_(std::make_shared<RCAppExtension>(kModuleId))
+      , rc_app_extention_(
+            std::make_shared<RCAppExtension>(kModuleId, *mock_app_))
       , rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
             smart_objects::SmartType::SmartType_Array)) {}
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/rc_app_extension_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/rc_app_extension_test.cc
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rc_rpc_plugin/rc_app_extension.h"
+
+#include <memory>
+#include <string>
+
+#include "application_manager/mock_application.h"
+#include "gtest/gtest.h"
+#include "rc_rpc_plugin/rc_module_constants.h"
+
+namespace {
+const uint32_t kRCAppExtensionId = 1ull;
+}  // namespace
+
+namespace test {
+namespace components {
+namespace rc_rpc_plugin_test {
+namespace rc_app_extension_test {
+
+using test::components::application_manager_test::MockApplication;
+using ::testing::NiceMock;
+
+class RcAppExtensionTest : public testing::Test {
+ public:
+  RcAppExtensionTest()
+      : mock_app_(new NiceMock<MockApplication>())
+      , rc_app_extension_(std::make_shared<rc_rpc_plugin::RCAppExtension>(
+            kRCAppExtensionId, *mock_app_)) {}
+
+ protected:
+  std::unique_ptr<MockApplication> mock_app_;
+  rc_rpc_plugin::RCAppExtensionPtr rc_app_extension_;
+};
+
+TEST_F(RcAppExtensionTest, SubscribeToInteriorVehicleData_AppUpdateHash) {
+  const std::string module_type = "CLIMATE";
+  const std::string module_id = "9cb963f3-c5e8-41cb-b001-19421cc16552";
+  rc_rpc_plugin::ModuleUid module{module_type, module_id};
+
+  EXPECT_CALL(*mock_app_, UpdateHash());
+
+  rc_app_extension_->SubscribeToInteriorVehicleData(module);
+  EXPECT_TRUE(rc_app_extension_->IsSubscribedToInteriorVehicleData(module));
+
+  auto subscription = rc_app_extension_->InteriorVehicleDataSubscriptions();
+  EXPECT_EQ(1ull, subscription.size());
+}
+
+TEST_F(RcAppExtensionTest, UnsubscribeFromInteriorVehicleData_AppUpdateHash) {
+  const std::string module_type = "CLIMATE";
+  const std::string module_id = "9cb963f3-c5e8-41cb-b001-19421cc16552";
+  rc_rpc_plugin::ModuleUid module{module_type, module_id};
+
+  EXPECT_CALL(*mock_app_, UpdateHash());
+  rc_app_extension_->SubscribeToInteriorVehicleData(module);
+
+  EXPECT_CALL(*mock_app_, UpdateHash());
+  rc_app_extension_->UnsubscribeFromInteriorVehicleData(module);
+
+  EXPECT_FALSE(rc_app_extension_->IsSubscribedToInteriorVehicleData(module));
+
+  auto subscription = rc_app_extension_->InteriorVehicleDataSubscriptions();
+  EXPECT_TRUE(subscription.empty());
+}
+
+TEST_F(RcAppExtensionTest,
+       UnsubscribeFromInteriorVehicleDataOfType_AppUpdateHash) {
+  const std::string module1_type = "CLIMATE";
+  const std::string module1_id = "9cb963f3-c5e8-41cb-b001-19421cc16552";
+  rc_rpc_plugin::ModuleUid module1{module1_type, module1_id};
+
+  const std::string module2_type = "RADIO";
+  const std::string module2_id = "357a3918-9f35-4d86-a8b6-60cd4308d76f";
+  rc_rpc_plugin::ModuleUid module2{module2_type, module2_id};
+
+  EXPECT_CALL(*mock_app_, UpdateHash()).Times(2);
+  rc_app_extension_->SubscribeToInteriorVehicleData(module1);
+  rc_app_extension_->SubscribeToInteriorVehicleData(module2);
+
+  EXPECT_CALL(*mock_app_, UpdateHash());
+  rc_app_extension_->UnsubscribeFromInteriorVehicleDataOfType(module1_type);
+
+  EXPECT_FALSE(
+      rc_app_extension_->IsSubscribedToInteriorVehicleDataOfType(module1_type));
+  EXPECT_TRUE(
+      rc_app_extension_->IsSubscribedToInteriorVehicleDataOfType(module2_type));
+
+  auto subscription = rc_app_extension_->InteriorVehicleDataSubscriptions();
+  EXPECT_EQ(1ull, subscription.size());
+}
+
+TEST_F(RcAppExtensionTest,
+       UnsubscribeFromInteriorVehicleDataOfType_UNSUCCESS_AppDoesntUpdateHash) {
+  const std::string module1_type = "CLIMATE";
+  const std::string module_id = "9cb963f3-c5e8-41cb-b001-19421cc16552";
+  rc_rpc_plugin::ModuleUid module{module1_type, module_id};
+
+  const std::string module2_type = "RADIO";
+
+  EXPECT_CALL(*mock_app_, UpdateHash());
+  rc_app_extension_->SubscribeToInteriorVehicleData(module);
+
+  EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
+  rc_app_extension_->UnsubscribeFromInteriorVehicleDataOfType(module2_type);
+
+  EXPECT_TRUE(rc_app_extension_->IsSubscribedToInteriorVehicleData(module));
+
+  auto subscription = rc_app_extension_->InteriorVehicleDataSubscriptions();
+  EXPECT_EQ(1ull, subscription.size());
+}
+
+TEST_F(RcAppExtensionTest, SaveResumptionData_SUCCESS) {
+  using namespace rc_rpc_plugin;
+
+  const std::string module1_type = "CLIMATE";
+  const std::string module1_id = "9cb963f3-c5e8-41cb-b001-19421cc16552";
+  ModuleUid module1{module1_type, module1_id};
+
+  const std::string module2_type = "RADIO";
+  const std::string module2_id = "357a3918-9f35-4d86-a8b6-60cd4308d76f";
+  ModuleUid module2{module2_type, module2_id};
+
+  std::set<ModuleUid> module_data{module1, module2};
+
+  EXPECT_CALL(*mock_app_, UpdateHash()).Times(2);
+  rc_app_extension_->SubscribeToInteriorVehicleData(module1);
+  rc_app_extension_->SubscribeToInteriorVehicleData(module2);
+
+  const auto subscriptions =
+      rc_app_extension_->InteriorVehicleDataSubscriptions();
+
+  auto subscription_so =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+
+  rc_app_extension_->SaveResumptionData(subscription_so);
+
+  const uint32_t lenght = subscription_so[message_params::kModuleData].length();
+
+  EXPECT_EQ(lenght, subscriptions.size());
+
+  for (uint32_t index = 0; index < lenght; ++index) {
+    auto module_so = subscription_so[message_params::kModuleData][index];
+    const auto module_type = module_so[message_params::kModuleType].asString();
+    const auto module_id = module_so[message_params::kModuleId].asString();
+
+    ModuleUid module{module_type, module_id};
+
+    auto found_module =
+        std::find(subscriptions.begin(), subscriptions.end(), module);
+
+    EXPECT_EQ(module_type, found_module->first);
+    EXPECT_EQ(module_id, found_module->second);
+  }
+}
+
+}  // namespace rc_app_extension_test
+}  // namespace rc_rpc_plugin_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager/resource_allocation_manager_impl_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/resource_allocation_manager/resource_allocation_manager_impl_test.cc
@@ -113,7 +113,8 @@ class RAManagerTest : public ::testing::Test {
     ON_CALL(mock_app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_));
     auto plugin_id = rc_rpc_plugin::RCRPCPlugin::kRCPluginID;
-    app_ext_ptr_ = std::make_shared<rc_rpc_plugin::RCAppExtension>(plugin_id);
+    app_ext_ptr_ = std::make_shared<rc_rpc_plugin::RCAppExtension>(
+        plugin_id, *mock_app_1_);
     ON_CALL(*mock_app_1_, app_id()).WillByDefault(Return(kAppId1));
 
     PrepareResources();
@@ -144,7 +145,8 @@ class RAManagerTest : public ::testing::Test {
   void SetUp() OVERRIDE {
     rc_app_extension_ = std::make_shared<rc_rpc_plugin::RCAppExtension>(
         static_cast<application_manager::AppExtensionUID>(
-            rc_rpc_plugin::RCRPCPlugin::kRCPluginID));
+            rc_rpc_plugin::RCRPCPlugin::kRCPluginID),
+        *mock_app_1_);
     ON_CALL(mock_rc_capabilities_manager_,
             GetDriverLocationFromSeatLocationCapability())
         .WillByDefault(Return(kDriverLocation));
@@ -403,9 +405,10 @@ TEST_F(RAManagerTest, AppUnregistered_ReleaseResource) {
       mock_app_mngr_, mock_rpc_service_, mock_rc_capabilities_manager_);
   ra_manager.SetAccessMode(hmi_apis::Common_RCAccessMode::eType::AUTO_DENY);
 
-  RCAppExtensionPtr rc_extention_ptr =
-      std::make_shared<RCAppExtension>(application_manager::AppExtensionUID(
-          rc_rpc_plugin::RCRPCPlugin::kRCPluginID));
+  RCAppExtensionPtr rc_extention_ptr = std::make_shared<RCAppExtension>(
+      application_manager::AppExtensionUID(
+          rc_rpc_plugin::RCRPCPlugin::kRCPluginID),
+      *mock_app_1_);
 
   EXPECT_EQ(rc_rpc_plugin::AcquireResult::ALLOWED,
             ra_manager.AcquireResource(kModuleType1, kModuleId, kAppId1));
@@ -477,9 +480,10 @@ TEST_F(RAManagerTest, AppsDisallowed_ReleaseAllResources) {
 
   EXPECT_CALL(mock_app_mngr_, applications()).WillRepeatedly(Return(apps_da));
 
-  RCAppExtensionPtr rc_extention_ptr =
-      std::make_shared<RCAppExtension>(application_manager::AppExtensionUID(
-          rc_rpc_plugin::RCRPCPlugin::kRCPluginID));
+  RCAppExtensionPtr rc_extention_ptr = std::make_shared<RCAppExtension>(
+      application_manager::AppExtensionUID(
+          rc_rpc_plugin::RCRPCPlugin::kRCPluginID),
+      *mock_app_1_);
 
   EXPECT_CALL(*mock_app_1_, QueryInterface(RCRPCPlugin::kRCPluginID))
       .WillRepeatedly(Return(rc_extention_ptr));
@@ -511,7 +515,8 @@ TEST_F(RAManagerTest, AppGotRevokedModulesWithPTU_ReleaseRevokedResource) {
   RCAppExtensionPtr rc_extention_ptr =
       std::make_shared<rc_rpc_plugin::RCAppExtension>(
           application_manager::AppExtensionUID(
-              rc_rpc_plugin::RCRPCPlugin::kRCPluginID));
+              rc_rpc_plugin::RCRPCPlugin::kRCPluginID),
+          *mock_app_1_);
 
   EXPECT_CALL(*mock_app_1_, QueryInterface(RCRPCPlugin::kRCPluginID))
       .WillRepeatedly(Return(rc_extention_ptr));


### PR DESCRIPTION
Fixes [FORDTCN-7210](https://adc.luxoft.com/jira/browse/FORDTCN-7210)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR provides the next changes:
- Saving ModuleInfo into the resumption data;
- Updated hash after subscribe/unsubscribe on a VD;


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
