### PR TITLE
Impl/vehicle data resumption handler rework

### DIFF
--- a/src/appMain/log4cxx.properties
+++ b/src/appMain/log4cxx.properties
@@ -14,7 +14,7 @@ log4j.appender.SmartDeviceLinkCoreSocketHub.locationInfo=true
 log4j.appender.TelnetLogging=org.apache.log4j.TelnetAppender
 log4j.appender.TelnetLogging.port=6676
 log4j.appender.TelnetLogging.layout=org.apache.log4j.PatternLayout
-log4j.appender.TelnetLogging.layout.ConversionPattern=%-5p [%d{dd MMM yyyy HH:mm:ss,SSS}][%t][%c] %F:%L %M: %m%n
+log4j.appender.TelnetLogging.layout.ConversionPattern= %M: %m%n
 
 # Log file for all SmartDeviceLinkCore messages
 log4j.appender.SmartDeviceLinkCoreLogFile=SafeFileAppender
@@ -23,7 +23,7 @@ log4j.appender.SmartDeviceLinkCoreLogFile.append=true
 log4j.appender.SmartDeviceLinkCoreLogFile.DatePattern='.' yyyy-MM-dd HH-mm
 log4j.appender.SmartDeviceLinkCoreLogFile.ImmediateFlush=true
 log4j.appender.SmartDeviceLinkCoreLogFile.layout=org.apache.log4j.PatternLayout
-log4j.appender.SmartDeviceLinkCoreLogFile.layout.ConversionPattern=%-5p [%d{dd MMM yyyy HH:mm:ss,SSS}][%t][%c] %F:%L %M: %m%n
+log4j.appender.SmartDeviceLinkCoreLogFile.layout.ConversionPattern=%M: %m%n
 
 # Log file for all TransportManager messages
 log4j.appender.TransportManagerLogFile=SafeFileAppender

--- a/src/appMain/log4cxx.properties
+++ b/src/appMain/log4cxx.properties
@@ -14,7 +14,7 @@ log4j.appender.SmartDeviceLinkCoreSocketHub.locationInfo=true
 log4j.appender.TelnetLogging=org.apache.log4j.TelnetAppender
 log4j.appender.TelnetLogging.port=6676
 log4j.appender.TelnetLogging.layout=org.apache.log4j.PatternLayout
-log4j.appender.TelnetLogging.layout.ConversionPattern= %M: %m%n
+log4j.appender.TelnetLogging.layout.ConversionPattern=%-5p [%d{dd MMM yyyy HH:mm:ss,SSS}][%t][%c] %F:%L %M: %m%n
 
 # Log file for all SmartDeviceLinkCore messages
 log4j.appender.SmartDeviceLinkCoreLogFile=SafeFileAppender
@@ -23,7 +23,7 @@ log4j.appender.SmartDeviceLinkCoreLogFile.append=true
 log4j.appender.SmartDeviceLinkCoreLogFile.DatePattern='.' yyyy-MM-dd HH-mm
 log4j.appender.SmartDeviceLinkCoreLogFile.ImmediateFlush=true
 log4j.appender.SmartDeviceLinkCoreLogFile.layout=org.apache.log4j.PatternLayout
-log4j.appender.SmartDeviceLinkCoreLogFile.layout.ConversionPattern=%M: %m%n
+log4j.appender.SmartDeviceLinkCoreLogFile.layout.ConversionPattern=%-5p [%d{dd MMM yyyy HH:mm:ss,SSS}][%t][%c] %F:%L %M: %m%n
 
 # Log file for all TransportManager messages
 log4j.appender.TransportManagerLogFile=SafeFileAppender

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -703,7 +703,6 @@ class MessageHelper {
    * @param function_id id of function
    * @param correlation_id correlation id
    * @param result_code result code
-   * @param info info message
    * @return pointer to created message
    */
   static smart_objects::SmartObjectSPtr CreateResponseMessageFromHmi(

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -699,6 +699,19 @@ class MessageHelper {
       const std::string& info);
 
   /**
+   * @brief Creates negative response message from HMI using provided params
+   * @param function_id id of function
+   * @param correlation_id correlation id
+   * @param result_code result code
+   * @param info info message
+   * @return pointer to created message
+   */
+  static smart_objects::SmartObjectSPtr CreateResponseMessageFromHmi(
+      const int32_t function_id,
+      const uint32_t correlation_id,
+      const int32_t result_code);
+
+  /**
    * @brief Get the full file path of an app file
    *
    * @param file_name The relative path of an application file

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/sdl_pending_resumption_handler.h
@@ -28,7 +28,9 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_PLUGIN_INCLUDE_SDL_PLUGIN_SDL_PENDING_RESUMPTION_HANDLER_H
 
+#include <map>
 #include <queue>
+#include <vector>
 #include "application_manager/event_engine/event_observer.h"
 #include "application_manager/resumption/extension_pending_resumption_handler.h"
 #include "application_manager/resumption/resumption_data_processor.h"
@@ -73,7 +75,7 @@ class SDLPendingResumptionHandler
    * the subscriber
    */
   void RaiseFakeSuccessfulResponse(smart_objects::SmartObject response,
-                                   int32_t corr_id);
+                                   const int32_t corr_id);
   smart_objects::SmartObjectSPtr CreateSubscriptionRequest();
   void ClearPendingRequestsMap();
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
@@ -99,7 +99,7 @@ void SDLPendingResumptionHandler::ClearPendingResumptionRequests() {
 
 void SDLPendingResumptionHandler::RaiseFakeSuccessfulResponse(
     ns_smart_device_link::ns_smart_objects::SmartObject response,
-    int32_t corr_id) {
+    const int32_t corr_id) {
   using namespace application_manager;
   response[strings::params][strings::correlation_id] = corr_id;
   auto fid = static_cast<hmi_apis::FunctionID::eType>(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -99,6 +99,8 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
 
   bool AddPendingSubscription(const std::string& vehicle_data);
 
+  bool RemovePendingSubscription(const std::string& vehicle_data);
+
   bool RemovePendingSubscriptions();
 
   const DataAccessor<VehicleInfoSubscriptions> PendingSubscriptions();

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -97,12 +97,34 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
    */
   const DataAccessor<VehicleInfoSubscriptions> Subscriptions();
 
+  /**
+   * @brief AddPendingSubscription add pending subscription
+   * @param vehicle_data subscription to add
+   * @return
+   */
   bool AddPendingSubscription(const std::string& vehicle_data);
 
+  /**
+   * @brief RemovePendingSubscription remove some paticular pending subscription
+   * @param vehicle_data subscription to remove
+   * @return
+   */
   bool RemovePendingSubscription(const std::string& vehicle_data);
 
-  bool RemovePendingSubscriptions();
+  /**
+   * @brief RemovePendingSubscriptions removed all pending subscriptions
+   * @return
+   */
+  void RemovePendingSubscriptions();
 
+  /**
+   * @brief PendingSubscriptions list of preliminary subscriptoins
+   * That will be moved to subscriptions as soon as HMI will respond with
+   * success.
+   * Used for resumption to keep list of preliminary subcriptions and wait for
+   * HMI response
+   * @return
+   */
   const DataAccessor<VehicleInfoSubscriptions> PendingSubscriptions();
 
   /**

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -58,6 +58,8 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
    */
   VehicleInfoAppExtension(VehicleInfoPlugin& plugin,
                           app_mngr::Application& app);
+  VehicleInfoAppExtension(const VehicleInfoAppExtension&) = delete;
+  VehicleInfoAppExtension& operator=(const VehicleInfoAppExtension&) = delete;
   virtual ~VehicleInfoAppExtension();
 
   /**
@@ -94,6 +96,12 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
    * @return list of subscriptions for application extension
    */
   const VehicleInfoSubscriptions& Subscriptions();
+
+  bool AddPendingSubscription(const std::string& vehicle_data);
+
+  bool RemovePendingSubscriptions();
+
+  const VehicleInfoSubscriptions& PendingSubscriptions();
 
   /**
    * @brief SaveResumptionData saves vehicle info data
@@ -134,6 +142,7 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
 
  private:
   VehicleInfoSubscriptions subscribed_data_;
+  VehicleInfoSubscriptions pending_subscriptions_;
   VehicleInfoPlugin& plugin_;
   app_mngr::Application& app_;
 };

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -95,13 +95,13 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
    * @brief Subscriptions get list of subscriptions for application extension
    * @return list of subscriptions for application extension
    */
-  const VehicleInfoSubscriptions& Subscriptions();
+  const DataAccessor<VehicleInfoSubscriptions> Subscriptions();
 
   bool AddPendingSubscription(const std::string& vehicle_data);
 
   bool RemovePendingSubscriptions();
 
-  const VehicleInfoSubscriptions& PendingSubscriptions();
+  const DataAccessor<VehicleInfoSubscriptions> PendingSubscriptions();
 
   /**
    * @brief SaveResumptionData saves vehicle info data
@@ -141,7 +141,10 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
       application_manager::Application& app);
 
  private:
+  mutable std::shared_ptr<sync_primitives::Lock> subscribed_data_lock_;
   VehicleInfoSubscriptions subscribed_data_;
+
+  mutable std::shared_ptr<sync_primitives::Lock> pending_subscriptions_lock_;
   VehicleInfoSubscriptions pending_subscriptions_;
   VehicleInfoPlugin& plugin_;
   app_mngr::Application& app_;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -32,12 +32,13 @@
 
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H
+#include <queue>
 #include "application_manager/event_engine/event_observer.h"
 #include "application_manager/resumption/extension_pending_resumption_handler.h"
+#include "application_manager/resumption/resumption_data_processor.h"
+
+#include "utils/optional.h"
 #include "vehicle_info_app_extension.h"
-
-#include <queue>
-
 namespace vehicle_info_plugin {
 
 namespace app_mngr = application_manager;
@@ -48,7 +49,6 @@ class VehicleInfoPendingResumptionHandler
   VehicleInfoPendingResumptionHandler(
       app_mngr::ApplicationManager& application_manager);
 
-  // EventObserver interface
   void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   void HandleResumptionSubscriptionRequest(app_mngr::AppExtension& extension,
@@ -59,38 +59,67 @@ class VehicleInfoPendingResumptionHandler
       const smart_objects::SmartObject& response,
       const smart_objects::SmartObject& request) const;
 
-  bool IsResumptionResultSuccessful(
-      std::map<std::string, bool>& subscription_results);
-
-  void RemoveSucessfulSubscriptions(
-      std::set<std::string>& subscriptions,
-      std::set<std::string>& successful_subscriptions);
-
   smart_objects::SmartObjectSPtr CreateSubscribeRequestToHMI(
       const std::set<std::string>& subscriptions);
 
+  ns_smart_device_link::ns_smart_objects::SmartObject CreateFakeResponseFromHMI(
+      const std::map<std::string, smart_objects::SmartObject>& subscriptions,
+      const uint32_t fake_corrlation_id);
   void ClearPendingResumptionRequests() OVERRIDE;
 
  private:
-  void ClearPendingRequestsMap();
+  void ProcessNextPendingResumption(
+      const smart_objects::SmartObject& response_message);
+  void TriggerPendingResumption();
 
-  struct ResumptionAwaitingHandling {
-    const uint32_t app_id;
-    VehicleInfoAppExtension& ext;
-    resumption::Subscriber subscriber;
+  struct PendingSubscriptionsResumption {
+    PendingSubscriptionsResumption(
+        const uint32_t app_id,
+        const uint32_t corr_id,
+        smart_objects::SmartObject request_message,
+        const std::set<std::string>& requested_vehicle_data)
+        : app_id_(app_id)
+        , fake_corr_id_(corr_id)
+        , requested_vehicle_data_(requested_vehicle_data) {}
+    uint32_t app_id_;
+    uint32_t fake_corr_id_;
+    std::set<std::string> requested_vehicle_data_;
+    std::set<std::string> restored_vehicle_data_;
 
-    ResumptionAwaitingHandling(const uint32_t application_id,
-                               VehicleInfoAppExtension& extension,
-                               resumption::Subscriber subscriber_callback)
-        : app_id(application_id)
-        , ext(extension)
-        , subscriber(subscriber_callback) {}
+    std::map<std::string, smart_objects::SmartObject> subscription_results_;
+
+    bool Successfull() const;
+
+    bool DataWasRequested(const std::string& vd) const;
+    std::set<std::string> NotSubscribedData() const;
+
+    void FillSubscriptionResults(const smart_objects::SmartObject& response);
+    void FillSubscriptionResults();
+
+    void FillRestoredData(
+        const std::set<std::string>& successful_subscriptions);
   };
 
-  typedef std::pair<VehicleInfoAppExtension, resumption::Subscriber>
-      FreezedResumption;
-  std::queue<ResumptionAwaitingHandling> freezed_resumptions_;
-  std::map<uint32_t, smart_objects::SmartObject> pending_requests_;
+  void SendHMIRequestForNotSubscribed(
+      const PendingSubscriptionsResumption& next_pending);
+  void RaiseFinishedPendingResumption(
+      const PendingSubscriptionsResumption& next_pending);
+
+  std::deque<PendingSubscriptionsResumption> pending_requests_;
+
+  /**
+   * @brief SubscribeToFakeRequest will create fake subscription for subscriber
+   * ( resumption_data_processor)
+   * @param app_id applicaiton to pass into subscriber
+   * @param subscriptions list of requested subscriptions
+   * @param subscriber function to subscribe caller for ready resumption
+   * @return pending_resumption with information about fake correlation id for
+   * subscriber, list of vehicle data to subscribe
+   */
+  PendingSubscriptionsResumption SubscribeToFakeRequest(
+      const uint32_t app,
+      const std::set<std::string>& subscriptions,
+      resumption::Subscriber& subscriber);
 };
 }  // namespace vehicle_info_plugin
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_VEHICLE_INFO_PLUGIN_INCLUDE_VEHICLE_INFO_PLUGIN_PENDING_RESUMPTION_HANDLER_H

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -56,6 +56,9 @@ class VehicleInfoPendingResumptionHandler
                                            app_mngr::Application& app) OVERRIDE;
   void ClearPendingResumptionRequests() OVERRIDE;
 
+  void HandleOnTimeOut(const uint32_t correlation_id,
+                       const hmi_apis::FunctionID::eType);
+
   std::map<std::string, bool> ExtractSubscribeResults(
       const smart_objects::SmartObject& response,
       const smart_objects::SmartObject& request) const;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -79,6 +79,7 @@ class VehicleInfoPendingResumptionHandler
         const std::set<std::string>& requested_vehicle_data)
         : app_id_(app_id)
         , fake_corr_id_(corr_id)
