### PR TITLE
Fix/fix vehicle data subscription for shared data

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_app_extension.h
@@ -92,6 +92,16 @@ class VehicleInfoAppExtension : public app_mngr::AppExtension {
   bool isSubscribedToVehicleInfo(const std::string& vehicle_data_type) const;
 
   /**
+   * @brief isPendingSubscriptionToVehicleInfo checks if there any extension
+   * with pending subscription to vehicle data
+   * @param vehicle_data vehicle data to check
+   * @return true if extension is subscribed to this vehicle_data, otherwise
+   * returns false
+   */
+  bool isPendingSubscriptionToVehicleInfo(
+      const std::string& vehicle_data) const;
+
+  /**
    * @brief Subscriptions get list of subscriptions for application extension
    * @return list of subscriptions for application extension
    */

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -98,6 +98,7 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
 
  private:
   bool IsSubscribedAppExist(const std::string& ivi);
+  bool IsAnyPendingSubscriptionExist(const std::string& ivi);
   void UnsubscribeFromRemovedVDItems();
   smart_objects::SmartObjectSPtr GetUnsubscribeIVIRequest(
       const std::vector<std::string>& ivi_names);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -87,6 +87,14 @@ bool VehicleInfoAppExtension::isSubscribedToVehicleInfo(
   return subscribed_data_.find(vehicle_data) != subscribed_data_.end();
 }
 
+bool VehicleInfoAppExtension::isPendingSubscriptionToVehicleInfo(
+    const std::string& vehicle_data) const {
+  LOG4CXX_DEBUG(logger_, vehicle_data);
+  sync_primitives::AutoLock lock(*pending_subscriptions_lock_);
+  return pending_subscriptions_.find(vehicle_data) !=
+         pending_subscriptions_.end();
+}
+
 const DataAccessor<VehicleInfoSubscriptions>
 VehicleInfoAppExtension::Subscriptions() {
   DataAccessor<VehicleInfoSubscriptions> data_accessor(subscribed_data_,

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_plugin.cc
@@ -188,7 +188,8 @@ void VehicleInfoPlugin::RevertResumption(
 
   std::set<std::string> subscriptions_to_revert;
   for (auto& ivi_data : list_of_subscriptions) {
-    if (!IsSubscribedAppExist(ivi_data)) {
+    if (!IsSubscribedAppExist(ivi_data) &&
+        !IsAnyPendingSubscriptionExist(ivi_data)) {
       subscriptions_to_revert.insert(ivi_data);
     }
   }
@@ -243,6 +244,20 @@ bool VehicleInfoPlugin::IsSubscribedAppExist(const std::string& ivi) {
       return true;
     }
   }
+  return false;
+}
+
+bool VehicleInfoPlugin::IsAnyPendingSubscriptionExist(const std::string& ivi) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto apps_accessor = application_manager_->applications();
+
+  for (auto& app : apps_accessor.GetData()) {
+    auto& ext = VehicleInfoAppExtension::ExtractVIExtension(*app);
+    if (ext.isPendingSubscriptionToVehicleInfo(ivi)) {
+      return true;
+    }
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Fixes [FORDTCN-7340](https://adc.luxoft.com/jira/browse/FORDTCN-7340)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered with ATF scripts

### Summary
- Do not unsubscribe from pending VD. Update SDL logic to avoid sending of `unsubscribeVD` to HMI during vehicle data resumption for case when another application is also have pending subscription for the same vehicle data
- Fill subscription data for all pending requests. Changed SDL logic to update subscription results for each pending subscription request before notifying resumption processor about current subscription is processed. This should be done beforehand because after raising of event to processor it can finish resumption process for current app and if it has failed then it can trigger sending of
the next subscription request. So at that point, each subscription request should contain updated subscriptions status, otherwise some redundant requests might be sent.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
