### PR TITLE
Fix first app subscription

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -223,6 +223,15 @@ void GetInteriorVehicleDataRequest::Execute() {
     return;
   }
   ProcessResponseToMobileFromCache(app);
+  if (AppShouldBeUnsubscribed()) {
+    (*message_)[app_mngr::strings::msg_params][message_params::kModuleType] =
+        ModuleType();
+    (*message_)[app_mngr::strings::msg_params][message_params::kModuleId] =
+        ModuleId();
+    SendHMIRequest(hmi_apis::FunctionID::RC_GetInteriorVehicleData,
+                   &(*message_)[app_mngr::strings::msg_params],
+                   true);
+  }
 }
 
 void GetInteriorVehicleDataRequest::on_event(


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
In the case when application tries to subscribe to a some module and SDL has the module data in the cache, it should send the RC_GetInteriorVehicleDataRequest in any case to have ability receive from a HMI OnInteriorVehicleDataNotification with module data updates. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