+        , waiting_for_hmi_response_(false)
         , requested_vehicle_data_(requested_vehicle_data) {}
 
     PendingSubscriptionsResumption(const PendingSubscriptionsResumption& copy) =
@@ -97,6 +98,7 @@ class VehicleInfoPendingResumptionHandler
 
     uint32_t app_id_;
     uint32_t fake_corr_id_;
+    bool waiting_for_hmi_response_;
     std::set<std::string> requested_vehicle_data_;
     std::set<std::string> restored_vehicle_data_;
     std::map<std::string, smart_objects::SmartObject> subscription_results_;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -90,7 +90,11 @@ class VehicleInfoPendingResumptionHandler
     PendingSubscriptionsResumption(const PendingSubscriptionsResumption& copy) =
         default;
 
-    bool Successfull() const;
+    /**
+     * @brief IsSuccessfullyDone check if SDL restored all required data or not
+     * @return
+     */
+    bool IsSuccessfullyDone() const;
 
     bool DataWasRequested(const std::string& vd) const;
     std::set<std::string> NotSubscribedData() const;
@@ -109,16 +113,23 @@ class VehicleInfoPendingResumptionHandler
     std::map<std::string, smart_objects::SmartObject> subscription_results_;
   };
 
-  void SendHMIRequestForNotSubscribed(
-      const PendingSubscriptionsResumption& next_pending);
-  void RaiseFinishedPendingResumption(
-      const PendingSubscriptionsResumption& next_pending);
+  void SendHMIRequestForNotSubscribed(const PendingSubscriptionsResumption& pending_resumption);
+  void RaiseFinishedPendingResumption(const PendingSubscriptionsResumption& pending_resumption);
   /**
    * @brief SubscribeToFakeRequest will create fake subscription for subscriber
    * ( resumption_data_processor)
+   * Fake request is required only for subscriber subscription.
+   * This request will not be sen't to HMI so it named as fake request.
+   * Fake request contains all data that need to be resumed for the application
+   * When HMI will resopond for any VehicleDara request, PendingSubscriptionsResumption
+   * will go throw all pending resumptions and fill it will received subscriptions.
+   * If certain pending resumption will take all requested subscriptions PendingSubscriptionsResumption
+   * will take this fake request correaltion id and create fake response based on it.
+   * Within fake response it will notify subscriber about resumption status.
+   *
    * @param app_id applicaiton to pass into subscriber
    * @param subscriptions list of requested subscriptions
-   * @param subscriber function to subscribe caller for ready resumption
+   * @param subscriber function to subscribe caller for finished resumption
    * @return pending_resumption with information about fake correlation id for
    * subscriber, list of vehicle data to subscribe
    */

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -40,6 +40,7 @@
 #include "utils/optional.h"
 #include "vehicle_info_app_extension.h"
 namespace vehicle_info_plugin {
+class CustomVehicleDataManager;
 
 namespace app_mngr = application_manager;
 
@@ -47,7 +48,8 @@ class VehicleInfoPendingResumptionHandler
     : public resumption::ExtensionPendingResumptionHandler {
  public:
   VehicleInfoPendingResumptionHandler(
-      app_mngr::ApplicationManager& application_manager);
+      app_mngr::ApplicationManager& application_manager,
+      CustomVehicleDataManager& custom_vehicle_data_manager);
 
   void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
@@ -127,6 +129,7 @@ class VehicleInfoPendingResumptionHandler
 
   std::deque<PendingSubscriptionsResumption> pending_requests_;
 
+  CustomVehicleDataManager& custom_vehicle_data_manager_;
   sync_primitives::RecursiveLock lock_;
 };
 }  // namespace vehicle_info_plugin

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -104,10 +104,10 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
   void DeleteSubscriptions(app_mngr::ApplicationSharedPtr app);
 
   std::unique_ptr<app_mngr::CommandFactory> command_factory_;
-  std::unique_ptr<CustomVehicleDataManager> custom_vehicle_data_manager_;
+  typedef std::shared_ptr<resumption::ExtensionPendingResumptionHandler>
+      ExtensionPendingResumptionHandlerSPtr;
   app_mngr::ApplicationManager* application_manager_;
-  using ExtensionPendingResumptionHandlerSPtr =
-      std::shared_ptr<resumption::ExtensionPendingResumptionHandler>;
+  std::unique_ptr<CustomVehicleDataManager> custom_vehicle_data_manager_;
   ExtensionPendingResumptionHandlerSPtr pending_resumption_handler_;
 };
 }  // namespace vehicle_info_plugin

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
@@ -87,9 +87,6 @@ void VISubscribeVehicleDataRequest::onTimeOut() {
       std::string("Timed out"));
   timeout_event.set_smart_object(*error_response);
   timeout_event.raise(application_manager_.event_dispatcher());
-  //  resume_ctrl.HandleOnTimeOut(
-  //      correlation_id(),
-  //      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
@@ -76,11 +76,20 @@ void VISubscribeVehicleDataRequest::Run() {
 }
 
 void VISubscribeVehicleDataRequest::onTimeOut() {
-  auto& resume_ctrl = application_manager_.resume_controller();
+  //  auto& resume_ctrl = application_manager_.resume_controller();
+  event_engine::Event timeout_event(
+      hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData);
 
-  resume_ctrl.HandleOnTimeOut(
+  auto error_response = MessageHelper::CreateNegativeResponseFromHmi(
+      function_id(),
       correlation_id(),
-      static_cast<hmi_apis::FunctionID::eType>(function_id()));
+      hmi_apis::Common_Result::GENERIC_ERROR,
+      std::string("Timed out"));
+  timeout_event.set_smart_object(*error_response);
+  timeout_event.raise(application_manager_.event_dispatcher());
+  //  resume_ctrl.HandleOnTimeOut(
+  //      correlation_id(),
+  //      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -44,6 +44,8 @@ VehicleInfoAppExtension::VehicleInfoAppExtension(
     VehicleInfoPlugin& plugin, application_manager::Application& app)
     : app_mngr::AppExtension(
           VehicleInfoAppExtension::VehicleInfoAppExtensionUID)
+    , subscribed_data_lock_(std::make_shared<sync_primitives::Lock>())
+    , pending_subscriptions_lock_(std::make_shared<sync_primitives::Lock>())
     , plugin_(plugin)
     , app_(app) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -112,10 +112,9 @@ bool VehicleInfoAppExtension::RemovePendingSubscription(
   return false;
 }
 
