### PR TITLE
Fix/CCB:SDL Crashing on receiving empty band from the radio

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_helpers.cc
@@ -291,6 +291,11 @@ smart_objects::SmartObject RCHelpers::MergeModuleData(
 
   smart_objects::SmartObject result = data1;
 
+  if (data2.empty()) {
+    SDL_LOG_ERROR("Data received from module is empty");
+    return result;
+  }
+
   for (auto it = data2.map_begin(); it != data2.map_end(); ++it) {
     const std::string& key = it->first;
     smart_objects::SmartObject& value = it->second;
@@ -300,9 +305,9 @@ smart_objects::SmartObject RCHelpers::MergeModuleData(
     }
 
     // Merge maps and arrays with `id` param included, replace other types
-    if (value.getType() == smart_objects::SmartType::SmartType_Map) {
+    if (smart_objects::SmartType::SmartType_Map == value.getType()) {
       value = MergeModuleData(result[key], value);
-    } else if (value.getType() == smart_objects::SmartType::SmartType_Array) {
+    } else if (smart_objects::SmartType::SmartType_Array == value.getType()) {
       value = MergeArray(result[key], value);
     }
     result[key] = value;


### PR DESCRIPTION
Fixes https://adc.luxoft.com/jira/browse/FORDTCN-7343

This PR is **[ready]** for review.

### Summary
If the HMI sends empty radioControlData it causing a crash on SDL because it was not validating the
received data before dereferencing it.
