### PR TITLE
Fix/fix rai default timeout

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -71,17 +71,19 @@ class RegisterAppInterfaceRequest
   /**
    * @brief RegisterAppInterfaceRequest class destructor
    **/
-  virtual ~RegisterAppInterfaceRequest();
+  ~RegisterAppInterfaceRequest();
 
   /**
    * @brief Init required by command resources
    **/
-  virtual bool Init();
+  bool Init() FINAL;
 
   /**
    * @brief Execute command
    **/
-  virtual void Run();
+  void Run() FINAL;
+
+  uint32_t default_timeout() const FINAL;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -80,6 +80,7 @@ using sdl_rpc_plugin::commands::RegisterAppInterfaceRequest;
 namespace {
 const uint32_t kConnectionKey = 1u;
 const uint32_t kConnectionKey2 = 2u;
+const uint32_t kDefaultTimeout = 0u;
 const connection_handler::DeviceHandle kDeviceHandle = 3u;
 const hmi_apis::Common_Language::eType kHmiLanguage =
     hmi_apis::Common_Language::EN_US;
@@ -348,6 +349,11 @@ TEST_F(RegisterAppInterfaceRequestTest, Init_SUCCESS) {
   EXPECT_TRUE(command_->Init());
 }
 
+TEST_F(RegisterAppInterfaceRequestTest, DefaultTimeout_CheckIfZero_SUCCESS) {
+  command_->Init();
+  EXPECT_EQ(command_->default_timeout(), kDefaultTimeout);
+}
+
 TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
   InitBasicMessage();
   (*msg_)[am::strings::msg_params][am::strings::hash_id] = kAppId1;
@@ -356,7 +362,6 @@ TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
       .WillOnce(Return(true))
       .WillOnce(Return(false));
   ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
-  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(_, _)).WillOnce(Return(false));
 
   connection_handler::DeviceHandle handle = 1;
@@ -448,7 +453,6 @@ TEST_F(RegisterAppInterfaceRequestTest,
       .WillOnce(Return(true))
       .WillOnce(Return(false));
   ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
-  EXPECT_CALL(app_mngr_, updateRequestTimeout(_, _, _));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(_, _)).WillOnce(Return(false));
 
   connection_handler::DeviceHandle handle = 1;
@@ -756,7 +760,6 @@ TEST_F(RegisterAppInterfaceRequestTest,
       .WillOnce(Return(true))
       .WillOnce(Return(false));
   ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
-  EXPECT_CALL(app_mngr_, updateRequestTimeout(kConnectionKey2, _, _));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(kConnectionKey2, kAppId1))
       .WillOnce(Return(false));
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
As RAI request does not depend on any HMI response there is no need to track any timeout for it. RAI request will be removed from/ RequestController queue upon RAI response which will be sent anyway.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