-bool VehicleInfoAppExtension::RemovePendingSubscriptions() {
+void VehicleInfoAppExtension::RemovePendingSubscriptions() {
   sync_primitives::AutoLock lock(*pending_subscriptions_lock_);
   pending_subscriptions_.clear();
-  return true;
 }
 
 const DataAccessor<VehicleInfoSubscriptions>

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -100,6 +100,18 @@ bool VehicleInfoAppExtension::AddPendingSubscription(
   return pending_subscriptions_.insert(vehicle_data).second;
 }
 
+bool VehicleInfoAppExtension::RemovePendingSubscription(
+    const std::string& vehicle_data) {
+  LOG4CXX_DEBUG(logger_, vehicle_data);
+  sync_primitives::AutoLock lock(*pending_subscriptions_lock_);
+  auto it = pending_subscriptions_.find(vehicle_data);
+  if (it != pending_subscriptions_.end()) {
+    pending_subscriptions_.erase(it);
+    return true;
+  }
+  return false;
+}
+
 bool VehicleInfoAppExtension::RemovePendingSubscriptions() {
   sync_primitives::AutoLock lock(*pending_subscriptions_lock_);
   pending_subscriptions_.clear();

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -85,6 +85,21 @@ const VehicleInfoSubscriptions& VehicleInfoAppExtension::Subscriptions() {
   return subscribed_data_;
 }
 
+bool VehicleInfoAppExtension::AddPendingSubscription(
+    const std::string& vehicle_data) {
+  return pending_subscriptions_.insert(vehicle_data).second;
+}
+
+bool VehicleInfoAppExtension::RemovePendingSubscriptions() {
+  pending_subscriptions_.clear();
+  return true;
+}
+
+const VehicleInfoSubscriptions&
+VehicleInfoAppExtension::PendingSubscriptions() {
+  return pending_subscriptions_;
+}
+
 void VehicleInfoAppExtension::SaveResumptionData(
     smart_objects::SmartObject& resumption_data) {
   resumption_data[strings::application_vehicle_info] =
@@ -115,7 +130,7 @@ void VehicleInfoAppExtension::ProcessResumption(
   const smart_objects::SmartObject& subscriptions_ivi =
       resumption_data[strings::application_vehicle_info];
   for (size_t i = 0; i < subscriptions_ivi.length(); ++i) {
-    subscribeToVehicleInfo(subscriptions_ivi[i].asString());
+    AddPendingSubscription(subscriptions_ivi[i].asString());
   }
   if (subscriptions_ivi.length() > 0) {
     plugin_.ProcessResumptionSubscription(app_, *this, subscriber);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -240,13 +240,15 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
   LOG4CXX_AUTO_TRACE(logger_);
   UNUSED(extension);
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(app);
-  const auto subscriptions = ext.PendingSubscriptions();
+
+  const auto subscriptions = ext.PendingSubscriptions().GetData();
   if (subscriptions.empty()) {
     LOG4CXX_DEBUG(logger_, "Subscriptions is empty");
     return;
   }
   auto pending_request =
       SubscribeToFakeRequest(app.app_id(), subscriptions, subscriber);
+
   pending_requests_.push_back(pending_request);
   LOG4CXX_DEBUG(
       logger_,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -207,10 +207,11 @@ void VehicleInfoPendingResumptionHandler::on_event(
 
   // workaround for existing scripts that do not send response for each
   // paticular data, but send only overal result
-  const auto successful_subscriptions =
-      SuccessfulSubscriptionsFromResponse(response_message);
-  if (IsResponseSuccessful(response_message) &&
-      successful_subscriptions.empty()) {
+  //  const auto successful_subscriptions =
+  //      SuccessfulSubscriptionsFromResponse(response_message);
+  const auto vs_count_in_response =
+      response_message[application_manager::strings::msg_params].length();
+  if (IsResponseSuccessful(response_message) && vs_count_in_response == 0) {
     FillResponseWithMissedVD(current_pending.requested_vehicle_data_,
                              &response_message);
   }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -38,18 +38,29 @@
 #include "application_manager/resumption/resumption_data_processor.h"
 #include "utils/helpers.h"
 namespace vehicle_info_plugin {
+CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPlugin")
+
 using hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
+
 uint32_t get_corr_id_from_message(const smart_objects::SmartObject& message) {
   using namespace application_manager;
   return message[strings::params][strings::correlation_id].asInt();
 }
-CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPendingResumptionHandler")
+
+template <class T>
+std::string Stringify(const T& container) {
+  std::stringstream ss;
+  for (const auto& val : container) {
+    ss << val << " ";
+  }
+  return ss.str();
+}
 
 std::set<std::string> SubscriptionsFromResponse(
     const smart_objects::SmartObject& response,
     std::function<bool(const smart_objects::SmartObject& vehicle_data)>
         vehicle_data_check) {
-  using namespace application_manager;
+  namespace strings = application_manager::strings;
   std::set<std::string> result;
   const auto response_params = response[strings::msg_params];
   const auto response_keys = response_params.enumerate();
@@ -61,21 +72,34 @@ std::set<std::string> SubscriptionsFromResponse(
   return result;
 }
 
+bool IsResponseSuccessful(const smart_objects::SmartObject& response) {
+  namespace strings = application_manager::strings;
+  if (!response[strings::params].keyExists(strings::error_msg)) {
+    return true;
+  }
+  return false;
+}
+
+void FillResponseWithMissedVD(const std::set<std::string>& vehicle_data,
+                              smart_objects::SmartObject* response) {
+  DCHECK(response)
+  namespace strings = application_manager::strings;
+  auto& msg_params = (*response)[strings::msg_params];
+  for (const auto& vd : vehicle_data) {
+    smart_objects::SmartObject vd_result(smart_objects::SmartType_Map);
+    vd_result[strings::result_code] =
+        hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+    msg_params[vd] = vd_result;
+  }
+}
+
 std::set<std::string> SuccessfulSubscriptionsFromResponse(
     const smart_objects::SmartObject& response) {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace application_manager;
 
-  auto succesfull_response = [](const smart_objects::SmartObject& response) {
-    const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
-        response[strings::params][application_manager::hmi_response::code]
-            .asInt());
-    return (result_code == hmi_apis::Common_Result::SUCCESS ||
-            result_code == hmi_apis::Common_Result::WARNINGS);
-  };
-
   std::set<std::string> result;
-  if (!succesfull_response(response)) {
+  if (!IsResponseSuccessful(response)) {
     return result;
   }
 
@@ -116,7 +140,7 @@ void VehicleInfoPendingResumptionHandler::RaiseFinishedPendingResumption(
       next_pending.subscription_results_, next_pending.fake_corr_id_);
   event_engine::Event event(VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(fake_response);
-  LOG4CXX_DEBUG(logger_, "AKutsan raise fake ");
+  LOG4CXX_DEBUG(logger_, "Raize fake response for resumption data processor");
   event.raise(application_manager_.event_dispatcher());
 }
 
@@ -166,14 +190,24 @@ void VehicleInfoPendingResumptionHandler::on_event(
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace application_manager;
   if (pending_requests_.empty()) {
-    LOG4CXX_DEBUG(logger_,
-                  "resumption handler is not waiting for any response");
+    LOG4CXX_DEBUG(logger_, "Not waiting for any response");
   }
 
   auto current_pending = pending_requests_.front();
   pending_requests_.pop_front();
 
   auto response_message = event.smart_object();
+
+  // workaround for existing scripts that do not send response for each
+  // paticular data, but send only overal result
+  const auto successful_subscriptions =
+      SuccessfulSubscriptionsFromResponse(response_message);
+  if (IsResponseSuccessful(response_message) &&
+      successful_subscriptions.empty()) {
+    FillResponseWithMissedVD(current_pending.requested_vehicle_data_,
+                             &response_message);
+  }
+
   current_pending.FillSubscriptionResults(response_message);
 
   RaiseFinishedPendingResumption(current_pending);
@@ -193,7 +227,7 @@ VehicleInfoPendingResumptionHandler::SubscribeToFakeRequest(
       fake_corr_id,
       hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
       *fake_request);
-  subscriber(fake_corr_id, resumption_request);
+  subscriber(app_id, resumption_request);
   PendingSubscriptionsResumption pending_request(
       app_id, fake_corr_id, *fake_request, subscriptions);
   return pending_request;
@@ -262,6 +296,10 @@ VehicleInfoPendingResumptionHandler::CreateFakeResponseFromHMI(
   smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
   for (const auto& subscription : subscriptions) {
     msg_params[subscription.first] = subscription.second;
+    LOG4CXX_DEBUG(logger_,
+                  "fake response data : "
+                      << subscription.first << " result = "
+                      << subscription.second[strings::result_code].asInt());
   }
 
   message[strings::msg_params] = msg_params;
@@ -277,7 +315,6 @@ bool VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
     DataWasRequested(const std::string& vd) const {
   bool result =
       (requested_vehicle_data_.end() != requested_vehicle_data_.find(vd));
-  LOG4CXX_DEBUG(logger_, "check : " << vd << " : " << result);
   return result;
 }
 
@@ -324,14 +361,16 @@ void VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
   using namespace application_manager;
 
   auto successful_subscriptions = SuccessfulSubscriptionsFromResponse(response);
-  for (auto suc : successful_subscriptions) {
-    LOG4CXX_DEBUG(logger_, "successful from response : " << suc);
-  }
+
+  LOG4CXX_DEBUG(logger_,
+                "Requested data " << Stringify(requested_vehicle_data_));
+  LOG4CXX_DEBUG(logger_,
+                "Successful subscription in response "
+                    << Stringify(successful_subscriptions));
+
   FillRestoredData(successful_subscriptions);
 
-  for (auto suc : restored_vehicle_data_) {
-    LOG4CXX_DEBUG(logger_, "restored_vehicle_data_ : " << suc);
-  }
+  LOG4CXX_DEBUG(logger_, "Restored data" << Stringify(restored_vehicle_data_));
 
   FillSubscriptionResults();
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -31,206 +31,172 @@
  */
 
 #include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
+#include <boost/range/algorithm/set_algorithm.hpp>
+#include <functional>
 #include "application_manager/event_engine/event_observer.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/resumption/resumption_data_processor.h"
 #include "utils/helpers.h"
-
 namespace vehicle_info_plugin {
-
+using hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
+uint32_t get_corr_id_from_message(const smart_objects::SmartObject& message) {
+  using namespace application_manager;
+  return message[strings::params][strings::correlation_id].asInt();
+}
 CREATE_LOGGERPTR_GLOBAL(logger_, "VehicleInfoPendingResumptionHandler")
+
+std::set<std::string> SubscriptionsFromResponse(
+    const smart_objects::SmartObject& response,
+    std::function<bool(const smart_objects::SmartObject& vehicle_data)>
+        vehicle_data_check) {
+  using namespace application_manager;
+  std::set<std::string> result;
+  const auto response_params = response[strings::msg_params];
+  const auto response_keys = response_params.enumerate();
+  for (auto key : response_keys) {
+    if (vehicle_data_check(response_params[key])) {
+      result.insert(key);
+    }
+  }
+  return result;
+}
+
+std::set<std::string> SuccessfulSubscriptionsFromResponse(
+    const smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+
+  auto succesfull_response = [](const smart_objects::SmartObject& response) {
+    const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+        response[strings::params][application_manager::hmi_response::code]
+            .asInt());
+    return (result_code == hmi_apis::Common_Result::SUCCESS ||
+            result_code == hmi_apis::Common_Result::WARNINGS);
+  };
+
+  std::set<std::string> result;
+  if (!succesfull_response(response)) {
+    return result;
+  }
+
+  auto sucessful_vehicle_data =
+      [](const smart_objects::SmartObject& vehicle_data) {
+        constexpr auto kSuccess =
+            hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+        const auto vd_result_code = vehicle_data[strings::result_code].asInt();
+        return kSuccess == vd_result_code;
+      };
+  return SubscriptionsFromResponse(response, sucessful_vehicle_data);
+}
 
 VehicleInfoPendingResumptionHandler::VehicleInfoPendingResumptionHandler(
     application_manager::ApplicationManager& application_manager)
     : ExtensionPendingResumptionHandler(application_manager) {}
 
-template <class Key, class Value>
-std::set<Key> EnumerateKeys(std::map<Key, Value>& container) {
-  std::set<std::string> keys;
-
-  std::transform(
-      container.begin(),
-      container.end(),
-      std::inserter(keys, keys.end()),
-      [&](const std::pair<std::string, bool>& pair) { return pair.first; });
-
-  return keys;
-}
-
-bool VehicleInfoPendingResumptionHandler::IsResumptionResultSuccessful(
-    std::map<std::string, bool>& subscription_results) {
-  for (auto ivi_status : subscription_results) {
-    if (!ivi_status.second) {
-      return false;
-      break;
-    }
-  }
-
-  return true;
-}
-
-void VehicleInfoPendingResumptionHandler::RemoveSucessfulSubscriptions(
-    std::set<std::string>& subscriptions,
-    std::set<std::string>& successful_subscriptions) {
-  for (auto subscription : subscriptions) {
-    if (helpers::in_range(successful_subscriptions, subscription)) {
-      subscriptions.erase(subscription);
-    }
-  }
-}
-
-void VehicleInfoPendingResumptionHandler::ClearPendingRequestsMap() {
-  using namespace application_manager;
-
-  for (auto const& it : pending_requests_) {
-    const hmi_apis::FunctionID::eType timed_out_pending_request_fid =
-        static_cast<hmi_apis::FunctionID::eType>(
-            it.second[strings::params][strings::function_id].asInt());
-    unsubscribe_from_event(timed_out_pending_request_fid);
-  }
-
-  pending_requests_.clear();
-}
-
 void VehicleInfoPendingResumptionHandler::ClearPendingResumptionRequests() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  TriggerPendingResumption();
+}
+
+void VehicleInfoPendingResumptionHandler::RaiseFinishedPendingResumption(
+    const PendingSubscriptionsResumption& next_pending) {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace application_manager;
 
-  ClearPendingRequestsMap();
-  if (!freezed_resumptions_.empty()) {
-    ResumptionAwaitingHandling freezed_resumption =
-        freezed_resumptions_.front();
-    freezed_resumptions_.pop();
-
-    std::set<std::string> subscriptions =
-        freezed_resumption.ext.Subscriptions();
-
-    auto request = CreateSubscribeRequestToHMI(subscriptions);
-    const uint32_t cid =
-        (*request)[strings::params][strings::correlation_id].asUInt();
-    const hmi_apis::FunctionID::eType fid =
-        static_cast<hmi_apis::FunctionID::eType>(
-            (*request)[strings::params][strings::function_id].asInt());
-    auto resumption_req = MakeResumptionRequest(cid, fid, *request);
-    auto subscriber = freezed_resumption.subscriber;
-    subscriber(freezed_resumption.app_id, resumption_req);
+  auto app = application_manager_.application(next_pending.app_id_);
+  auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+  ext.RemovePendingSubscriptions();
+  for (const auto& subscription : next_pending.restored_vehicle_data_) {
     LOG4CXX_DEBUG(logger_,
-                  "Subscribing for event with function id: "
-                      << fid << " correlation id: " << cid);
-    subscribe_on_event(fid, cid);
-    pending_requests_[cid] = *request;
-    LOG4CXX_DEBUG(logger_,
-                  "Sending request with fid: " << fid << " and cid: " << cid);
-    application_manager_.GetRPCService().ManageHMICommand(request);
+                  "Subscribe " << app->app_id() << "  to " << subscription);
+    ext.subscribeToVehicleInfo(subscription);
   }
+
+  auto fake_response = CreateFakeResponseFromHMI(
+      next_pending.subscription_results_, next_pending.fake_corr_id_);
+  event_engine::Event event(VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(fake_response);
+  LOG4CXX_DEBUG(logger_, "AKutsan raise fake ");
+  event.raise(application_manager_.event_dispatcher());
+}
+
+void VehicleInfoPendingResumptionHandler::SendHMIRequestForNotSubscribed(
+    const PendingSubscriptionsResumption& next_pending) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto left_so_subscribe = next_pending.NotSubscribedData();
+  auto request = CreateSubscribeRequestToHMI(left_so_subscribe);
+  const auto corr_id = get_corr_id_from_message(*request);
+  subscribe_on_event(VehicleInfo_SubscribeVehicleData, corr_id);
+  application_manager_.GetRPCService().ManageHMICommand(request);
+}
+
+void VehicleInfoPendingResumptionHandler::ProcessNextPendingResumption(
+    const smart_objects::SmartObject& response_message) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_, "No more pending resumptions");
+    return;
+  }
+  auto& pending = pending_requests_.front();
+  const auto successful_subscriptions =
+      SuccessfulSubscriptionsFromResponse(response_message);
+  pending.FillRestoredData(successful_subscriptions);
+
+  if (!pending.Successfull()) {
+    SendHMIRequestForNotSubscribed(pending);
+    return;
+  }
+  auto copy = pending;
+  pending_requests_.pop_front();
+  RaiseFinishedPendingResumption(copy);
+  ProcessNextPendingResumption(response_message);
+}
+
+void VehicleInfoPendingResumptionHandler::TriggerPendingResumption() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (pending_requests_.empty()) {
+    return;
+  }
+  auto next_pending = pending_requests_.front();
+  SendHMIRequestForNotSubscribed(next_pending);
 }
 
 void VehicleInfoPendingResumptionHandler::on_event(
     const application_manager::event_engine::Event& event) {
-  using namespace application_manager;
   LOG4CXX_AUTO_TRACE(logger_);
-
-  const smart_objects::SmartObject& response = event.smart_object();
-  const uint32_t corr_id = event.smart_object_correlation_id();
-
-  smart_objects::SmartObject pending_request;
-  if (pending_requests_.find(corr_id) == pending_requests_.end()) {
-    LOG4CXX_DEBUG(logger_, "corr id" << corr_id << " NOT found");
-    return;
-  }
-  pending_request = pending_requests_[corr_id];
-  pending_requests_.erase(corr_id);
-
-  LOG4CXX_DEBUG(logger_,
-                "Received event with function id: "
-                    << event.id() << " and correlation id: " << corr_id);
-
-  if (freezed_resumptions_.empty()) {
-    LOG4CXX_DEBUG(logger_, "freezed resumptions is empty");
-    return;
+  using namespace application_manager;
+  if (pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_,
+                  "resumption handler is not waiting for any response");
   }
 
-  std::map<std::string, bool> subscription_results =
-      ExtractSubscribeResults(pending_request, response);
+  auto current_pending = pending_requests_.front();
+  pending_requests_.pop_front();
 
-  LOG4CXX_DEBUG(logger_,
-                "pending_requests_.size()" << pending_requests_.size());
+  auto response_message = event.smart_object();
+  current_pending.FillSubscriptionResults(response_message);
 
-  std::set<std::string> successful_subscriptions =
-      EnumerateKeys(subscription_results);
+  RaiseFinishedPendingResumption(current_pending);
 
-  ResumptionAwaitingHandling freezed_resumption = freezed_resumptions_.front();
-  freezed_resumptions_.pop();
-  resumption::Subscriber subscriber = freezed_resumption.subscriber;
-
-  std::set<std::string> subscriptions = freezed_resumption.ext.Subscriptions();
-
-  if (!IsResumptionResultSuccessful(subscription_results)) {
-    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is NOT successful");
-  } else {
-    LOG4CXX_DEBUG(logger_, "Resumption of subscriptions is successful");
-    RemoveSucessfulSubscriptions(subscriptions, successful_subscriptions);
-  }
-
-  auto request = CreateSubscribeRequestToHMI(subscriptions);
-  const uint32_t cid =
-      (*request)[strings::params][strings::correlation_id].asUInt();
-  const hmi_apis::FunctionID::eType fid =
-      static_cast<hmi_apis::FunctionID::eType>(
-          (*request)[strings::params][strings::function_id].asInt());
-  auto resumption_req = MakeResumptionRequest(cid, fid, *request);
-  subscribe_on_event(fid, cid);
-  subscriber(freezed_resumption.app_id, resumption_req);
-  LOG4CXX_DEBUG(logger_,
-                "Subscribing for event with function id: "
-                    << fid << " correlation id: " << cid);
-  pending_requests_[cid] = *request;
-  LOG4CXX_DEBUG(logger_,
-                "Sending request with fid: " << fid << " and cid: " << cid);
-  application_manager_.GetRPCService().ManageHMICommand(request);
+  ProcessNextPendingResumption(response_message);
 }
 
-std::map<std::string, bool>
-VehicleInfoPendingResumptionHandler::ExtractSubscribeResults(
-    const smart_objects::SmartObject& response,
-    const smart_objects::SmartObject& request) const {
-  using namespace application_manager;
-  const hmi_apis::Common_Result::eType result_code =
-      static_cast<hmi_apis::Common_Result::eType>(
-          response[strings::params][application_manager::hmi_response::code]
-              .asInt());
-  bool succesfull_response = (result_code == hmi_apis::Common_Result::SUCCESS ||
-                              result_code == hmi_apis::Common_Result::WARNINGS);
-  const auto response_keys =
-      response[application_manager::strings::msg_params].enumerate();
-  const auto request_keys =
-      request[application_manager::strings::msg_params].enumerate();
-
-  auto response_params = response[strings::msg_params];
-
-  std::map<std::string, bool> subscription_results;
-
-  if (!succesfull_response) {
-    for (auto key : request_keys) {
-      subscription_results[key] = false;
-    }
-  }
-
-  if (succesfull_response) {
-    for (auto key : request_keys) {
-      if (!helpers::in_range(response_keys, key)) {
-        subscription_results[key] = true;
-      } else {
-        const auto kSuccess =
-            hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
-        const auto vd_result_code =
-            response_params[key][application_manager::strings::result_code]
-                .asInt();
-        subscription_results[key] = vd_result_code == kSuccess;
-      }
-    }
-  }
-  return subscription_results;
+VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption
+VehicleInfoPendingResumptionHandler::SubscribeToFakeRequest(
+    const uint32_t app_id,
+    const std::set<std::string>& subscriptions,
+    resumption::Subscriber& subscriber) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto fake_request = CreateSubscribeRequestToHMI(subscriptions);
+  const auto fake_corr_id = get_corr_id_from_message(*fake_request);
+  auto resumption_request = MakeResumptionRequest(
+      fake_corr_id,
+      hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
+      *fake_request);
+  subscriber(fake_corr_id, resumption_request);
+  PendingSubscriptionsResumption pending_request(
+      app_id, fake_corr_id, *fake_request, subscriptions);
+  return pending_request;
 }
 
 void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
@@ -238,45 +204,24 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     resumption::Subscriber& subscriber,
     application_manager::Application& app) {
   LOG4CXX_AUTO_TRACE(logger_);
-
-  VehicleInfoAppExtension& ext =
-      dynamic_cast<VehicleInfoAppExtension&>(extension);
-
-  std::set<std::string> subscriptions = ext.Subscriptions();
-
-  smart_objects::SmartObjectSPtr request =
-      CreateSubscribeRequestToHMI(subscriptions);
-
-  smart_objects::SmartObject& request_ref = *request;
-  const auto function_id = static_cast<hmi_apis::FunctionID::eType>(
-      request_ref[application_manager::strings::params]
-                 [application_manager::strings::function_id]
-                     .asInt());
-  const uint32_t corr_id =
-      request_ref[application_manager::strings::params]
-                 [application_manager::strings::correlation_id]
-                     .asUInt();
-
-  auto resumption_request =
-      MakeResumptionRequest(corr_id, function_id, *request);
-
-  if (pending_requests_.empty()) {
-    LOG4CXX_DEBUG(logger_,
-                  "There are no pending requests for app_id: " << app.app_id());
-    pending_requests_[corr_id] = request_ref;
-    subscribe_on_event(function_id, corr_id);
-    subscriber(app.app_id(), resumption_request);
-    LOG4CXX_DEBUG(logger_,
-                  "Sending request with function id: "
-                      << function_id << " and correlation_id: " << corr_id);
-    application_manager_.GetRPCService().ManageHMICommand(request);
+  UNUSED(extension);
+  auto& ext = VehicleInfoAppExtension::ExtractVIExtension(app);
+  const auto subscriptions = ext.PendingSubscriptions();
+  if (subscriptions.empty()) {
+    LOG4CXX_DEBUG(logger_, "Subscriptions is empty");
     return;
-  } else {
-    LOG4CXX_DEBUG(logger_,
-                  "There are pending requests for app_id: " << app.app_id());
-    ResumptionAwaitingHandling frozen_res(app.app_id(), ext, subscriber);
-    freezed_resumptions_.push(frozen_res);
   }
+  auto pending_request =
+      SubscribeToFakeRequest(app.app_id(), subscriptions, subscriber);
+  pending_requests_.push_back(pending_request);
+  LOG4CXX_DEBUG(
+      logger_,
+      "Add to pending resumptins corr_id = " << pending_request.fake_corr_id_);
+  if (pending_requests_.size() == 1) {
+    TriggerPendingResumption();
+  }
+  // If there was pending resumption before, it will be triggered on HMI
+  // response
 }
 
 smart_objects::SmartObjectSPtr
@@ -293,10 +238,110 @@ VehicleInfoPendingResumptionHandler::CreateSubscribeRequestToHMI(
 
   smart_objects::SmartObjectSPtr request =
       application_manager::MessageHelper::CreateModuleInfoSO(
-          hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData,
-          application_manager_);
+          VehicleInfo_SubscribeVehicleData, application_manager_);
   (*request)[strings::msg_params] = msg_params;
 
   return request;
 }
+
+smart_objects::SmartObject
+VehicleInfoPendingResumptionHandler::CreateFakeResponseFromHMI(
+    const std::map<std::string, smart_objects::SmartObject>& subscriptions,
+    const uint32_t fake_corrlation_id) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  namespace strings = application_manager::strings;
+  namespace hmi_response = application_manager::hmi_response;
+  smart_objects::SmartObject message(smart_objects::SmartType_Map);
+  smart_objects::SmartObject params(smart_objects::SmartType_Map);
+  params[strings::function_id] = VehicleInfo_SubscribeVehicleData;
+  params[strings::message_type] = 1;  // MessageType::kResponse;
+  params[strings::correlation_id] = fake_corrlation_id;
+  params[strings::protocol_type] = 1;  // HMI protocol type
+  params[hmi_response::code] = hmi_apis::Common_Result::SUCCESS;
+  message[strings::params] = params;
+  smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
+  for (const auto& subscription : subscriptions) {
+    msg_params[subscription.first] = subscription.second;
+  }
+
+  message[strings::msg_params] = msg_params;
+  return message;
+}
+
+bool VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    Successfull() const {
+  return requested_vehicle_data_.size() == restored_vehicle_data_.size();
+}
+
+bool VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    DataWasRequested(const std::string& vd) const {
+  bool result =
+      (requested_vehicle_data_.end() != requested_vehicle_data_.find(vd));
+  LOG4CXX_DEBUG(logger_, "check : " << vd << " : " << result);
+  return result;
+}
+
+std::set<std::string> VehicleInfoPendingResumptionHandler::
+    PendingSubscriptionsResumption::NotSubscribedData() const {
+  std::set<std::string> not_subscribed;
+  boost::set_difference(requested_vehicle_data_,
+                        restored_vehicle_data_,
+                        std::inserter(not_subscribed, not_subscribed.end()));
+  return not_subscribed;
+}
+
+void VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    FillSubscriptionResults() {
+  namespace strings = application_manager::strings;
+  for (const auto& key : restored_vehicle_data_) {
+    smart_objects::SmartObject vd_result(smart_objects::SmartType_Map);
+    vd_result[strings::result_code] =
+        hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS;
+    subscription_results_[key] = vd_result;
+  }
+
+  const auto not_subscribed = NotSubscribedData();
+  for (const auto& key : not_subscribed) {
+    smart_objects::SmartObject vd_result(smart_objects::SmartType_Map);
+    vd_result[strings::result_code] =
+        hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED;
+    subscription_results_[key] = vd_result;
+  }
+}
+
+void VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    FillRestoredData(const std::set<std::string>& successful_subscriptions) {
+  for (auto& subscribed : successful_subscriptions) {
+    if (DataWasRequested(subscribed)) {
+      restored_vehicle_data_.insert(subscribed);
+    }
+  }
+}
+
+void VehicleInfoPendingResumptionHandler::PendingSubscriptionsResumption::
+    FillSubscriptionResults(const smart_objects::SmartObject& response) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  using namespace application_manager;
+
+  auto successful_subscriptions = SuccessfulSubscriptionsFromResponse(response);
+  for (auto suc : successful_subscriptions) {
+    LOG4CXX_DEBUG(logger_, "successful from response : " << suc);
+  }
+  FillRestoredData(successful_subscriptions);
+
+  for (auto suc : restored_vehicle_data_) {
+    LOG4CXX_DEBUG(logger_, "restored_vehicle_data_ : " << suc);
+  }
+
+  FillSubscriptionResults();
+
+  auto msg_params = response[strings::msg_params];
+  auto keys = msg_params.enumerate();
+  for (auto key : keys) {
+    if (DataWasRequested(key)) {
+      subscription_results_[key] = msg_params[key];
+    }
+  }
+}
+
 }  // namespace vehicle_info_plugin

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -193,6 +193,13 @@ void VehicleInfoPendingResumptionHandler::TriggerPendingResumption() {
     return;
   }
   auto& next_pending = pending_requests_.front();
+  if (next_pending.waiting_for_hmi_response_) {
+    LOG4CXX_DEBUG(logger_,
+                  "Pending resumption for  "
+                      << next_pending.app_id_
+                      << " is already waiting for HMI response");
+    return;
+  }
   SendHMIRequestForNotSubscribed(next_pending);
   next_pending.waiting_for_hmi_response_ = true;
 }
@@ -254,6 +261,7 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     application_manager::Application& app) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock lock(lock_);
+  LOG4CXX_TRACE(logger_, "app id " << app.app_id());
   UNUSED(extension);
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(app);
 
@@ -262,6 +270,8 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     LOG4CXX_DEBUG(logger_, "Subscriptions is empty");
     return;
   }
+  LOG4CXX_TRACE(logger_,
+                "resume subscriptions to : " << Stringify(subscriptions));
   auto pending_request =
       SubscribeToFakeRequest(app.app_id(), subscriptions, subscriber);
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -132,8 +132,8 @@ void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
     auto applications = application_manager_->applications();
     for (auto& app : applications.GetData()) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-      auto subscription_names = ext.Subscriptions();
-      for (auto& subscription_name : subscription_names.GetData()) {
+      auto subscription_names = ext.Subscriptions().GetData();
+      for (auto& subscription_name : subscription_names) {
         if (custom_vehicle_data_manager_->IsRemovedCustomVehicleDataName(
                 subscription_name)) {
           ext.unsubscribeFromVehicleInfo(subscription_name);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -59,10 +59,11 @@ bool VehicleInfoPlugin::Init(
     resumption::LastStateWrapperPtr last_state) {
   UNUSED(last_state);
   application_manager_ = &app_manager;
-  pending_resumption_handler_ =
-      std::make_shared<VehicleInfoPendingResumptionHandler>(app_manager);
   custom_vehicle_data_manager_.reset(
       new CustomVehicleDataManagerImpl(policy_handler, rpc_service));
+  pending_resumption_handler_ =
+      std::make_shared<VehicleInfoPendingResumptionHandler>(
+          app_manager, *custom_vehicle_data_manager_);
   command_factory_.reset(new vehicle_info_plugin::VehicleInfoCommandFactory(
       app_manager,
       rpc_service,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -166,6 +166,13 @@ void VehicleInfoPlugin::ProcessResumptionSubscription(
     resumption::Subscriber subscriber) {
   LOG4CXX_AUTO_TRACE(logger_);
 
+  auto pending = ext.PendingSubscriptions().GetData();
+  for (const auto& ivi : pending) {
+    if (IsSubscribedAppExist(ivi)) {
+      ext.RemovePendingSubscription(ivi);
+      ext.subscribeToVehicleInfo(ivi);
+    }
+  }
   pending_resumption_handler_->HandleResumptionSubscriptionRequest(
       ext, subscriber, app);
 }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -132,7 +132,7 @@ void VehicleInfoPlugin::UnsubscribeFromRemovedVDItems() {
     for (auto& app : applications.GetData()) {
       auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
       auto subscription_names = ext.Subscriptions();
-      for (auto& subscription_name : subscription_names) {
+      for (auto& subscription_name : subscription_names.GetData()) {
         if (custom_vehicle_data_manager_->IsRemovedCustomVehicleDataName(
                 subscription_name)) {
           ext.unsubscribeFromVehicleInfo(subscription_name);
@@ -306,7 +306,7 @@ smart_objects::SmartObjectSPtr VehicleInfoPlugin::GetUnsubscribeIVIRequest(
 void VehicleInfoPlugin::DeleteSubscriptions(
     application_manager::ApplicationSharedPtr app) {
   auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
-  auto subscriptions = ext.Subscriptions();
+  auto subscriptions = ext.Subscriptions().GetData();
   std::vector<std::string> ivi_to_unsubscribe;
   for (auto& ivi : subscriptions) {
     ext.unsubscribeFromVehicleInfo(ivi);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/CMakeLists.txt
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/CMakeLists.txt
@@ -52,6 +52,7 @@ file(GLOB SOURCES
   ${COMMANDS_TEST_DIR}/mobile/*
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_vehicle_data_manager_test.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/vehicle_data_item_schema_test.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/vehicle_info_pending_resumption_test.cc
   ${COMPONENTS_DIR}/application_manager/src/message.cc
   ${COMPONENTS_DIR}/application_manager/src/event_engine/*
   ${COMPONENTS_DIR}/resumption/src/last_state_wrapper_impl.cc
@@ -60,7 +61,6 @@ file(GLOB SOURCES
 set(LIBRARIES
   gmock
   Utils
-  SmartObjects
   HMI_API
   MOBILE_API
   connectionHandler

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Ford Motor Company
+ * Copyright (c) 2020, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -135,8 +135,8 @@ smart_objects::SmartObjectSPtr CreateVDRequest(const uint32_t corr_id) {
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
   smart_objects::SmartObject& object = *request;
-  object[strings::params][strings::message_type] =
-      static_cast<int>(0);  // request
+  const auto message_type_request = 0;
+  object[strings::params][strings::message_type] = message_type_request;
   object[strings::params][strings::function_id] =
       static_cast<int>(VehicleInfo_SubscribeVehicleData);
 
@@ -156,22 +156,6 @@ mobile_apis::VehicleDataType::eType ToVDType(const std::string& vd) {
   return mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA;
 }
 
-// smart_objects::SmartObject CreateVDError(
-//    const hmi_apis::Common_Result::eType common_result,
-//    uint32_t correleation_id) {
-//  namespace strings = application_manager::strings;
-//  namespace hmi_response = application_manager::hmi_response;
-//  smart_objects::SmartObject message(smart_objects::SmartType_Map);
-//  smart_objects::SmartObject params(smart_objects::SmartType_Map);
-//  params[strings::function_id] = VehicleInfo_SubscribeVehicleData;
-//  params[strings::message_type] = 1;  // MessageType::kResponse;
-//  params[strings::correlation_id] = correleation_id;
-//  params[strings::error_msg] = "error message";
-//  params[strings::protocol_type] = 1;  // HMI protocol type
-//  params[hmi_response::code] = common_result;
-//  return message;
-//}
-
 smart_objects::SmartObject CreateVDError(const uint32_t correlation_id,
                                          const int32_t result_code,
                                          const std::string& info) {
@@ -181,10 +165,12 @@ smart_objects::SmartObject CreateVDError(const uint32_t correlation_id,
 
   message[strings::params][strings::function_id] =
       VehicleInfo_SubscribeVehicleData;
-  message[strings::params][strings::protocol_type] = 1;
+  const auto hmi_protocol_type = 1;
+  message[strings::params][strings::protocol_type] = hmi_protocol_type;
   message[strings::params][strings::correlation_id] = correlation_id;
 
-  message[strings::params][strings::message_type] = 1;
+  const auto message_type_response = 1;
+  message[strings::params][strings::message_type] = message_type_response;
   message[strings::params][hmi_response::code] = result_code;
   message[strings::params][strings::error_msg] = info;
 
@@ -202,9 +188,11 @@ smart_objects::SmartObject CreateVDResponse(
   smart_objects::SmartObject message(smart_objects::SmartType_Map);
   smart_objects::SmartObject params(smart_objects::SmartType_Map);
   params[strings::function_id] = VehicleInfo_SubscribeVehicleData;
-  params[strings::message_type] = 1;  // MessageType::kResponse;
+  const auto message_type_response = 1;
+  params[strings::message_type] = message_type_response;
   params[strings::correlation_id] = correleation_id;
-  params[strings::protocol_type] = 1;  // HMI protocol type
+  const auto hmi_protocol_type = 1;
+  params[strings::protocol_type] = hmi_protocol_type;
   params[hmi_response::code] = common_result;
   message[strings::params] = params;
   smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
@@ -329,7 +329,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->on_event(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
-  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
 }
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
@@ -375,7 +375,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->on_event(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
-  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
 }
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
@@ -415,7 +415,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->on_event(event);
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
-  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
 }
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
@@ -454,7 +454,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->on_event(event);
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
-  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
 }
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest, TwoAppsOneSharedDataSuccess) {
@@ -494,8 +494,8 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest, TwoAppsOneSharedDataSuccess) {
   resumption_handler_->on_event(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
-  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
-  EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().GetData().size(), 0u);
 }
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
@@ -541,8 +541,8 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
   EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("speed"));
-  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
-  EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().GetData().size(), 0u);
 }
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
@@ -597,8 +597,8 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->on_event(second_event);
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
-  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
-  EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().GetData().size(), 0u);
 }
 
 }  // namespace vehicle_info_plugin_test

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
@@ -36,7 +36,7 @@
 #include "application_manager/test/include/application_manager/mock_message_helper.h"
 #include "gtest/gtest.h"
 #include "test/application_manager/mock_application_manager.h"
-//#include "application_manager/mock_rpc_service.h"
+#include "vehicle_info_plugin/mock_custom_vehicle_data_manager.h"
 #include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
 
 namespace vehicle_info_plugin_test {
@@ -88,7 +88,7 @@ class VehicleInfoPendingResumptionHandlerTest : public ::testing::Test {
         .WillByDefault(ReturnRef(mock_rpc_service_));
     resumption_handler_.reset(
         new vehicle_info_plugin::VehicleInfoPendingResumptionHandler(
-            app_manager_mock_));
+            app_manager_mock_, custom_vehicle_data_manager_mock_));
   }
 
   MockAppPtr CreateApp(uint32_t app_id) {
@@ -122,6 +122,7 @@ class VehicleInfoPendingResumptionHandlerTest : public ::testing::Test {
   MockApplicationManager app_manager_mock_;
   MockEventDispatcher event_dispatcher_mock_;
   MockRPCService mock_rpc_service_;
+  MockCustomVehicleDataManager custom_vehicle_data_manager_mock_;
   vehicle_info_plugin::VehicleInfoPlugin plugin_;
 
   std::unique_ptr<vehicle_info_plugin::VehicleInfoPendingResumptionHandler>

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
@@ -29,46 +29,51 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE. */
 
-#include "gtest/gtest.h"
 #include <boost/range/algorithm/set_algorithm.hpp>
-#include "test/application_manager/mock_application_manager.h"
+#include "application_manager/test/include/application_manager/mock_application.h"
 #include "application_manager/test/include/application_manager/mock_event_dispatcher.h"
 #include "application_manager/test/include/application_manager/mock_event_observer.h"
-#include "application_manager/test/include/application_manager/mock_application.h"
 #include "application_manager/test/include/application_manager/mock_message_helper.h"
+#include "gtest/gtest.h"
+#include "test/application_manager/mock_application_manager.h"
 //#include "application_manager/mock_rpc_service.h"
 #include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
 
 namespace vehicle_info_plugin_test {
 using namespace vehicle_info_plugin;
 
+using ::testing::_;
+using ::testing::DoAll;
 using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::SaveArg;
-using ::testing::DoAll;
-using ::testing::_;
 
 using application_manager::MockMessageHelper;
-typedef NiceMock<::test::components::event_engine_test::MockEventDispatcher> MockEventDispatcher;
-typedef NiceMock<::test::components::event_engine_test::MockEventObserver> MockEventObserver;
-typedef NiceMock<::test::components::application_manager_test::MockApplicationManager> MockApplicationManager;
-typedef NiceMock<::test::components::application_manager_test::MockApplication> MockApplication;
-typedef NiceMock<test::components::application_manager_test::MockRPCService> MockRPCService;
+typedef NiceMock< ::test::components::event_engine_test::MockEventDispatcher>
+    MockEventDispatcher;
+typedef NiceMock< ::test::components::event_engine_test::MockEventObserver>
+    MockEventObserver;
+typedef NiceMock<
+    ::test::components::application_manager_test::MockApplicationManager>
+    MockApplicationManager;
+typedef NiceMock< ::test::components::application_manager_test::MockApplication>
+    MockApplication;
+typedef NiceMock<test::components::application_manager_test::MockRPCService>
+    MockRPCService;
 typedef std::shared_ptr<MockApplication> MockAppPtr;
 typedef std::shared_ptr<vehicle_info_plugin::VehicleInfoAppExtension>
     VehicleInfoAppExtensionPtr;
 using hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
 
-  class SubscribeCatcher {
-   public:
-     MOCK_METHOD2(subscribe, void(const int32_t,
-                  const resumption::ResumptionRequest));
-
-   };
+class SubscribeCatcher {
+ public:
+  MOCK_METHOD2(subscribe,
+               void(const int32_t, const resumption::ResumptionRequest));
+};
 
 class VehicleInfoPendingResumptionHandlerTest : public ::testing::Test {
-// using namespace vehicle_info_plugin;
+  // using namespace vehicle_info_plugin;
  public:
   VehicleInfoPendingResumptionHandlerTest()
       : mock_message_helper_(
@@ -77,41 +82,40 @@ class VehicleInfoPendingResumptionHandlerTest : public ::testing::Test {
   {}
 
   void SetUp() OVERRIDE {
-    ON_CALL(app_manager_mock_, event_dispatcher()).WillByDefault(ReturnRef(event_dispatcher_mock_));
-    ON_CALL(app_manager_mock_, GetRPCService()).WillByDefault(ReturnRef(mock_rpc_service_));
+    ON_CALL(app_manager_mock_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_mock_));
+    ON_CALL(app_manager_mock_, GetRPCService())
+        .WillByDefault(ReturnRef(mock_rpc_service_));
     resumption_handler_.reset(
-          new vehicle_info_plugin::VehicleInfoPendingResumptionHandler(app_manager_mock_));
+        new vehicle_info_plugin::VehicleInfoPendingResumptionHandler(
+            app_manager_mock_));
   }
-
 
   MockAppPtr CreateApp(uint32_t app_id) {
     auto mock_app = std::make_shared<MockApplication>();
 
-    ON_CALL(app_manager_mock_, application(app_id)).WillByDefault(Return(mock_app));
+    ON_CALL(app_manager_mock_, application(app_id))
+        .WillByDefault(Return(mock_app));
     ON_CALL(*mock_app, app_id()).WillByDefault(Return(app_id));
     return mock_app;
   }
 
-
   VehicleInfoAppExtensionPtr CreateExtension(MockApplication& app) {
-    auto ext_ptr = std::make_shared<VehicleInfoAppExtension>(
-          plugin_,
-          app
-          );
-    ON_CALL(app, QueryInterface(VehicleInfoAppExtension::VehicleInfoAppExtensionUID)).
-        WillByDefault(Return(ext_ptr));
+    auto ext_ptr = std::make_shared<VehicleInfoAppExtension>(plugin_, app);
+    ON_CALL(app,
+            QueryInterface(VehicleInfoAppExtension::VehicleInfoAppExtensionUID))
+        .WillByDefault(Return(ext_ptr));
     return ext_ptr;
   }
 
   resumption::Subscriber& get_subscriber() {
     static resumption::Subscriber subscriber =
         [this](const int32_t corr_id,
-        const resumption::ResumptionRequest resumption_request) {
-        this->subscribe_catcher_.subscribe(corr_id,resumption_request);
-    };
+               const resumption::ResumptionRequest resumption_request) {
+          this->subscribe_catcher_.subscribe(corr_id, resumption_request);
+        };
     return subscriber;
   }
-
 
   SubscribeCatcher subscribe_catcher_;
   MockMessageHelper& mock_message_helper_;
@@ -120,22 +124,22 @@ class VehicleInfoPendingResumptionHandlerTest : public ::testing::Test {
   MockRPCService mock_rpc_service_;
   vehicle_info_plugin::VehicleInfoPlugin plugin_;
 
-  std::unique_ptr<
-  vehicle_info_plugin::VehicleInfoPendingResumptionHandler> resumption_handler_;
+  std::unique_ptr<vehicle_info_plugin::VehicleInfoPendingResumptionHandler>
+      resumption_handler_;
 };
-
 
 smart_objects::SmartObjectSPtr CreateVDRequest(const uint32_t corr_id) {
   using namespace application_manager;
-  smart_objects::SmartObjectSPtr request=
+  smart_objects::SmartObjectSPtr request =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
   smart_objects::SmartObject& object = *request;
-  object[strings::params][strings::message_type] = static_cast<int>(0); // request
-  object[strings::params][strings::function_id] = static_cast<int>(VehicleInfo_SubscribeVehicleData);
+  object[strings::params][strings::message_type] =
+      static_cast<int>(0);  // request
+  object[strings::params][strings::function_id] =
+      static_cast<int>(VehicleInfo_SubscribeVehicleData);
 
-  object[strings::params][strings::correlation_id] =
-      corr_id;
+  object[strings::params][strings::correlation_id] = corr_id;
   object[strings::msg_params] =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
   return request;
@@ -151,11 +155,30 @@ mobile_apis::VehicleDataType::eType ToVDType(const std::string& vd) {
   return mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA;
 }
 
-typedef std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType> VDResponseMap;
-smart_objects::SmartObject CreateVDResponse(const hmi_apis::Common_Result::eType common_result,
-    const VDResponseMap&  subscriptions_result,
-    uint32_t correleation_id
-                                            ) {
+typedef std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+    VDResponseMap;
+smart_objects::SmartObject CreateVDError(
+    const hmi_apis::Common_Result::eType common_result,
+    uint32_t correleation_id) {
+  namespace strings = application_manager::strings;
+  namespace hmi_response = application_manager::hmi_response;
+  smart_objects::SmartObject message(smart_objects::SmartType_Map);
+  smart_objects::SmartObject params(smart_objects::SmartType_Map);
+  params[strings::function_id] = VehicleInfo_SubscribeVehicleData;
+  params[strings::message_type] = 1;  // MessageType::kResponse;
+  params[strings::correlation_id] = correleation_id;
+  params[strings::error_msg] = "error message";
+  params[strings::protocol_type] = 1;  // HMI protocol type
+  params[hmi_response::code] = common_result;
+  return message;
+}
+
+typedef std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+    VDResponseMap;
+smart_objects::SmartObject CreateVDResponse(
+    const hmi_apis::Common_Result::eType common_result,
+    const VDResponseMap& subscriptions_result,
+    uint32_t correleation_id) {
   namespace strings = application_manager::strings;
   namespace hmi_response = application_manager::hmi_response;
   smart_objects::SmartObject message(smart_objects::SmartType_Map);
@@ -168,7 +191,8 @@ smart_objects::SmartObject CreateVDResponse(const hmi_apis::Common_Result::eType
   message[strings::params] = params;
   smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
   for (const auto& subscription : subscriptions_result) {
-    smart_objects::SmartObject subscription_result(smart_objects::SmartType_Map);
+    smart_objects::SmartObject subscription_result(
+        smart_objects::SmartType_Map);
     subscription_result[strings::data_type] = ToVDType(subscription.first);
     subscription_result[strings::result_code] = subscription.second;
     msg_params[subscription.first] = subscription_result;
@@ -177,29 +201,25 @@ smart_objects::SmartObject CreateVDResponse(const hmi_apis::Common_Result::eType
   return message;
 }
 
-enum class ContainsPolicy {
-  Strict,
-  Nice
-};
+enum class ContainsPolicy { Strict, Nice };
 
-bool CheckThatMessageContainsVD(const smart_objects::SmartObject& message,
-                                const std::set<std::string>& vehicle_data,
-                                ContainsPolicy policy = ContainsPolicy::Strict) {
+bool CheckThatMessageContainsVD(
+    const smart_objects::SmartObject& message,
+    const std::set<std::string>& vehicle_data,
+    ContainsPolicy policy = ContainsPolicy::Strict) {
   using namespace application_manager;
   auto& msg_params = message[strings::msg_params];
   auto keys = msg_params.enumerate();
   std::set<std::string> missed;
-  boost::set_difference(vehicle_data,
-                        keys,
-                        std::inserter(missed, missed.end()));
+  boost::set_difference(
+      vehicle_data, keys, std::inserter(missed, missed.end()));
   if (missed.size() > 0) {
     return false;
   }
   if (ContainsPolicy::Strict == policy) {
     std::set<std::string> redundant;
-    boost::set_difference(keys,
-                          vehicle_data,
-                          std::inserter(redundant, redundant.end()));
+    boost::set_difference(
+        keys, vehicle_data, std::inserter(redundant, redundant.end()));
     if (redundant.size() > 0) {
       return false;
     }
@@ -207,42 +227,34 @@ bool CheckThatMessageContainsVD(const smart_objects::SmartObject& message,
   return true;
 }
 
-
 /**
  * @brief EventCheck check that event contains apropriate vehicle data,
  * check that is matched correlation id,
  * check that function id is correct
  */
-MATCHER_P2(EventCheck, expected_corr_id,  vehicle_data, "") {
+MATCHER_P2(EventCheck, expected_corr_id, vehicle_data, "") {
   namespace strings = application_manager::strings;
   const auto& response_message = arg.smart_object();
-  const bool vehicle_data_ok = CheckThatMessageContainsVD(response_message, vehicle_data);
-  const auto cid = response_message[strings::params][strings::correlation_id].asInt();
+  const bool vehicle_data_ok =
+      CheckThatMessageContainsVD(response_message, vehicle_data);
+  const auto cid =
+      response_message[strings::params][strings::correlation_id].asInt();
   const bool cid_ok = (cid == expected_corr_id);
-  const auto fid= response_message[strings::params][strings::function_id].asInt();
+  const auto fid =
+      response_message[strings::params][strings::function_id].asInt();
   const bool fid_ok = (fid == VehicleInfo_SubscribeVehicleData);
   return fid_ok && cid_ok && vehicle_data_ok;
 }
 
-
-
-TEST_F(VehicleInfoPendingResumptionHandlerTest,
-       NoSubscriptionNoAction) {
-
-
+TEST_F(VehicleInfoPendingResumptionHandlerTest, NoSubscriptionNoAction) {
   auto mock_app = CreateApp(1);
   auto ext_ptr = CreateExtension(*mock_app);
 
-
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(0);
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(0);
   resumption::Subscriber& subscribe = get_subscriber();
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext_ptr,
-        subscribe,
-        *mock_app
-        );
+      *ext_ptr, subscribe, *mock_app);
 }
-
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
        OneAppSeveralVehicleDataSuccess) {
@@ -253,36 +265,25 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
 
   auto request = CreateVDRequest(1);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
-
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
   uint32_t subscribed_correlation_id;
   resumption::ResumptionRequest resumption_request;
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_))
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
       .WillOnce(DoAll(SaveArg<0>(&subscribed_correlation_id),
                       SaveArg<1>(&resumption_request)));
 
   smart_objects::SmartObjectSPtr message_to_hmi;
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_))
-             .WillOnce(DoAll(SaveArg<0>(&message_to_hmi),
-                             Return(true)));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&message_to_hmi), Return(true)));
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
+      *ext, get_subscriber(), *mock_app);
   EXPECT_EQ(resumption_request.request_ids.function_id,
             VehicleInfo_SubscribeVehicleData);
-  EXPECT_TRUE(CheckThatMessageContainsVD(
-                resumption_request.message,
-                {"gps", "speed"}
-                ));
-  EXPECT_TRUE(CheckThatMessageContainsVD(
-                *message_to_hmi,
-                {"gps", "speed"}
-                ));
+  EXPECT_TRUE(
+      CheckThatMessageContainsVD(resumption_request.message, {"gps", "speed"}));
+  EXPECT_TRUE(CheckThatMessageContainsVD(*message_to_hmi, {"gps", "speed"}));
 }
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
@@ -295,36 +296,30 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   uint32_t corr_id = 345;
   auto request = CreateVDRequest(corr_id);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
   uint32_t subscribed_correlation_id;
   resumption::ResumptionRequest resumption_request;
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_))
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
       .WillOnce(DoAll(SaveArg<0>(&subscribed_correlation_id),
                       SaveArg<1>(&resumption_request)));
 
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
 
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+          {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
 
-
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-  };
-
-  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
   application_manager::event_engine::Event event(
       VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(response);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
-
+      *ext, get_subscriber(), *mock_app);
 
   std::set<std::string> expected_data_in_event = {"gps", "speed"};
   EXPECT_CALL(event_dispatcher_mock_,
@@ -347,29 +342,27 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   uint32_t corr_id = 345;
   auto request = CreateVDRequest(corr_id);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
   uint32_t subscribed_correlation_id;
   resumption::ResumptionRequest resumption_request;
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_))
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _))
       .WillOnce(DoAll(SaveArg<0>(&subscribed_correlation_id),
                       SaveArg<1>(&resumption_request)));
 
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
-  };
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+          {"speed",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+      };
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
+      *ext, get_subscriber(), *mock_app);
 
-  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
   application_manager::event_engine::Event event(
       VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(response);
@@ -385,7 +378,6 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
 }
 
-
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
        OneAppSeveralVehicleDataResponseAllFailed) {
   auto mock_app = CreateApp(1);
@@ -396,29 +388,28 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   uint32_t corr_id = 345;
   auto request = CreateVDRequest(corr_id);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_));
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _));
   // TODO save cid and fid of the subscription
   EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
-    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
-  };
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+          {"speed",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+      };
 
-  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
   application_manager::event_engine::Event event(
       VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(response);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
+      *ext, get_subscriber(), *mock_app);
 
   // TODO check that raized the same fid and cid as subscribed
   resumption_handler_->on_event(event);
@@ -437,30 +428,27 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   uint32_t corr_id = 345;
   auto request = CreateVDRequest(corr_id);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_));
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _));
   // TODO save cid and fid of the subscription
   EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-  };
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+          {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
 
-  auto response = CreateVDResponse(hmi_apis::Common_Result::ABORTED, subscriptions_result, corr_id);
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::ABORTED, subscriptions_result, corr_id);
   // TODO use error message type instead of result code
   application_manager::event_engine::Event event(
       VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(response);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
+      *ext, get_subscriber(), *mock_app);
 
   // TODO check that raized the same fid and cid as subscribed
   resumption_handler_->on_event(event);
