### PR TITLE
Fix issue with redundant subscriptions to shared vehicle data during resumption

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -197,8 +197,10 @@ void VehicleInfoPendingResumptionHandler::TriggerPendingResumption() {
                   << " is already waiting for HMI response");
     return;
   }
-  SendHMIRequestForNotSubscribed(pending_resumption);
-  pending_resumption.waiting_for_hmi_response_ = true;
+  if (!pending_resumption.IsSuccessfullyDone()) {
+    SendHMIRequestForNotSubscribed(pending_resumption);
+    pending_resumption.waiting_for_hmi_response_ = true;
+  }
 }
 
 void VehicleInfoPendingResumptionHandler::on_event(


### PR DESCRIPTION
Fixes #[7471](https://adc.luxoft.com/jira/browse/FORDTCN-7471) #[7322](https://adc.luxoft.com/jira/browse/FORDTCN-7322)
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
This PR is intended to fix issue with redundant subscriptions to shared vehicle data during resumption. In several cases we have successful shared subscriptions to vehicle data and also failed other subscriptions. During reverting of all subscriptions for application with failed resumption there is the case when fake response for next waiting request with shared vehicle data cannot transfer to ResumptionDataProcessor, because this request is triggered during resumption revert in wrong way, when we don't check whether restoring of all required data was already completed.

If this restoring wasn't completed yet, there is a need in sending request to HMI for not subscribed requests. But if this work was done for previous requests, there is no need in sending duplicate requests, we only need to wait when response from HMI will be processed by ResumptionDataProcessor. That's why above-mentioned check is added to method, invoked during resumption revert.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
