### PR TITLE
[SDL-0190] Fix issue with processing of on_events

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
@@ -72,8 +72,11 @@ void SDLPendingResumptionHandler::ClearPendingRequestsMap() {
 void SDLPendingResumptionHandler::OnResumptionRevert() {
   LOG4CXX_AUTO_TRACE(logger_);
   using namespace application_manager;
-  ClearPendingRequestsMap();
 
+  if (!pending_requests_.empty()) {
+    LOG4CXX_DEBUG(logger_, "Still waiting for some resonse");
+    return;
+  }
   if (!freezed_resumptions_.empty()) {
     ResumptionAwaitingHandling freezed_resumption = freezed_resumptions_.back();
     freezed_resumptions_.pop_back();


### PR DESCRIPTION
Fix https://adc.luxoft.com/jira/browse/FORDTCN-7299 

If a subscription is the last request for resumption, that resumption data processor will revert resumption after it `ClearPendingResumptionRequests` will be called before `SDLPendingResumptionHandler::on_event`, and resumption data processor will think that vehicle data was not subscribed successfully.


Quick fix is reordered subscription to response event. 
SO that pending resumption handler will be subscribed first and redumption data processor the second 


Also renamed ClearPendingResumption to OnResumptionRevert, that is more correct 


Second fix : 
event dispatcher was not support recursive on_event because of shared state. Make variable observers_ local,so it could ro recursive on_event call