@@ -469,8 +457,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
 }
 
-TEST_F(VehicleInfoPendingResumptionHandlerTest,
-       TwoAppsOneSharedDataSuccess) {
+TEST_F(VehicleInfoPendingResumptionHandlerTest, TwoAppsOneSharedDataSuccess) {
   auto mock_app = CreateApp(1);
   auto mock_app2 = CreateApp(2);
   auto ext = CreateExtension(*mock_app);
@@ -481,34 +468,28 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   uint32_t corr_id = 345;
   auto request = CreateVDRequest(corr_id);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(2);
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(2);
   // TODO save cid and fid of the subscription
   EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-  };
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
 
-  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
   // TODO use error message type instead of result code
   application_manager::event_engine::Event event(
       VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(response);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
+      *ext, get_subscriber(), *mock_app);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext2,
-        get_subscriber(),
-        *mock_app2
-        );
+      *ext2, get_subscriber(), *mock_app2);
   // TODO check that raized the same fid and cid as subscribed
   resumption_handler_->on_event(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
@@ -516,7 +497,6 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
   EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
 }
-
 
 TEST_F(VehicleInfoPendingResumptionHandlerTest,
        TwoAppsMultipleSharedDataSuccessResumption) {
@@ -532,35 +512,29 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   uint32_t corr_id = 345;
   auto request = CreateVDRequest(corr_id);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(2);
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(2);
   // TODO save cid and fid of the subscription
   EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-  };
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+          {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
 
-  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
   // TODO use error message type instead of result code
   application_manager::event_engine::Event event(
       VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(response);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
+      *ext, get_subscriber(), *mock_app);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext2,
-        get_subscriber(),
-        *mock_app2
-        );
+      *ext2, get_subscriber(), *mock_app2);
   // TODO check that raized the same fid and cid as subscribed
   resumption_handler_->on_event(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
@@ -583,42 +557,38 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   uint32_t corr_id = 345;
   auto request = CreateVDRequest(corr_id);
   ON_CALL(mock_message_helper_,
-          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
-                             _)
-          ).WillByDefault(Return(request));
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData, _))
+      .WillByDefault(Return(request));
 
