### PR TITLE
send GASD(subscribe=true) on reusmption of app data subscription

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -1034,10 +1034,13 @@ class MessageHelper {
    * @param service_type Name of the app service data type
    * @param subscribe_value whether to subscribe or unsubscribe from
    * notifications
+   * @param out_request Resumption request sent out so that the response can be
+   * tracked
    */
   static void SendGetAppServiceData(ApplicationManager& app_mngr,
                                     const std::string& service_type,
-                                    const bool subscribe_value = false);
+                                    const bool subscribe_value,
+                                    resumption::ResumptionRequest& out_request);
 
   /**
    * @brief SendResetPropertiesRequest sends requests to HMI to remove/reset

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -1028,6 +1028,18 @@ class MessageHelper {
                                          ApplicationManager& app_mngr);
 
   /**
+   * @brief SendGetAppServiceData sends a GetAppServiceData request to an app
+   * service provider
+   * @param app_mngr Application manager
+   * @param service_type Name of the app service data type
+   * @param subscribe_value whether to subscribe or unsubscribe from
+   * notifications
+   */
+  static void SendGetAppServiceData(ApplicationManager& app_mngr,
+                                    const std::string& service_type,
+                                    const bool subscribe_value = false);
+
+  /**
    * @brief SendResetPropertiesRequest sends requests to HMI to remove/reset
    * global properties for application
    * @param application Application to remove/reset global properties for

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/app_service_app_extension.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/app_service_app_extension.h
@@ -59,7 +59,8 @@ class AppServiceAppExtension : public app_mngr::AppExtension {
    * @param app application that contains this plugin
    */
   AppServiceAppExtension(AppServiceRpcPlugin& plugin,
-                         app_mngr::Application& app);
+                         app_mngr::Application& app,
+                         app_mngr::ApplicationManager* app_mngr);
   virtual ~AppServiceAppExtension();
 
   /**
@@ -119,6 +120,7 @@ class AppServiceAppExtension : public app_mngr::AppExtension {
   AppServiceSubscriptions subscribed_data_;
   AppServiceRpcPlugin& plugin_;
   app_mngr::Application& app_;
+  app_mngr::ApplicationManager* app_manager_;
 };
 }  // namespace app_service_rpc_plugin
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
@@ -89,8 +89,8 @@ void AppServiceRpcPlugin::OnApplicationEvent(
     plugins::ApplicationEvent event,
     app_mngr::ApplicationSharedPtr application) {
   if (plugins::ApplicationEvent::kApplicationRegistered == event) {
-    application->AddExtension(
-        std::make_shared<AppServiceAppExtension>(*this, *application));
+    application->AddExtension(std::make_shared<AppServiceAppExtension>(
+        *this, *application, application_manager_));
   } else if (plugins::ApplicationEvent::kDeleteApplicationData == event) {
     DeleteSubscriptions(application);
   }

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/app_service_rpc_plugin.cc
@@ -91,7 +91,8 @@ void AppServiceRpcPlugin::OnApplicationEvent(
   if (plugins::ApplicationEvent::kApplicationRegistered == event) {
     application->AddExtension(std::make_shared<AppServiceAppExtension>(
         *this, *application, application_manager_));
-  } else if (plugins::ApplicationEvent::kDeleteApplicationData == event) {
+  } else if (plugins::ApplicationEvent::kDeleteApplicationData == event ||
+             plugins::ApplicationEvent::kApplicationUnregistered == event) {
     DeleteSubscriptions(application);
   }
 }
@@ -99,10 +100,7 @@ void AppServiceRpcPlugin::OnApplicationEvent(
 void AppServiceRpcPlugin::DeleteSubscriptions(
     application_manager::ApplicationSharedPtr app) {
   auto& ext = AppServiceAppExtension::ExtractASExtension(*app);
-  auto subscriptions = ext.Subscriptions();
-  for (auto& service_type : subscriptions) {
-    ext.UnsubscribeFromAppService(service_type);
-  }
+  ext.UnsubscribeFromAppService();
 }
 
 }  // namespace app_service_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/on_app_service_data_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/test/commands/mobile/on_app_service_data_notification_test.cc
@@ -76,9 +76,10 @@ class OnAppServiceDataNotificationTest
  public:
   OnAppServiceDataNotificationTest()
       : mock_app_(std::make_shared<NiceMock<MockApplication> >())
+      , mock_app_mgr_(std::make_shared<NiceMock<MockApplicationManager> >())
       , app_service_app_extension_(
             std::make_shared<app_service_rpc_plugin::AppServiceAppExtension>(
-                app_service_plugin_, *mock_app_))
+                app_service_plugin_, *mock_app_, mock_app_mgr_.get()))
       , apps_lock_(std::make_shared<sync_primitives::Lock>())
       , apps_da_(apps_, apps_lock_)
       , last_state_(std::make_shared<resumption::LastStateWrapperImpl>(
@@ -107,6 +108,7 @@ class OnAppServiceDataNotificationTest
 
  protected:
   std::shared_ptr<MockApplication> mock_app_;
+  std::shared_ptr<MockApplicationManager> mock_app_mgr_;
   std::shared_ptr<AppServiceAppExtension> app_service_app_extension_;
   app_service_rpc_plugin::AppServiceRpcPlugin app_service_plugin_;
   application_manager::ApplicationSet apps_;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -784,6 +784,8 @@ void MessageHelper::SendGetAppServiceData(ApplicationManager& app_mngr,
     if (!app_mngr.GetRPCService().ManageHMICommand(message)) {
       LOG4CXX_ERROR(logger_, "Unable to send request to HMI");
     }
+  } else if (!app_service_provider_app) {
+    LOG4CXX_DEBUG(logger_, "No app service found of type " << service_type);
   } else {
     auto message = std::make_shared<smart_objects::SmartObject>();
 

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -779,10 +779,10 @@ void MessageHelper::SendGetAppServiceData(ApplicationManager& app_mngr,
     (*message)[strings::params][strings::function_id] =
         hmi_apis::FunctionID::AppService_GetAppServiceData;
     (*message)[strings::msg_params][strings::service_type] = service_type;
-    (*message)[strings::msg_params][strings::subscribe] = true;
+    (*message)[strings::msg_params][strings::subscribe] = subscribe_value;
 
     if (!app_mngr.GetRPCService().ManageHMICommand(message)) {
-      LOG4CXX_ERROR(logger_, "Unable to send request to mobile");
+      LOG4CXX_ERROR(logger_, "Unable to send request to HMI");
     }
   } else {
     auto message = std::make_shared<smart_objects::SmartObject>();

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -361,6 +361,10 @@ class MockMessageHelper {
                void(smart_objects::SmartObject* cmd,
                     ApplicationSharedPtr application,
                     ApplicationManager& app_mngr));
+  MOCK_METHOD3(SendGetAppServiceData,
+               void(ApplicationManager& app_mngr,
+                    const std::string& service_type,
+                    const bool subscribe_value));
   MOCK_METHOD2(SendResetPropertiesRequest,
                void(ApplicationSharedPtr application,
                     ApplicationManager& app_mngr));

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -361,10 +361,11 @@ class MockMessageHelper {
                void(smart_objects::SmartObject* cmd,
                     ApplicationSharedPtr application,
                     ApplicationManager& app_mngr));
-  MOCK_METHOD3(SendGetAppServiceData,
+  MOCK_METHOD4(SendGetAppServiceData,
                void(ApplicationManager& app_mngr,
                     const std::string& service_type,
-                    const bool subscribe_value));
+                    const bool subscribe_value,
+                    resumption::ResumptionRequest& out_request));
   MOCK_METHOD2(SendResetPropertiesRequest,
                void(ApplicationSharedPtr application,
                     ApplicationManager& app_mngr));

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -33,6 +33,7 @@
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/policies/policy_handler_interface.h"
+#include "application_manager/resumption/resumption_data_processor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "transport_manager/common.h"
@@ -617,11 +618,13 @@ void MessageHelper::SendDeleteChoiceSetRequest(smart_objects::SmartObject* cmd,
       cmd, application, app_mngr);
 }
 
-void MessageHelper::SendGetAppServiceData(ApplicationManager& app_mngr,
-                                          const std::string& service_type,
-                                          const bool subscribe_value) {
+void MessageHelper::SendGetAppServiceData(
+    ApplicationManager& app_mngr,
+    const std::string& service_type,
+    const bool subscribe_value,
+    resumption::ResumptionRequest& subscribe_app_data) {
   return MockMessageHelper::message_helper_mock()->SendGetAppServiceData(
-      app_mngr, service_type, subscribe_value);
+      app_mngr, service_type, subscribe_value, subscribe_app_data);
 }
 
 void MessageHelper::SendResetPropertiesRequest(ApplicationSharedPtr application,

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -617,6 +617,13 @@ void MessageHelper::SendDeleteChoiceSetRequest(smart_objects::SmartObject* cmd,
       cmd, application, app_mngr);
 }
 
+void MessageHelper::SendGetAppServiceData(ApplicationManager& app_mngr,
+                                          const std::string& service_type,
+                                          const bool subscribe_value) {
+  return MockMessageHelper::message_helper_mock()->SendGetAppServiceData(
+      app_mngr, service_type, subscribe_value);
+}
+
 void MessageHelper::SendResetPropertiesRequest(ApplicationSharedPtr application,
                                                ApplicationManager& app_mngr) {
   return MockMessageHelper::message_helper_mock()->SendResetPropertiesRequest(


### PR DESCRIPTION
Enables testing of AppServiceData `RevertResumption` for subscriptions to HMI provider

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
UT and ATF from Issue

### Summary
Send GASD(subscribe=true) when resuming app service data subscriptions

Still needed to fix #3470:

- [x] Only send GASD subscribe message if no other apps are already subscribed
- [x] GASD sent on resumption to mobile ASD providers
- [x] GASD subscribe = false on app disconnect (if only subscribed app)
- [ ] implement ExtensionPendingResumptionHandler for app service data
- [ ] on GASD subscribe fail response, fail resumption??

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
