### PR TITLE
[SDL-0190] Update commands unit tests

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_bc_system_capability_updated_notification_from_hmi_test.cc
@@ -137,6 +137,9 @@ TEST_F(
   (*message_)[strings::msg_params][strings::app_id] = kAppId;
 
   ON_CALL(app_mngr_, application(kAppId)).WillByDefault(Return(mock_app_));
+  application_manager::DisplayCapabilitiesBuilder builder(*mock_app_);
+  ON_CALL(*mock_app_, display_capabilities_builder())
+      .WillByDefault(ReturnRef(builder));
 
   EXPECT_CALL(*mock_app_,
               set_display_capabilities(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
@@ -221,6 +221,11 @@ class AddCommandRequestTest
         mock_rpc_service_,
         ManageMobileCommand(response,
                             am::commands::Command::CommandSource::SOURCE_SDL));
+
+    resumprion_test::MockResumeCtrl mock_resume_ctrl;
+    EXPECT_CALL(app_mngr_, resume_controller())
+        .WillOnce(ReturnRef(mock_resume_ctrl));
+    EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
     std::shared_ptr<CommandRequestImpl> base_class_request =
         static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
     base_class_request->onTimeOut();
@@ -1092,6 +1097,12 @@ TEST_F(AddCommandRequestTest,
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
+
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
+
   std::shared_ptr<CommandRequestImpl> base_class_request =
       static_cast<std::shared_ptr<CommandRequestImpl> >(
           CreateCommand<AddCommandRequest>(msg_));
@@ -1142,6 +1153,12 @@ TEST_F(AddCommandRequestTest, OnTimeOut_AppRemoveCommandCalled) {
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
+
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
+
   std::shared_ptr<CommandRequestImpl> base_class_request =
       static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
   base_class_request->onTimeOut();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -184,6 +184,11 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeout_GENERIC_ERROR) {
       ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
       .WillOnce(DoAll(SaveArg<0>(&vr_command_result), Return(true)));
 
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
+
   req_vr->onTimeOut();
   EXPECT_EQ(
       (*vr_command_result)[strings::msg_params][strings::success].asBool(),
@@ -704,7 +709,12 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
                   MobileResultCodeIs(mobile_apis::Result::GENERIC_ERROR),
                   am::commands::Command::SOURCE_SDL));
 
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+
   command_->onTimeOut();
 }
 
@@ -748,7 +758,12 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(*mock_app_, RemoveChoiceSet(kChoiceSetId));
 
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
+
   command_->onTimeOut();
 }
 
@@ -794,6 +809,11 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(invalid_app));
   EXPECT_CALL(*mock_app_, RemoveChoiceSet(_)).Times(0);
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
+
   command_->onTimeOut();
 }
 
@@ -833,6 +853,10 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   FillMessageFieldsItem2(message_);
 
   EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _)).Times(0);
+  resumprion_test::MockResumeCtrl mock_resume_ctrl;
+  EXPECT_CALL(app_mngr_, resume_controller())
+      .WillOnce(ReturnRef(mock_resume_ctrl));
+  EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
 
   Event event(hmi_apis::FunctionID::VR_AddCommand);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -125,157 +125,50 @@ TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidApp_UNSUCCESS) {
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_InvalidVrHelp_UNSUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-  std::vector<std::string> help_prompt = {"help_prompt"};
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  EXPECT_CALL(app_mngr_settings_, help_prompt())
-      .WillOnce(ReturnRef(help_prompt));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(smart_objects::SmartObjectSPtr()));
 
-  smart_objects::SmartObject so_help_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  so_help_prompt[am::strings::text] = help_prompt[0];
-  so_help_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
+  ON_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillByDefault(Return(std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map)));
 
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  so_prompt[0] = so_help_prompt;
-
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
-
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
-
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
-
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
-
-  smart_objects::SmartObjectSPtr vr_help;  // = NULL;
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
-
-  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(0);
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(1);
 
   command_->Run();
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest, Run_SUCCESS) {
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::HELPPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][1] =
-      mobile_apis::GlobalProperty::TIMEOUTPROMPT;
-  (*msg_)[am::strings::msg_params][am::strings::properties][2] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
-  (*msg_)[am::strings::msg_params][am::strings::properties][3] =
-      mobile_apis::GlobalProperty::MENUNAME;
-  (*msg_)[am::strings::msg_params][am::strings::properties][4] =
-      mobile_apis::GlobalProperty::MENUICON;
-  (*msg_)[am::strings::msg_params][am::strings::properties][5] =
-      mobile_apis::GlobalProperty::KEYBOARDPROPERTIES;
+  am::ResetGlobalPropertiesResult result;
+  result.help_prompt = true;
+  result.timeout_prompt = true;
+  result.vr_help_title_items = true;
+  result.menu_name = true;
+  result.menu_icon = true;
+  result.keyboard_properties = true;
+  result.number_of_reset_vr = 1;
 