-  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(2);
+  EXPECT_CALL(subscribe_catcher_, subscribe(_, _)).Times(2);
   // TODO save cid and fid of the subscription
   EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(2);
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_AVAILABLE},
-  };
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(2);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      subscriptions_result = {
+          {"gps",
+           hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_AVAILABLE},
+      };
 
-  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  auto response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
   // TODO use error message type instead of result code
   application_manager::event_engine::Event event(
       VehicleInfo_SubscribeVehicleData);
   event.set_smart_object(response);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext,
-        get_subscriber(),
-        *mock_app
-        );
+      *ext, get_subscriber(), *mock_app);
   resumption_handler_->HandleResumptionSubscriptionRequest(
-        *ext2,
-        get_subscriber(),
-        *mock_app2
-        );
+      *ext2, get_subscriber(), *mock_app2);
   // TODO check that raized the same fid and cid as subscribed
   resumption_handler_->on_event(event);
 
-  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  second_subscriptions_result=
-  {
-    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
-  };
-  auto second_response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, second_subscriptions_result, corr_id);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
+      second_subscriptions_result = {
+          {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+      };
+  auto second_response = CreateVDResponse(
+      hmi_apis::Common_Result::SUCCESS, second_subscriptions_result, corr_id);
   // TODO use error message type instead of result code
   application_manager::event_engine::Event second_event(
       VehicleInfo_SubscribeVehicleData);
@@ -630,7 +600,5 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
   EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
 }
