### PR TITLE
Add checking is subscribe parameter to clarify if response is successful

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
@@ -371,7 +371,20 @@ bool RCHelpers::IsResponseSuccessful(
           response[application_manager::strings::params]
                   [application_manager::strings::message_type]
                       .asInt());
-  return hmi_apis::messageType::response == message_type;
+  const bool is_correct_message_type =
+      hmi_apis::messageType::response == message_type;
+
+  bool is_successful_subscribed = false;
+
+  if (response[application_manager::strings::msg_params].keyExists(
+          rc_rpc_plugin::message_params::kIsSubscribed)) {
+    is_successful_subscribed =
+        response[application_manager::strings::msg_params]
+                [rc_rpc_plugin::message_params::kIsSubscribed]
+                    .asBool();
+  }
+
+  return is_correct_message_type && is_successful_subscribed;
 }
 
 }  // namespace rc_rpc_plugin


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Provides checking the 'is_subscribed' parameter in a HMI response

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
