### PR TITLE
[SDL-0188] SDL reverts already resumed data and fail resumption if HMI responds with error to GetInteriorVehicleDataRequest

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor.h
@@ -34,6 +34,7 @@
 #include "application_manager/application.h"
 #include "application_manager/event_engine/event_observer.h"
 #include "application_manager/resumption/resume_ctrl.h"
+#include "application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_types.h"
 #include "smart_objects/smart_object.h"
 #include "utils/rwlock.h"
 
@@ -45,6 +46,8 @@ namespace app_mngr = application_manager;
  * @brief The ResumptionRequestIDs struct contains fields, needed during
  * processing events, related to responses from HMI to each resumption request
  */
+using ModuleUid = rc_rpc_plugin::rc_rpc_types::ModuleUid;
+
 struct ResumptionRequestIDs {
   hmi_apis::FunctionID::eType function_id;
   int32_t correlation_id;
@@ -75,6 +78,8 @@ struct ApplicationResumptionStatus {
   std::vector<ResumptionRequest> successful_requests;
   std::vector<std::string> unsuccessful_vehicle_data_subscriptions_;
   std::vector<std::string> successful_vehicle_data_subscriptions_;
+  std::vector<ModuleUid> succesfull_module_subscriptions_;
+  std::vector<ModuleUid> unsuccesfull_module_subscriptions_;
 };
 
 /**
@@ -385,6 +390,10 @@ class ResumptionDataProcessor : public app_mngr::event_engine::EventObserver {
   void CheckVehicleDataResponse(const smart_objects::SmartObject& request,
                                 const smart_objects::SmartObject& response,
                                 ApplicationResumptionStatus& status);
+
+  void CheckModuleDataSubscription(const smart_objects::SmartObject& request,
+                                   const smart_objects::SmartObject& response,
+                                   ApplicationResumptionStatus& status);
 
   /**
    * @brief Checks whether CreateWindow response successful or not and handles

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_app_extension.h
@@ -228,7 +228,7 @@ class RCAppExtension : public application_manager::AppExtension {
                          resumption::Subscriber subscriber) OVERRIDE;
 
   void RevertResumption(
-      const smart_objects::SmartObject& subscriptions) OVERRIDE;
+      const smart_objects::SmartObject& subscriptions_so) OVERRIDE;
 };
 
 typedef std::shared_ptr<RCAppExtension> RCAppExtensionPtr;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_rpc_plugin.h
@@ -114,6 +114,17 @@ class RCRPCPlugin : public plugins::RPCPlugin {
                                      RCAppExtension& ext,
                                      resumption::Subscriber subscriber);
 
+  /**
+   * @brief Reverts resumption data, clears all pending resumption and sends
+   * ubsubscribe vehicle data request to a HMI
+   * @param subscriptions Module data that SDL should unsubscribe off
+   */
+  void RevertResumption(const std::set<ModuleUid>& subscriptions);
+
+  bool IsAnotherAppsSubscribedOnTheSameModule(
+      const rc_rpc_types::ModuleUid& module,
+      const application_manager::ApplicationSet& applications);
+
   static const uint32_t kRCPluginID = 153;
 
   typedef std::vector<application_manager::ApplicationSharedPtr> Apps;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
@@ -77,7 +77,7 @@ void RCPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     const auto resumption_request =
         MakeResumptionRequest(cid, fid, *subscription_request);
     freezed_resumptions_[subscription].push(resumption_request);
-    subscriber(cid, resumption_request);
+    subscriber(app.app_id(), resumption_request);
     LOG4CXX_DEBUG(logger_,
                   "Freezed request with correlation_id: "
                       << cid << " module type: " << subscription.first

--- a/src/components/application_manager/src/resumption/resumption_data_processor.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor.cc
@@ -33,6 +33,7 @@
 #include "application_manager/event_engine/event_observer.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/resumption/resumption_data_processor.h"
+#include "application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h"
 #include "application_manager/smart_object_keys.h"
 
 namespace resumption {
@@ -45,8 +46,17 @@ using app_mngr::MessageHelper;
 namespace strings = app_mngr::strings;
 namespace event_engine = app_mngr::event_engine;
 namespace commands = app_mngr::commands;
+namespace message_params = rc_rpc_plugin::message_params;
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "Resumption")
+std::map<hmi_apis::Common_ModuleType::eType, std::string>
+    module_types_str_mapping{
+        {hmi_apis::Common_ModuleType::eType::CLIMATE, {"CLIMATE"}},
+        {hmi_apis::Common_ModuleType::eType::RADIO, {"RADIO"}},
+        {hmi_apis::Common_ModuleType::eType::SEAT, {"SEAT"}},
+        {hmi_apis::Common_ModuleType::eType::AUDIO, {"AUDIO"}},
+        {hmi_apis::Common_ModuleType::eType::LIGHT, {"LIGHT"}},
+        {hmi_apis::Common_ModuleType::eType::HMI_SETTINGS, {"HMI_SETTINGS"}}};
 
 ResumptionDataProcessor::ResumptionDataProcessor(
     app_mngr::ApplicationManager& application_manager)
@@ -1007,15 +1017,37 @@ void ResumptionDataProcessor::DeletePluginsSubscriptions(
   }
 
   const ApplicationResumptionStatus& status = it->second;
-  smart_objects::SmartObject extension_subscriptions;
+  smart_objects::SmartObject extension_vd_subscriptions;
   for (auto ivi : status.successful_vehicle_data_subscriptions_) {
     LOG4CXX_DEBUG(logger_, "ivi " << ivi << " should be deleted");
-    extension_subscriptions[ivi] = true;
+    extension_vd_subscriptions[ivi] = true;
+  }
+
+  smart_objects::SmartObject extension_modules_subscriptions(
+      smart_objects::SmartType_Map);
+
+  if (!status.succesfull_module_subscriptions_.empty()) {
+    extension_modules_subscriptions[message_params::kModuleData] =
+        new smart_objects::SmartObject(smart_objects::SmartType_Array);
+
+    auto& module_data_so =
+        extension_modules_subscriptions[message_params::kModuleData];
+
+    uint32_t index = 0;
+    for (const auto& module : status.succesfull_module_subscriptions_) {
+      module_data_so[index] =
+          new smart_objects::SmartObject(smart_objects::SmartType_Map);
+      module_data_so[index][message_params::kModuleType] = module.first;
+      module_data_so[index][message_params::kModuleId] = module.second;
+    }
+
+    extension_vd_subscriptions[message_params::kModuleData] =
+        extension_modules_subscriptions[message_params::kModuleData];
   }
   resumption_status_lock_.Release();
 
   for (auto& extension : application->Extensions()) {
-    extension->RevertResumption(extension_subscriptions);
+    extension->RevertResumption(extension_vd_subscriptions);
   }
 }
 
@@ -1059,6 +1091,61 @@ void ResumptionDataProcessor::CheckVehicleDataResponse(
       LOG4CXX_TRACE(logger_, "ivi " << ivi << " was successfuly subscribed");
       status.successful_vehicle_data_subscriptions_.push_back(ivi);
     }
+  }
+}
+
+void ResumptionDataProcessor::CheckModuleDataSubscription(
+    const ns_smart_device_link::ns_smart_objects::SmartObject& request,
+    const ns_smart_device_link::ns_smart_objects::SmartObject& response,
+    ApplicationResumptionStatus& status) {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  const auto& msg_params__so = request[strings::msg_params];
+  const auto requested_module_type =
+      msg_params__so[message_params::kModuleType].asString();
+  const auto requested_module_id =
+      msg_params__so[message_params::kModuleId].asString();
+  const ModuleUid requested_module{requested_module_type, requested_module_id};
+
+  if (!IsResponseSuccessful(response)) {
+    LOG4CXX_TRACE(logger_, "Module data subscription request NOT succesfull");
+    status.unsuccesfull_module_subscriptions_.push_back(requested_module);
+    return;
+  }
+
+  const auto& responsed_module_data_so =
+      response[strings::msg_params][message_params::kModuleData];
+
+  if (0 == responsed_module_data_so.length()) {
+    LOG4CXX_TRACE(logger_, "Module data subscription request not succesfull");
+    status.unsuccesfull_module_subscriptions_.push_back(requested_module);
+    return;
+  }
+
+  const auto responsed_module_type_int =
+      static_cast<hmi_apis::Common_ModuleType::eType>(
+          responsed_module_data_so[message_params::kModuleType].asUInt());
+
+  const auto responsed_module_type_str =
+      module_types_str_mapping[responsed_module_type_int];
+
+  const auto responsed_module_id =
+      responsed_module_data_so[message_params::kModuleId].asString();
+  const ModuleUid responsed_module{responsed_module_type_str,
+                                   responsed_module_id};
+
+  if (requested_module == responsed_module) {
+    LOG4CXX_TRACE(logger_,
+                  "Module [" << requested_module.first << ":"
+                             << requested_module.second
+                             << "] was successfuly subscribed");
+    status.succesfull_module_subscriptions_.push_back(requested_module);
+  } else {
+    LOG4CXX_TRACE(logger_,
+                  "Module [" << requested_module.first << ":"
+                             << requested_module.second
+                             << "] was NOT successfuly subscribed");
+    status.unsuccesfull_module_subscriptions_.push_back(requested_module);
   }
 }
 


### PR DESCRIPTION
Fixes [FORDTCN-7214](https://adc.luxoft.com/jira/browse/FORDTCN-7214)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests
ATF scripts

### Summary
SDL should revert already resumed data and fail resumption if HMI responds with error to GetInteriorVehicleDataRequest

### Tasks Remaining:
- [ ] Fix build with UT
- [ ] Add Unit test for this functionality

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