-
-
 
 }  // namespace vehicle_info_plugin_test

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
@@ -1,0 +1,553 @@
+/*
+ * Copyright (c) 2018, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE. */
+
+#include "gtest/gtest.h"
+#include "test/application_manager/mock_application_manager.h"
+#include "application_manager/test/include/application_manager/mock_event_dispatcher.h"
+#include "application_manager/test/include/application_manager/mock_event_observer.h"
+#include "application_manager/test/include/application_manager/mock_application.h"
+#include "application_manager/test/include/application_manager/mock_message_helper.h"
+//#include "application_manager/mock_rpc_service.h"
+#include "vehicle_info_plugin/vehicle_info_pending_resumption_handler.h"
+
+namespace vehicle_info_plugin_test {
+using namespace vehicle_info_plugin;
+
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::_;
+
+using application_manager::MockMessageHelper;
+typedef NiceMock<::test::components::event_engine_test::MockEventDispatcher> MockEventDispatcher;
+typedef NiceMock<::test::components::event_engine_test::MockEventObserver> MockEventObserver;
+typedef NiceMock<::test::components::application_manager_test::MockApplicationManager> MockApplicationManager;
+typedef NiceMock<::test::components::application_manager_test::MockApplication> MockApplication;
+typedef NiceMock<test::components::application_manager_test::MockRPCService> MockRPCService;
+typedef std::shared_ptr<MockApplication> MockAppPtr;
+typedef std::shared_ptr<vehicle_info_plugin::VehicleInfoAppExtension>
+    VehicleInfoAppExtensionPtr;
+using hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData;
+
+  class SubscribeCatcher {
+   public:
+     MOCK_METHOD2(subscribe, void(const int32_t,
+                  const resumption::ResumptionRequest));
+
+   };
+
+class VehicleInfoPendingResumptionHandlerTest : public ::testing::Test {
+// using namespace vehicle_info_plugin;
+ public:
+  VehicleInfoPendingResumptionHandlerTest()
+      : mock_message_helper_(
+            *application_manager::MockMessageHelper::message_helper_mock())
+
+  {}
+
+  void SetUp() OVERRIDE {
+    ON_CALL(app_manager_mock_, event_dispatcher()).WillByDefault(ReturnRef(event_dispatcher_mock_));
+    ON_CALL(app_manager_mock_, GetRPCService()).WillByDefault(ReturnRef(mock_rpc_service_));
+    resumption_handler_.reset(
+          new vehicle_info_plugin::VehicleInfoPendingResumptionHandler(app_manager_mock_));
+  }
+
+
+  MockAppPtr CreateApp(uint32_t app_id) {
+    auto mock_app = std::make_shared<MockApplication>();
+
+    ON_CALL(app_manager_mock_, application(app_id)).WillByDefault(Return(mock_app));
+    ON_CALL(*mock_app, app_id()).WillByDefault(Return(app_id));
+    return mock_app;
+  }
+
+
+  VehicleInfoAppExtensionPtr CreateExtension(MockApplication& app) {
+    auto ext_ptr = std::make_shared<VehicleInfoAppExtension>(
+          plugin_,
+          app
+          );
+    ON_CALL(app, QueryInterface(VehicleInfoAppExtension::VehicleInfoAppExtensionUID)).
+        WillByDefault(Return(ext_ptr));
+    return ext_ptr;
+  }
+
+  resumption::Subscriber& get_subscriber() {
+    static resumption::Subscriber subscriber =
+        [this](const int32_t corr_id,
+        const resumption::ResumptionRequest resumption_request) {
+        this->subscribe_catcher_.subscribe(corr_id,resumption_request);
+    };
+    return subscriber;
+  }
+
+
+  SubscribeCatcher subscribe_catcher_;
+  MockMessageHelper& mock_message_helper_;
+  MockApplicationManager app_manager_mock_;
+  MockEventDispatcher event_dispatcher_mock_;
+  MockRPCService mock_rpc_service_;
+  vehicle_info_plugin::VehicleInfoPlugin plugin_;
+
+  std::unique_ptr<
+  vehicle_info_plugin::VehicleInfoPendingResumptionHandler> resumption_handler_;
+};
+
+
+smart_objects::SmartObjectSPtr CreateVDRequest(const uint32_t corr_id) {
+  using namespace application_manager;
+  smart_objects::SmartObjectSPtr request=
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  smart_objects::SmartObject& object = *request;
+  object[strings::params][strings::message_type] = static_cast<int>(0); // request
+  object[strings::params][strings::function_id] = static_cast<int>(VehicleInfo_SubscribeVehicleData);
+
+  object[strings::params][strings::correlation_id] =
+      corr_id;
+  object[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  return request;
+}
+
+mobile_apis::VehicleDataType::eType ToVDType(const std::string& vd) {
+  if ("gps" == vd) {
+    return mobile_apis::VehicleDataType::VEHICLEDATA_GPS;
+  }
+  if ("speed" == vd) {
+    return mobile_apis::VehicleDataType::VEHICLEDATA_SPEED;
+  }
+  return mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA;
+}
+
+typedef std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType> VDResponseMap;
+smart_objects::SmartObject CreateVDResponse(const hmi_apis::Common_Result::eType common_result,
+    const VDResponseMap&  subscriptions_result,
+    uint32_t correleation_id
+                                            ) {
+  namespace strings = application_manager::strings;
+  namespace hmi_response = application_manager::hmi_response;
+  smart_objects::SmartObject message(smart_objects::SmartType_Map);
+  smart_objects::SmartObject params(smart_objects::SmartType_Map);
+  params[strings::function_id] = VehicleInfo_SubscribeVehicleData;
+  params[strings::message_type] = 1;  // MessageType::kResponse;
+  params[strings::correlation_id] = correleation_id;
+  params[strings::protocol_type] = 1;  // HMI protocol type
+  params[hmi_response::code] = common_result;
+  message[strings::params] = params;
+  smart_objects::SmartObject msg_params(smart_objects::SmartType_Map);
+  for (const auto& subscription : subscriptions_result) {
+    smart_objects::SmartObject subscription_result(smart_objects::SmartType_Map);
+    subscription_result[strings::data_type] = ToVDType(subscription.first);
+    subscription_result[strings::result_code] = subscription.second;
+    msg_params[subscription.first] = subscription_result;
+  }
+  message[strings::msg_params] = msg_params;
+  return message;
+}
+
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       NoSubscriptionNoAction) {
+
+
+  auto mock_app = CreateApp(1);
+  auto ext_ptr = CreateExtension(*mock_app);
+
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(0);
+  resumption::Subscriber& subscribe = get_subscriber();
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext_ptr,
+        subscribe,
+        *mock_app
+        );
+}
+
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataSuccess) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  auto request = CreateVDRequest(1);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_));
+  // TODO subscription data
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_));
+  // TODO check hmi request
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseSuccess) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_));
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
+
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+  };
+
+  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseOneFailed) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_));
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+  };
+
+  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+}
+
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseAllFailed) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_));
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_SUBSCRIBED},
+  };
+
+  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       OneAppSeveralVehicleDataResponseOveralResultFailed) {
+  auto mock_app = CreateApp(1);
+  auto ext = CreateExtension(*mock_app);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_));
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_));
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+  };
+
+  auto response = CreateVDResponse(hmi_apis::Common_Result::ABORTED, subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       TwoAppsOneSharedDataSuccess) {
+  auto mock_app = CreateApp(1);
+  auto mock_app2 = CreateApp(2);
+  auto ext = CreateExtension(*mock_app);
+  auto ext2 = CreateExtension(*mock_app2);
+  ext->AddPendingSubscription("gps");
+  ext2->AddPendingSubscription("gps");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(2);
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+  };
+
+  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext2,
+        get_subscriber(),
+        *mock_app2
+        );
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
+  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
+}
+
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       TwoAppsMultipleSharedDataSuccessResumption) {
+  auto mock_app = CreateApp(1);
+  auto mock_app2 = CreateApp(2);
+  auto ext = CreateExtension(*mock_app);
+  auto ext2 = CreateExtension(*mock_app2);
+  ext->AddPendingSubscription("gps");
+  ext->AddPendingSubscription("speed");
+  ext2->AddPendingSubscription("gps");
+  ext2->AddPendingSubscription("speed");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(2);
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(1);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+    {"speed", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+  };
+
+  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext2,
+        get_subscriber(),
+        *mock_app2
+        );
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("speed"));
+  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
+}
+
+TEST_F(VehicleInfoPendingResumptionHandlerTest,
+       TwoAppsOneSharedDataFailRetryforSecondApp) {
+  auto mock_app = CreateApp(1);
+  auto mock_app2 = CreateApp(2);
+  auto ext = CreateExtension(*mock_app);
+  auto ext2 = CreateExtension(*mock_app2);
+  ext->AddPendingSubscription("gps");
+  ext2->AddPendingSubscription("gps");
+
+  uint32_t corr_id = 345;
+  auto request = CreateVDRequest(corr_id);
+  ON_CALL(mock_message_helper_,
+          CreateModuleInfoSO(VehicleInfo_SubscribeVehicleData,
+                             _)
+          ).WillByDefault(Return(request));
+
+  EXPECT_CALL(subscribe_catcher_, subscribe(_,_)).Times(2);
+  // TODO save cid and fid of the subscription
+  EXPECT_CALL(event_dispatcher_mock_, raise_event(_)).Times(2);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_,_)).Times(2);
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_DATA_NOT_AVAILABLE},
+  };
+
+  auto response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event event(
+      VehicleInfo_SubscribeVehicleData);
+  event.set_smart_object(response);
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext,
+        get_subscriber(),
+        *mock_app
+        );
+  resumption_handler_->HandleResumptionSubscriptionRequest(
+        *ext2,
+        get_subscriber(),
+        *mock_app2
+        );
+  // TODO check that raized the same fid and cid as subscribed
+  resumption_handler_->on_event(event);
+
+  const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>  second_subscriptions_result=
+  {
+    {"gps", hmi_apis::Common_VehicleDataResultCode::VDRC_SUCCESS},
+  };
+  auto second_response = CreateVDResponse(hmi_apis::Common_Result::SUCCESS, second_subscriptions_result, corr_id);
+  // TODO use error message type instead of result code
+  application_manager::event_engine::Event second_event(
+      VehicleInfo_SubscribeVehicleData);
+  second_event.set_smart_object(second_response);
+
+  resumption_handler_->on_event(second_event);
+  EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
+  EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
+  EXPECT_EQ(ext->PendingSubscriptions().size(), 0u);
+  EXPECT_EQ(ext2->PendingSubscriptions().size(), 0u);
+}
+
+
+
+}  // namespace vehicle_info_plugin_test

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -2490,6 +2490,27 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponseFromHmi(
   return message;
 }
 