-  EXPECT_CALL(app_mngr_, RemoveAppFromTTSGlobalPropertiesList(kConnectionKey));
-
-  std::vector<std::string> help_prompt = {"help_prompt"};
-
-  EXPECT_CALL(app_mngr_settings_, help_prompt())
-      .WillOnce(ReturnRef(help_prompt));
-
-  smart_objects::SmartObject so_help_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  so_help_prompt[am::strings::text] = help_prompt[0];
-  so_help_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-  so_prompt[0] = so_help_prompt;
-  EXPECT_CALL(*mock_app_, set_help_prompt(so_prompt));
-
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
-
-  smart_objects::SmartObject timeout_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  timeout_prompt[am::strings::text] = time_out_prompt[0];
-  timeout_prompt[am::strings::type] =
-      hmi_apis::Common_SpeechCapabilities::SC_TEXT;
-
-  smart_objects::SmartObject so_time_out_prompt =
-      smart_objects::SmartObject(smart_objects::SmartType_Array);
-
-  so_time_out_prompt[0] = timeout_prompt;
-
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(so_time_out_prompt));
-
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
-
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  ON_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillByDefault(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
-  smart_objects::SmartObjectSPtr vr_help =
+  smart_objects::SmartObjectSPtr msg_params =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
-  smart_objects::SmartObject msg_params =
-      smart_objects::SmartObject(smart_objects::SmartType_Map);
-  msg_params[am::hmi_request::menu_title] = "";
-
-  EXPECT_CALL(*mock_app_,
-              set_menu_title(msg_params[am::hmi_request::menu_title]));
-
-  EXPECT_CALL(*mock_app_, help_prompt()).WillOnce(Return(&so_help_prompt));
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(&so_help_prompt));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -304,27 +197,18 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       hmi_apis::Common_Result::SUCCESS;
   (*msg_)[am::strings::params][am::hmi_response::code] = result_code;
 
-  (*msg_)[am::strings::msg_params][am::strings::properties][0] =
-      mobile_apis::GlobalProperty::VRHELPTITLE;
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
 
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
-  EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
-
-  smart_objects::SmartObjectSPtr vr_help =
+  smart_objects::SmartObjectSPtr msg_params =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
+
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+
   EXPECT_CALL(
       mock_rpc_service_,
       ManageHMICommand(
@@ -353,20 +237,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   MessageSharedPtr ui_msg = CreateMessage();
   (*ui_msg)[am::strings::params][am::strings::correlation_id] = kCorrelationId;
@@ -412,19 +298,22 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   (*msg_)[am::strings::msg_params][am::strings::properties][0] =
       mobile_apis::GlobalProperty::VRHELPTITLE;
 
-  std::string vr_help_title("vr_help_title");
-  EXPECT_CALL(app_mngr_settings_, vr_help_title())
-      .WillOnce(ReturnRef(vr_help_title));
+  am::ResetGlobalPropertiesResult result;
+  result.vr_help_title_items = true;
 
-  smart_objects::SmartObject so_vr_help_title =
-      smart_objects::SmartObject(smart_objects::SmartType_String);
-  so_vr_help_title = vr_help_title;
-  EXPECT_CALL(*mock_app_, set_vr_help_title(so_vr_help_title));
-
-  EXPECT_CALL(*mock_app_, reset_vr_help_title());
-  EXPECT_CALL(*mock_app_, reset_vr_help());
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .Times(0);
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+
   EXPECT_CALL(
       mock_rpc_service_,
       ManageHMICommand(
@@ -433,8 +322,6 @@ TEST_F(ResetGlobalPropertiesRequestTest, OnEvent_InvalidApp_NoHashUpdate) {
   smart_objects::SmartObjectSPtr vr_help =
       std::make_shared<smart_objects::SmartObject>(
           smart_objects::SmartType_Map);
-  EXPECT_CALL(mock_message_helper_, CreateAppVrHelp(_))
-      .WillOnce(Return(vr_help));
 
   EXPECT_CALL(*mock_app_, UpdateHash()).Times(0);
 
@@ -461,20 +348,22 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
-
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
-
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
+
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
+
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(
       mock_rpc_service_,
@@ -528,18 +417,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 
@@ -594,18 +485,20 @@ TEST_F(ResetGlobalPropertiesRequestTest,
   (*msg_)[am::strings::msg_params][am::strings::properties][1] =
       mobile_apis::GlobalProperty::MENUICON;
 
-  std::vector<std::string> time_out_prompt;
-  time_out_prompt.push_back("time_out");
-  EXPECT_CALL(app_mngr_settings_, time_out_promt())
-      .WillOnce(ReturnRef(time_out_prompt));
+  am::ResetGlobalPropertiesResult result;
+  result.timeout_prompt = true;
+  result.menu_icon = true;
 
-  EXPECT_CALL(*mock_app_, set_timeout_prompt(_));
+  EXPECT_CALL(app_mngr_, ResetGlobalProperties(_, _)).WillOnce(Return(result));
 
-  smart_objects::SmartObjectSPtr prompt =
-      std::make_shared<smart_objects::SmartObject>();
-  *prompt = "prompt";
+  smart_objects::SmartObjectSPtr msg_params =
+      std::make_shared<smart_objects::SmartObject>(
+          smart_objects::SmartType_Map);
 
-  EXPECT_CALL(*mock_app_, timeout_prompt()).WillOnce(Return(prompt.get()));
+  EXPECT_CALL(mock_message_helper_, CreateTTSResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
+  EXPECT_CALL(mock_message_helper_, CreateUIResetGlobalPropertiesRequest(_, _))
+      .WillOnce(Return(msg_params));
 
   EXPECT_CALL(*mock_app_, set_reset_global_properties_active(true));
 


### PR DESCRIPTION
In the scope of https://adc.luxoft.com/jira/browse/FORDTCN-6865

This PR is **[ready]** for review.


### Summary

- Fix sdl_commands_test_unity

In accordance with the [[SDL-0190] Handle response from HMI during resumption data](https://github.com/LuxoftSDL/sdl_core/pull/84) implementation 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
