### PR TITLE
Fix extension extractions while traversing apps

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc
@@ -157,13 +157,6 @@ void OnSystemCapabilityUpdatedNotification::Run() {
       [&system_capability_type,
        &initial_connection_key](const ApplicationSharedPtr app) {
         DCHECK_OR_RETURN(app, false);
-        auto& ext = SystemCapabilityAppExtension::ExtractExtension(*app);
-        if (!ext.IsSubscribedTo(system_capability_type)) {
-          LOG4CXX_DEBUG(logger_,
-                        "App " << app->app_id()
-                               << " is not subscribed to this capability type");
-          return false;
-        }
 
         if (mobile_apis::SystemCapabilityType::DISPLAYS ==
                 system_capability_type &&
@@ -172,6 +165,27 @@ void OnSystemCapabilityUpdatedNotification::Run() {
                         "Display capabilities notification for app "
                             << initial_connection_key << " only");
           return app->app_id() == initial_connection_key;
+        }
+
+        auto ext_ptr = app->QueryInterface(
+            SystemCapabilityAppExtension::SystemCapabilityAppExtensionUID);
+
+        if (!ext_ptr) {
+          LOG4CXX_DEBUG(logger_,
+                        "App "
+                            << app->app_id()
+                            << " does not have SystemCapabilityAppExtension");
+          return false;
+        }
+
+        auto ext =
+            std::static_pointer_cast<SystemCapabilityAppExtension>(ext_ptr);
+
+        if (!ext->IsSubscribedTo(system_capability_type)) {
+          LOG4CXX_DEBUG(logger_,
+                        "App " << app->app_id()
+                               << " is not subscribed to this capability type");
+          return false;
         }
 
         LOG4CXX_DEBUG(logger_,


### PR DESCRIPTION
Fixes [#7258](https://adc.luxoft.com/jira/browse/FORDTCN-7258)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF scripts

### Summary
There might be a situation that `applications()` call returns a collection of app pointers including the apps which registration is currently in progress. These applications might have not initialized yet extensions so on attempt to extract some extension
by uid there will be a `DCHECK` error. To avoid that, more protective way to extract app extension was used. Additionally, `DISPLAYS` check has been moved before extension check as it much faster and also avoids redundant checks.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
