### PR TITLE
Rework processing of the OnExitApplication

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_application_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_exit_application_notification.cc
@@ -119,7 +119,6 @@ void OnExitApplicationNotification::Run() {
           MessageHelper::GetOnAppInterfaceUnregisteredNotificationToMobile(
               app_id, AppInterfaceUnregisteredReason::RESOURCE_CONSTRAINT);
       SendNotificationToMobile(message);
-      application_manager_.UnregisterApplication(app_id, Result::SUCCESS);
       return;
     }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/hmi_notifications_test.cc
@@ -1031,14 +1031,12 @@ TEST_F(HMICommandsNotificationsTest,
   using ExitReason = hmi_apis::Common_ApplicationExitReason::eType;
   std::vector<ExitReason> reason_list = {
       ExitReason::UNAUTHORIZED_TRANSPORT_REGISTRATION,
-      ExitReason::UNSUPPORTED_HMI_RESOURCE,
-      ExitReason::RESOURCE_CONSTRAINT};
+      ExitReason::UNSUPPORTED_HMI_RESOURCE};
 
   using UnregisteredReason = mobile_apis::AppInterfaceUnregisteredReason::eType;
   std::vector<UnregisteredReason> mobile_reason_list = {
       UnregisteredReason::APP_UNAUTHORIZED,
-      UnregisteredReason::UNSUPPORTED_HMI_RESOURCE,
-      UnregisteredReason::RESOURCE_CONSTRAINT};
+      UnregisteredReason::UNSUPPORTED_HMI_RESOURCE};
 
   std::vector<mobile_apis::AppInterfaceUnregisteredReason::eType>::iterator
       it_mobile_reason = mobile_reason_list.begin();
@@ -1069,6 +1067,47 @@ TEST_F(HMICommandsNotificationsTest,
                     kAppId_, mobile_apis::Result::SUCCESS, false, false));
     command->Run();
   }
