### PR TITLE
Fix problem with OnSCU notification during resumption with only main window

### DIFF
--- a/src/components/application_manager/include/application_manager/display_capabilities_builder.h
+++ b/src/components/application_manager/include/application_manager/display_capabilities_builder.h
@@ -94,6 +94,14 @@ class DisplayCapabilitiesBuilder {
    */
   const smart_objects::SmartObjectSPtr display_capabilities() const;
 
+  /**
+   * @brief is_window_resumption_needed checks that is there a need for
+   * resumption of windows (except main window)
+   * @return true if data about windows to be resumed was saved in window_info,
+   * otherwise returns false
+   */
+  bool is_window_resumption_needed() const;
+
  private:
   /**
    * @brief InvokeCallbackFunction invokes callback function if all required
@@ -107,6 +115,7 @@ class DisplayCapabilitiesBuilder {
   Application& owner_;
   ResumeCallback resume_callback_;
   sync_primitives::Lock display_capabilities_lock_;
+  bool is_widget_windows_resumption_;
 };
 }  // namespace application_manager
 #endif

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
@@ -208,13 +208,14 @@ void OnSystemCapabilityUpdatedNotification::Run() {
     if (mobile_apis::SystemCapabilityType::DISPLAYS == system_capability_type) {
       LOG4CXX_DEBUG(logger_, "Using common display capabilities");
       auto capabilities = hmi_capabilities_.system_display_capabilities();
-      if (app->is_resuming() && app->is_app_data_resumption_allowed()) {
+
+      auto& builder = app->display_capabilities_builder();
+      if (app->is_resuming() && builder.is_window_resumption_needed()) {
         LOG4CXX_DEBUG(logger_,
                       "Application "
                           << app->app_id()
                           << " is resuming. Providing cached capabilities");
-        auto display_caps =
-            app->display_capabilities_builder().display_capabilities();
+        auto display_caps = builder.display_capabilities();
         capabilities = display_caps;
       } else if (app->display_capabilities()) {
         LOG4CXX_DEBUG(logger_,

--- a/src/components/application_manager/src/display_capabilities_builder.cc
+++ b/src/components/application_manager/src/display_capabilities_builder.cc
@@ -42,7 +42,7 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "DisplayCapabilitiesBuilder")
 const WindowID kDefaultWindowID = 0;
 
 DisplayCapabilitiesBuilder::DisplayCapabilitiesBuilder(Application& application)
-    : owner_(application) {
+    : owner_(application), is_widget_windows_resumption_(false) {
   LOG4CXX_AUTO_TRACE(logger_);
 }
 
@@ -53,6 +53,8 @@ void DisplayCapabilitiesBuilder::InitBuilder(
   sync_primitives::AutoLock lock(display_capabilities_lock_);
   resume_callback_ = resume_callback;
   window_ids_to_resume_.insert(kDefaultWindowID);
+  is_widget_windows_resumption_ = !windows_info.empty();
+
   for (size_t i = 0; i < windows_info.length(); ++i) {
     auto window_id = windows_info[i][strings::window_id].asInt();
     LOG4CXX_DEBUG(logger_,
@@ -100,6 +102,10 @@ const smart_objects::SmartObjectSPtr
 DisplayCapabilitiesBuilder::display_capabilities() const {
   LOG4CXX_AUTO_TRACE(logger_);
   return display_capabilities_;
+}
+
+bool DisplayCapabilitiesBuilder::is_window_resumption_needed() const {
+  return is_widget_windows_resumption_;
 }
 
 void DisplayCapabilitiesBuilder::InvokeCallbackFunction() {
@@ -181,8 +187,7 @@ void DisplayCapabilitiesBuilder::StopWaitingForWindow(
     const WindowID window_id) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(display_capabilities_lock_);
-  LOG4CXX_DEBUG(logger_,
-                "Window id " << window_id << " will be erased due to failure");
+  LOG4CXX_DEBUG(logger_, "Window id " << window_id << " will be erased");
   window_ids_to_resume_.erase(window_id);
 
   InvokeCallbackFunction();


### PR DESCRIPTION
Fixes #[7166](https://adc.luxoft.com/jira/browse/FORDTCN-7166)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
There was a gap in logic of processing resuming app, which has only main window, which is not cached. Before we had logic for processing not resumed app with only main window and resuming app, which may have one or more cached windows.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
