### PR TITLE
[SDL-0190] Update unit tests 

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_pending_resumption_handler.cc
@@ -62,7 +62,6 @@ void SDLPendingResumptionHandler::ClearPendingRequestsMap() {
             it.second[strings::params][strings::function_id].asInt());
     unsubscribe_from_event(timed_out_pending_request_fid);
     if (!app_ids_.empty()) {
-      auto app_id = app_ids_.front();
       app_ids_.pop();
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_system_capability_updated_notification_test.cc
@@ -183,6 +183,10 @@ TEST_F(
   ON_CALL(mock_hmi_capabilities_, system_display_capabilities())
       .WillByDefault(Return(system_display_capabilities));
 
+  application_manager::DisplayCapabilitiesBuilder builder(*mock_app_);
+  ON_CALL(*mock_app_, display_capabilities_builder())
+      .WillByDefault(ReturnRef(builder));
+
   sdl_rpc_plugin::SDLRPCPlugin sdl_rpc_plugin;
 
   std::shared_ptr<sdl_rpc_plugin::SystemCapabilityAppExtension>
@@ -197,7 +201,7 @@ TEST_F(
       DataAccessor<application_manager::ApplicationSet>(apps, apps_lock_));
 
   ON_CALL(app_mngr_, applications()).WillByDefault(Return(apps_data));
-  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
+  ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kAppId));
   ON_CALL(*mock_app_, display_capabilities()).WillByDefault(Return(nullptr));
   ON_CALL(*mock_app_,
           QueryInterface(sdl_rpc_plugin::SystemCapabilityAppExtension::


### PR DESCRIPTION
In the scope of https://adc.luxoft.com/jira/browse/FORDTCN-6865

This PR is **[ready]** for review.


### Summary

- Remove unused variable 
- Fix unit test

In accordance with the [[SDL-0190] Handle response from HMI during resumption data](https://github.com/LuxoftSDL/sdl_core/pull/84) implementation 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
