### PR TITLE
[SDL-0188] WARNINGS at the double subscription

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -121,17 +121,27 @@ void GetInteriorVehicleDataRequest::ProcessResponseToMobileFromCache(
   LOG4CXX_DEBUG(logger_,
                 "kSubscribe exist" << request_msg_params.keyExists(
                     message_params::kSubscribe));
+
+  mobile_apis::Result::eType result_code = mobile_apis::Result::SUCCESS;
   if (request_msg_params.keyExists(message_params::kSubscribe)) {
     response_msg_params[message_params::kIsSubscribed] =
         request_msg_params[message_params::kSubscribe].asBool();
     if (request_msg_params[message_params::kSubscribe].asBool()) {
       auto extension = RCHelpers::GetRCExtension(*app);
       DCHECK(extension);
-      extension->SubscribeToInteriorVehicleData(module);
+      const bool is_app_already_subscribed =
+          extension->IsSubscribedToInteriorVehicleData(module);
+      if (is_app_already_subscribed) {
+        response_msg_params
+            [app_mngr::strings::msg_params][app_mngr::strings::info] =
+                "App is already subscribed to the provided module";
+        result_code = mobile_apis::Result::WARNINGS;
+      } else {
+        extension->SubscribeToInteriorVehicleData(module);
+      }
     }
   }
-  SendResponse(
-      true, mobile_apis::Result::SUCCESS, nullptr, &response_msg_params);
+  SendResponse(true, result_code, nullptr, &response_msg_params);
   if (AppShouldBeUnsubscribed()) {
     auto extension = RCHelpers::GetRCExtension(*app);
     DCHECK(extension);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/get_interior_vehicle_data_request_test.cc
@@ -315,6 +315,51 @@ TEST_F(
 
 TEST_F(
     GetInteriorVehicleDataRequestTest,
+    Execute_ExpectMessageNotSentToHMI_DoubleSubscription_WarningsSentToMobile) {
+  // Arrange
+  const ModuleUid module(module_type, module_id);
+  rc_app_extention_->SubscribeToInteriorVehicleData(module);
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kModuleType] = module_eType;
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kModuleId] = module_id;
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kSubscribe] = true;
+
+  auto command =
+      CreateRCCommand<rc_rpc_plugin::commands::GetInteriorVehicleDataRequest>(
+          mobile_message);
+
+  // Expectations
+  EXPECT_CALL(mock_interior_data_cache_, Contains(module))
+      .WillOnce(Return(true));
+
+  smart_objects::SmartObject radio_data;
+  radio_data[message_params::kBand] = enums_value::kAM;
+  EXPECT_CALL(mock_interior_data_cache_, Retrieve(module))
+      .WillOnce(Return(radio_data));
+
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(0);
+  MessageSharedPtr command_result;
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(MobileResultCodeIs(mobile_apis::Result::WARNINGS), _))
+      .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
+
+  // Act
+  ASSERT_TRUE(command->Init());
+  command->Run();
+
+  // Assert
+  EXPECT_EQ((*command_result)[application_manager::strings::msg_params]
+                             [message_params::kModuleData]
+                             [message_params::kRadioControlData],
+            radio_data);
+}
+
+TEST_F(
+    GetInteriorVehicleDataRequestTest,
     Execute_ExpectCorrectMessageSentToHMI_LastAppSubscribedUnsubscribe_ClearCache) {
   // Arrange
   MessageSharedPtr mobile_message = CreateBasicMessage();


### PR DESCRIPTION

In the scope of https://adc.luxoft.com/jira/browse/FORDTCN-7215

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
https://github.com/LuxoftSDL/sdl_atf_test_scripts/pull/61

### Summary
SDL should respond with the WARNINGS result code if already subscribed app tries to subscribe to the same module


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
