### PR TITLE
[SDL-0188] Save interior vehicle data to cache during resumption

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
@@ -7,6 +7,7 @@
 #include "application_manager/resumption/extension_pending_resumption_handler.h"
 #include "application_manager/resumption/resumption_data_processor.h"
 #include "application_manager/rpc_service.h"
+#include "rc_rpc_plugin/interior_data_cache.h"
 #include "rc_rpc_plugin/rc_app_extension.h"
 
 namespace rc_rpc_plugin {
@@ -20,7 +21,8 @@ class RCPendingResumptionHandler
     : public resumption::ExtensionPendingResumptionHandler {
  public:
   RCPendingResumptionHandler(
-      application_manager::ApplicationManager& application_manager);
+      application_manager::ApplicationManager& application_manager,
+      rc_rpc_plugin::InteriorDataCache& interior_data_cache);
 
   void on_event(const application_manager::event_engine::Event& event) override;
 
@@ -59,6 +61,7 @@ class RCPendingResumptionHandler
   sync_primitives::Lock pending_resumption_lock_;
   std::map<int32_t, smart_objects::SmartObject> pending_requests_;
   application_manager::rpc_service::RPCService& rpc_service_;
+  rc_rpc_plugin::InteriorDataCache& interior_data_cache_;
 };
 
 }  // namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -77,8 +77,8 @@ bool RCRPCPlugin::Init(
   command_factory_.reset(new rc_rpc_plugin::RCCommandFactory(params));
   rpc_service_ = &rpc_service;
   app_mngr_ = &app_manager;
-  pending_resumption_handler_ =
-      std::make_shared<RCPendingResumptionHandler>(app_manager);
+  pending_resumption_handler_ = std::make_shared<RCPendingResumptionHandler>(
+      app_manager, *(interior_data_cache_.get()));
 
   // Check all saved consents and remove expired
   rc_consent_manager_->RemoveExpiredConsents();


### PR DESCRIPTION
In scope of https://adc.luxoft.com/jira/browse/FORDTCN-7367
Save interior vehicle data to cache during resumption after receiving a successful response from HMI. 
Add interior_data_cache_ as a class member to the rc_pending_resumption_handler