### PR TITLE
Fix/fix ivd subscriptions on revert

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_request.h
@@ -51,6 +51,8 @@ class RCGetInteriorVehicleDataRequest
       const RCCommandParams& params);
 
   void Run() OVERRIDE;
+  void onTimeOut() OVERRIDE;
+
   ~RCGetInteriorVehicleDataRequest();
 };
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_manager.h
@@ -87,6 +87,13 @@ class InteriorDataManager {
    * false.
    */
   virtual bool CheckRequestsToHMIFrequency(const ModuleUid& module) = 0;
+
+  /**
+   * @brief Reverts resumption data and sends ubsubscribe vehicle data request
+   * to a HMI
+   * @param subscriptions Module data that SDL should unsubscribe off
+   */
+  virtual void OnResumptionRevert(const std::set<ModuleUid>& subscriptions) = 0;
 };
 
 }  // namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/interior_data_manager_impl.h
@@ -65,6 +65,8 @@ class InteriorDataManagerImpl : public InteriorDataManager {
 
   bool CheckRequestsToHMIFrequency(const ModuleUid& module) OVERRIDE;
 
+  void OnResumptionRevert(const std::set<ModuleUid>& subscriptions) OVERRIDE;
+
  private:
   /**
    * @brief UpdateHMISubscriptionsOnPolicyUpdated process policy update event.

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
@@ -55,7 +55,6 @@ class RCPendingResumptionHandler
 
   bool IsPendingForResponse(const ModuleUid& module) const;
 
-  void RemoveWaitingForResponse(const ModuleUid& module);
   void AddWaitingForResponse(const ModuleUid& module);
 
   using QueueFreezedResumptions = std::queue<resumption::ResumptionRequest>;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_request.cc
@@ -31,6 +31,8 @@
  */
 
 #include "rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_request.h"
+#include "application_manager/resumption/resume_ctrl.h"
+
 #include "utils/macro.h"
 
 namespace rc_rpc_plugin {
@@ -50,6 +52,14 @@ RCGetInteriorVehicleDataRequest::~RCGetInteriorVehicleDataRequest() {}
 void RCGetInteriorVehicleDataRequest::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
   SendRequest();
+}
+
+void RCGetInteriorVehicleDataRequest::onTimeOut() {
+  auto& resume_ctrl = application_manager_.resume_controller();
+
+  resume_ctrl.HandleOnTimeOut(
+      correlation_id(),
+      static_cast<hmi_apis::FunctionID::eType>(function_id()));
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/interior_data_manager_impl.cc
@@ -50,6 +50,13 @@ void InteriorDataManagerImpl::OnDisablingRC() {
   }
 }
 
+void InteriorDataManagerImpl::OnResumptionRevert(
+    const std::set<ModuleUid>& subscriptions) {
+  for (const auto& module : subscriptions) {
+    UnsubscribeFromInteriorVehicleData(module);
+  }
+}
+
 void InteriorDataManagerImpl::StoreRequestToHMITime(const ModuleUid& module) {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock autolock(requests_to_hmi_history_lock_);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
@@ -33,7 +33,7 @@ void RCPendingResumptionHandler::on_event(
   auto module_uid = GetModuleUid(current_request);
 
   auto& response = event.smart_object();
-  RemoveWaitingForResponse(module_uid);
+
   if (RCHelpers::IsResponseSuccessful(response)) {
     LOG4CXX_DEBUG(logger_,
                   "Resumption of subscriptions is successful"
@@ -76,6 +76,10 @@ void RCPendingResumptionHandler::HandleResumptionSubscriptionRequest(
     } else {
       need_to_subscribe.push_back(subscription);
     }
+  }
+
+  if (pending_requests_.empty()) {
+    already_pending.clear();
   }
 
   for (auto subscription : already_pending) {
@@ -209,15 +213,6 @@ bool RCPendingResumptionHandler::IsPendingForResponse(
                       waiting_for_response_modules_.end(),
                       module);
   return it != waiting_for_response_modules_.end();
-}
-
-void RCPendingResumptionHandler::RemoveWaitingForResponse(
-    const ModuleUid& module) {
-  std::remove_if(waiting_for_response_modules_.begin(),
-                 waiting_for_response_modules_.end(),
-                 [&module](const ModuleUid& module_to_remove) {
-                   return module_to_remove == module;
-                 });
 }
 
 void RCPendingResumptionHandler::AddWaitingForResponse(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
@@ -117,6 +117,7 @@ void RCPendingResumptionHandler::HandleResumptionSubscriptionRequest(
 
 void RCPendingResumptionHandler::OnResumptionRevert() {
   LOG4CXX_AUTO_TRACE(logger_);
+  waiting_for_response_modules_.clear();
 }
 
 void RCPendingResumptionHandler::HandleSuccessfulResponse(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_rpc_plugin.cc
@@ -176,17 +176,7 @@ void RCRPCPlugin::ProcessResumptionSubscription(
 void RCRPCPlugin::RevertResumption(const std::set<ModuleUid>& subscriptions) {
   LOG4CXX_AUTO_TRACE(logger_);
 
-  for (auto& module : subscriptions) {
-    auto unsubscribe_request = RCHelpers::CreateGetInteriorVDRequestToHMI(
-        module,
-        app_mngr_->GetNextHMICorrelationID(),
-        RCHelpers::GetInteriorData::UNSUBSCRIBE);
-
-    LOG4CXX_DEBUG(logger_,
-                  "Send Unsubscribe from module type: "
-                      << module.first << " id: " << module.second);
-    rpc_service_->ManageHMICommand(unsubscribe_request);
-  }
+  interior_data_manager_->OnResumptionRevert(subscriptions);
   pending_resumption_handler_->OnResumptionRevert();
 }
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_app_extension.cc
@@ -167,7 +167,19 @@ void VehicleInfoAppExtension::RevertResumption(
   LOG4CXX_AUTO_TRACE(logger_);
 
   unsubscribeFromVehicleInfo();
-  plugin_.RevertResumption(app_, subscriptions.enumerate());
+
+  std::set<std::string> ivi_subscriptions_to_revert;
+  const auto ivi_subscriptions_keys = subscriptions.enumerate();
+  for (const auto& key : ivi_subscriptions_keys) {
+    // Only boolean keys in subscriptions list are true vehicle data
+    // subscriptions
+    if (smart_objects::SmartType::SmartType_Boolean ==
+        subscriptions.getElement(key).getType()) {
+      ivi_subscriptions_to_revert.insert(key);
+    }
+  }
+
+  plugin_.RevertResumption(app_, ivi_subscriptions_to_revert);
 }
 
 VehicleInfoAppExtension& VehicleInfoAppExtension::ExtractVIExtension(


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered with ATF scripts

### Summary
- Cherry-pick of #116 
- Fix proper IVD cache cleaning on data revert
- Clear waiting for response on revert
- Fix VD unsubscription on revert
- Avoid crash on empty data on response
- Add OnTimeout handler for RC.GetIVD 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