+}
+
+TEST_F(HMICommandsNotificationsTest,
+       OnExitApplicationNotificationResourceConstraintReason) {
+  auto message = CreateMessage();
+  (*message)[am::strings::msg_params][am::strings::app_id] = kAppId_;
+  const auto notification = std::make_shared<smart_objects::SmartObject>();
+  (*notification)[am::strings::params][am::strings::function_id] =
+      static_cast<int32_t>(
+          mobile_apis::FunctionID::OnAppInterfaceUnregisteredID);
+  (*notification)[am::strings::params][am::strings::message_type] =
+      static_cast<int32_t>(am::MessageType::kNotification);
+  (*notification)[am::strings::params][am::strings::connection_key] = kAppId_;
+
+  using ExitReason = hmi_apis::Common_ApplicationExitReason::eType;
+  auto hmi_reason = ExitReason::RESOURCE_CONSTRAINT;
+
+  using UnregisteredReason = mobile_apis::AppInterfaceUnregisteredReason::eType;
+  auto mobile_reason = UnregisteredReason::RESOURCE_CONSTRAINT;
+
+  (*message)[am::strings::msg_params][am::strings::reason] = hmi_reason;
+  const auto command = CreateCommand<OnExitApplicationNotification>(message);
+
+  (*notification)[am::strings::msg_params][am::strings::reason] =
+      static_cast<int32_t>(mobile_reason);
+
+  am::plugin_manager::MockRPCPluginManager mock_rpc_plugin_manager_;
+  EXPECT_CALL(app_mngr_, GetPluginManager())
+      .WillRepeatedly(ReturnRef(mock_rpc_plugin_manager_));
+
+  EXPECT_CALL(app_mngr_, application(kAppId_)).WillRepeatedly(Return(app_));
+  EXPECT_CALL(
+      mock_message_helper_,
+      GetOnAppInterfaceUnregisteredNotificationToMobile(kAppId_, mobile_reason))
+      .WillOnce(Return(notification));
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(notification, Command::SOURCE_SDL));
+  EXPECT_CALL(app_mngr_, UnregisterApplication(_, _, _, _)).Times(0);
+
+  ASSERT_TRUE(command->Init());
+  command->Run();
 }
 
 TEST_F(HMICommandsNotificationsTest,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2166,6 +2166,12 @@ void ApplicationManagerImpl::OnServiceEndedCallback(
         is_unexpected_disconnect = false;
         break;
       }
+      case CloseSessionReason::kFinalMessage: {
+        reason = Result::SUCCESS;
+        is_resuming = false;
+        is_unexpected_disconnect = false;
+        break;
+      }
       default: {
         reason = Result::INVALID_ENUM;
         is_resuming = true;

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -467,8 +467,8 @@ void RPCServiceImpl::Handle(const impl::MessageToMobile message) {
   SDL_LOG_INFO("Message for mobile given away");
 
   if (close_session) {
-    app_manager_.connection_handler().CloseSession(message->connection_key(),
-                                                   connection_handler::kCommon);
+    app_manager_.connection_handler().CloseSession(
+        message->connection_key(), connection_handler::kFinalMessage);
   }
 }
 

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -654,8 +654,7 @@ class ConnectionHandlerImpl
    * @param connection_id Connection unique identifier.
    * @param close_reason Reason for a session closing
    */
-  void OnConnectionEnded(const transport_manager::ConnectionUID connection_id,
-                         const CloseSessionReason close_reason);
+  void OnConnectionEnded(const transport_manager::ConnectionUID connection_id);
 
   const uint8_t GetSessionIdFromSecondaryTransport(
       transport_manager::ConnectionUID secondary_transport_id) const;

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -652,7 +652,6 @@ class ConnectionHandlerImpl
   /**
    * @brief Called when connection is closed.
    * @param connection_id Connection unique identifier.
-   * @param close_reason Reason for a session closing
    */
   void OnConnectionEnded(const transport_manager::ConnectionUID connection_id);
 

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -35,6 +35,7 @@
 
 #include <list>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -271,6 +272,8 @@ class ConnectionHandlerImpl
    * \param connection_key  used by other components as application identifier
    */
   void OnMalformedMessageCallback(const uint32_t& connection_key) OVERRIDE;
+
+  void OnFinalMessageCallback(const uint32_t& connection_key) OVERRIDE;
 
   /**
    * @brief Converts connection handle to transport type string used in
@@ -646,7 +649,13 @@ class ConnectionHandlerImpl
    **/
   void RemoveConnection(const ConnectionHandle connection_handle);
 
-  void OnConnectionEnded(const transport_manager::ConnectionUID connection_id);
+  /**
+   * @brief Called when connection is closed.
+   * @param connection_id Connection unique identifier.
+   * @param close_reason Reason for a session closing
+   */
+  void OnConnectionEnded(const transport_manager::ConnectionUID connection_id,
+                         const CloseSessionReason close_reason);
 
   const uint8_t GetSessionIdFromSecondaryTransport(
       transport_manager::ConnectionUID secondary_transport_id) const;
@@ -659,6 +668,15 @@ class ConnectionHandlerImpl
    */
   Connection* GetPrimaryConnection(
       const ConnectionHandle connection_handle) const;
+
+  /**
+   * @brief Handling a reason for closing a session
+   * @param connection_id Connection unique identifier.
+   * @return the reason for connection closed, if connection processed final
+   * message returns kFinalMessage, otherwise returns kCommon
+   */
+  CloseSessionReason ClosureReasonHandling(
+      const transport_manager::ConnectionUID connection_id);
 
   const ConnectionHandlerSettings& settings_;
   /**
@@ -715,6 +733,11 @@ class ConnectionHandlerImpl
    * @brief connection object as it's being closed
    */
   Connection* ending_connection_;
+
+  /**
+   * @brief List connection, which processed final message
+   */
+  std::set<transport_manager::ConnectionUID> connections_final_message;
 
 #ifdef BUILD_TESTS
   // Methods for test usage

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -352,8 +352,7 @@ void ConnectionHandlerImpl::OnConnectionClosed(
     transport_manager::ConnectionUID connection_id) {
   SDL_LOG_AUTO_TRACE();
 
-  auto reason = ClosureReasonHandling(connection_id);
-  OnConnectionEnded(connection_id, reason);
+  OnConnectionEnded(connection_id);
 }
 
 void ConnectionHandlerImpl::OnConnectionClosedFailure(
@@ -367,9 +366,8 @@ void ConnectionHandlerImpl::OnUnexpectedDisconnect(
     transport_manager::ConnectionUID connection_id,
     const transport_manager::CommunicationError& error) {
   SDL_LOG_AUTO_TRACE();
-
-  auto reason = ClosureReasonHandling(connection_id);
-  OnConnectionEnded(connection_id, reason);
+  UNUSED(error);
+  OnConnectionEnded(connection_id);
 }
 
 void ConnectionHandlerImpl::OnDeviceConnectionLost(
@@ -390,7 +388,7 @@ void ConnectionHandlerImpl::RemoveConnection(
     const ConnectionHandle connection_handle) {
   SDL_LOG_AUTO_TRACE();
 
-  OnConnectionEnded(connection_handle, CloseSessionReason::kCommon);
+  OnConnectionEnded(connection_handle);
 }
 
 #ifdef ENABLE_SECURITY
@@ -1703,8 +1701,8 @@ void ConnectionHandlerImpl::KeepConnectionAlive(uint32_t connection_key,
 }
 
 void ConnectionHandlerImpl::OnConnectionEnded(
-    const transport_manager::ConnectionUID connection_id,
-    const CloseSessionReason close_reason) {
+    const transport_manager::ConnectionUID connection_id) {
+  const auto close_reason = ClosureReasonHandling(connection_id);
   SDL_LOG_INFO("Delete Connection: " << static_cast<int32_t>(connection_id)
                                      << " from the list."
                                      << " with reason " << close_reason);

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -855,6 +855,24 @@ TEST_F(ConnectionHandlerTest, OnConnectionClosed) {
   connection_handler_->OnConnectionClosed(uid_);
 }
 
+TEST_F(ConnectionHandlerTest, OnFinalMessageCallback_OnConnectionClosed) {
+  AddTestDeviceConnection();
+  AddTestSession();
+
+  connection_handler_test::MockConnectionHandlerObserver
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
+
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(connection_key_, kBulk, kFinalMessage));
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(connection_key_, kRpc, kFinalMessage));
+
+  connection_handler_->OnFinalMessageCallback(connection_key_);
+  connection_handler_->OnConnectionClosed(uid_);
+}
+
 TEST_F(ConnectionHandlerTest, OnUnexpectedDisconnect) {
   AddTestDeviceConnection();
   AddTestSession();
@@ -871,6 +889,27 @@ TEST_F(ConnectionHandlerTest, OnUnexpectedDisconnect) {
               OnServiceEndedCallback(
                   connection_key_, kRpc, CloseSessionReason::kCommon));
 
+  connection_handler_->OnUnexpectedDisconnect(uid_, err);
+}
+
+TEST_F(ConnectionHandlerTest, OnFinalMessageCallback_OnUnexpectedDisconnect) {
+  AddTestDeviceConnection();
+  AddTestSession();
+
+  connection_handler_test::MockConnectionHandlerObserver
+      mock_connection_handler_observer;
+  connection_handler_->set_connection_handler_observer(
+      &mock_connection_handler_observer);
+
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(
+                  connection_key_, kBulk, CloseSessionReason::kFinalMessage));
+  EXPECT_CALL(mock_connection_handler_observer,
+              OnServiceEndedCallback(
+                  connection_key_, kRpc, CloseSessionReason::kFinalMessage));
+
+  connection_handler_->OnFinalMessageCallback(connection_key_);
+  transport_manager::CommunicationError err;
   connection_handler_->OnUnexpectedDisconnect(uid_, err);
 }
 

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -48,7 +48,13 @@
  */
 namespace connection_handler {
 
-enum CloseSessionReason { kCommon = 0, kFlood, kMalformed, kUnauthorizedApp };
+enum CloseSessionReason {
+  kCommon = 0,
+  kFlood,
+  kMalformed,
+  kUnauthorizedApp,
+  kFinalMessage
+};
 
 class ConnectionHandlerObserver;
 

--- a/src/components/include/protocol_handler/session_observer.h
+++ b/src/components/include/protocol_handler/session_observer.h
@@ -179,6 +179,13 @@ class SessionObserver {
   virtual void OnMalformedMessageCallback(const uint32_t& connection_key) = 0;
 
   /**
+   * @brief Callback function used by ProtocolHandler when the last message was
+   * sent for a mobile connection
+   * @param connection_key used by other components as an application identifier
+   */
+  virtual void OnFinalMessageCallback(const uint32_t& connection_key) = 0;
+
+  /**
    * @brief Converts connection handle to transport type string used in
    * smartDeviceLink.ini file, e.g. "TCP_WIFI"
    * @param connection_handle A connection identifier

--- a/src/components/include/test/protocol_handler/mock_session_observer.h
+++ b/src/components/include/test/protocol_handler/mock_session_observer.h
@@ -83,6 +83,7 @@ class MockSessionObserver : public ::protocol_handler::SessionObserver {
                void(const uint32_t& connection_key));
   MOCK_METHOD1(OnMalformedMessageCallback,
                void(const uint32_t& connection_key));
+  MOCK_METHOD1(OnFinalMessageCallback, void(const uint32_t& connection_key));
   MOCK_CONST_METHOD1(
       TransportTypeProfileStringFromConnHandle,
       const std::string(transport_manager::ConnectionUID connection_handle));

--- a/src/components/protocol_handler/src/protocol_handler_impl.cc
+++ b/src/components/protocol_handler/src/protocol_handler_impl.cc
@@ -1075,6 +1075,7 @@ void ProtocolHandlerImpl::OnTMMessageSend(const RawMessagePtr message) {
 
   if (ready_to_close_connections_.end() != connection_it) {
     ready_to_close_connections_.erase(connection_it);
+    session_observer_.OnFinalMessageCallback(connection_handle);
     transport_manager_.Disconnect(connection_handle);
     return;
   }

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -3550,6 +3550,56 @@ TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_NullCount) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
+TEST_F(ProtocolHandlerImplTest, OnFinalMessageCallback) {
+  const auto protection = false;
+  const auto is_final_message = true;
+  const uint32_t total_data_size = 1;
+  UCharDataVector data(total_data_size);
+
+  ProtocolFramePtr ptr(new protocol_handler::ProtocolPacket(connection_id,
+                                                            PROTOCOL_VERSION_3,
+                                                            protection,
+                                                            FRAME_TYPE_SINGLE,
+                                                            kControl,
+                                                            FRAME_DATA_SINGLE,
+                                                            session_id,
+                                                            total_data_size,
+                                                            message_id,
+                                                            &data[0]));
+
+  using RawFordMessageToMobile = protocol_handler::impl::RawFordMessageToMobile;
+  using Handler = protocol_handler::impl::ToMobileQueue::Handler;
+
+  auto message =
+      std::make_shared<RawFordMessageToMobile>(ptr, is_final_message);
+  auto raw_message = ptr->serializePacket();
+
+  auto handler = std::static_pointer_cast<Handler>(protocol_handler_impl);
+  auto transport_manager_listener =
+      std::static_pointer_cast<TransportManagerListener>(protocol_handler_impl);
+
+  EXPECT_CALL(session_observer_mock,
+              ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
+      .WillRepeatedly(Return(false));
+
+  EXPECT_CALL(session_observer_mock,
+              PairFromKey(raw_message->connection_key(), _, _))
+      .WillRepeatedly(
+          DoAll(SetArgPointee<1>(connection_id), SetArgPointee<2>(session_id)));
+
+  EXPECT_CALL(transport_manager_mock, SendMessageToDevice(_))
+      .WillOnce(Return(E_SUCCESS));
+
+  EXPECT_CALL(session_observer_mock, OnFinalMessageCallback(connection_id));
+  EXPECT_CALL(transport_manager_mock, Disconnect(connection_id));
+
+  handler->Handle(*message);
+  // Put the message to list of connections ready to close
+  transport_manager_listener->OnTMMessageSend(raw_message);
+  // Processing the list of connections ready to close
+  transport_manager_listener->OnTMMessageSend(raw_message);
+}
+
 TEST_F(ProtocolHandlerImplTest,
        SendEndServicePrivate_NoConnection_MessageNotSent) {
   // Expect check connection with ProtocolVersionUsed


### PR DESCRIPTION
Fixes [#FORDTCN-6888](https://adc.luxoft.com/jira/browse/FORDTCN-6888)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
SDL sends "unexpectedDisconnect=true" because happens data race.

In current implementation at OnExitApplicationNotification for the reason "RESOURCE_CONSTRAINT" we send unregister notification to mobile with flag "final message", after that
we call application_manager_.UnregisterApplication.

The root issue is call application_manager_.UnregisterApplication.
Because we send unregister notification to mobile with flag "final message".

At this case in the "ProtocolHandlerImpl::Handle(const impl::RawFordMessageToMobile)"
we put this session to sessions_last_message_id_.
After that at the ProtocolHandlerImpl::OnTMMessageSend we puts that connection to ready_to_close_connections_
and sends SendEndSession.

When this message will be send, we again call ProtocolHandlerImpl::OnTMMessageSend and we try find this connection in ready_to_close_connections_
If connection found we call transport_manager_.Disconnect(connection_handle);

After disconnect done"TransportManagerImpl::Handle(TransportAdapterEvent) case ON_DISCONNECT_DONE" will be called "ConnectionHandlerImpl::OnConnectionClosed".
Which will result in the call
"connection_handler_observer_->OnServiceEndedCallback" with "kCommon" reason and there will be a repeated call "UnregisterApplication with is_unexpected_disconnect = true". 

This PR provides the next changes:
* Rework processing of the OnExitApplication
(RESOURCE_CONSTRAINT) notification
* UTs update

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