+smart_objects::SmartObjectSPtr MessageHelper::CreateResponseMessageFromHmi(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const int32_t result_code) {
+  smart_objects::SmartObject params(smart_objects::SmartType_Map);
+  params[strings::function_id] = function_id;
+  params[strings::message_type] = MessageType::kResponse;
+  params[strings::correlation_id] = correlation_id;
+  params[strings::protocol_type] = commands::CommandImpl::hmi_protocol_type_;
+  params[hmi_response::code] = result_code;
+
+  smart_objects::SmartObjectSPtr response =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+  auto& message = *response;
+  message[strings::params] = params;
+  message[strings::msg_params] =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  return response;
+}
+
 smart_objects::SmartObjectSPtr MessageHelper::CreateOnServiceUpdateNotification(
     const hmi_apis::Common_ServiceType::eType service_type,
     const hmi_apis::Common_ServiceEvent::eType service_event,

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -395,6 +395,11 @@ class MockMessageHelper {
                                               const uint32_t correlation_id,
                                               const int32_t result_code,
                                               const std::string& info));
+
+  MOCK_METHOD3(CreateResponseMessageFromHmi,
+               smart_objects::SmartObjectSPtr(const int32_t function_id,
+                                              const uint32_t correlation_id,
+                                              const int32_t result_code));
   MOCK_METHOD3(CreateUIDeleteWindowRequestToHMI,
                smart_objects::SmartObjectSPtr(
                    application_manager::ApplicationSharedPtr application,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -728,4 +728,12 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponseFromHmi(
       ->CreateNegativeResponseFromHmi(
           function_id, correlation_id, result_code, info);
 }
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateResponseMessageFromHmi(
+    const int32_t function_id,
+    const uint32_t correlation_id,
+    const int32_t result_code) {
+  return MockMessageHelper::message_helper_mock()->CreateResponseMessageFromHmi(
+      function_id, correlation_id, result_code);
+}
 }  // namespace application_manager


### PR DESCRIPTION
Rework VehicleData resumption Handler.

This is how resumption handler should looks like. 

Contains some debug logs, will remove before merge


Temporary points to impl/fix_way_points_simultanious_resumption, for easier review 