### PR TITLE
[SDL-0188] Remove redundant OnHashUpdate sending

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_app_extension.cc
@@ -220,7 +220,6 @@ void RCAppExtension::RevertResumption(
                no_apps_subscribed);
 
   plugin_.RevertResumption(not_subscribed_by_other_apps);
-  UpdateHash();
 }
 
 std::set<ModuleUid> RCAppExtension::InteriorVehicleDataSubscriptions() const {


### PR DESCRIPTION
OnHashUpdate will be sent once after resumption is finished (from here https://github.com/LuxoftSDL/sdl_core/blob/feature/sdl_0188_interior_vehicle_data_resumption/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc#L788)
So I just removed redundant OnHashUpdate sending during RevertResumption