### PR TITLE
Fix deadlock in connection_handler

### DIFF
--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -461,16 +461,22 @@ void ConnectionHandlerImpl::OnSessionStartedCallback(
     return;
   }
 #endif  // ENABLE_SECURITY
-  sync_primitives::AutoReadLock lock(connection_list_lock_);
-  ConnectionList::iterator it =
-      connection_list_.find(primary_connection_handle);
-  if (connection_list_.end() == it) {
+
+  Connection* connection = nullptr;
+  {
+    sync_primitives::AutoReadLock lock(connection_list_lock_);
+    auto it = connection_list_.find(primary_connection_handle);
+    if (it != connection_list_.end()) {
+      connection = it->second;
+    }
+  }
+
+  if (!connection) {
     SDL_LOG_ERROR("Unknown connection!");
     protocol_handler_->NotifySessionStarted(context, rejected_params);
     return;
   }
 
-  Connection* connection = it->second;
   context.is_new_service_ =
       !connection->SessionServiceExists(session_id, service_type);
 


### PR DESCRIPTION
Fixes [FORDTCN-7341](https://adc.luxoft.com/jira/browse/FORDTCN-7341)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR provides changes for avoiding deadlock in the `connection_handler` during work with connections list.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
