### PR TITLE
[SDL-0190] Fix wrong revert of GP and Commands

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -4346,6 +4346,9 @@ ApplicationManagerImpl::CreateAllAppGlobalPropsIDList(
   if (application->vr_help_title()) {
     (*global_properties)[i++] = GlobalProperty::VRHELPTITLE;
   }
+  if (application->vr_help()) {
+    (*global_properties)[i++] = GlobalProperty::VRHELPITEMS;
+  }
   if (application->menu_title()) {
     (*global_properties)[i++] = GlobalProperty::MENUNAME;
   }


### PR DESCRIPTION
Fixes [FORDTCN-7298](https://adc.luxoft.com/jira/browse/FORDTCN-7298)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF scripts

### Summary
There was found two issues:
1. Commands revert has been done by internal id instead of cmdID which makes resumption data revert sensitive to commands order. This peace of code was updated to work properly with cmdID despite of commands resumption order
2. There was a missing part of logic regarding reset of VRHelp property. Because this property was not considered during revert, in some cases SDL does not trigger sending of SetGP. Missing check has been added to resolve that issue

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
