### PR TITLE
Add additional check to avoid duplicate subscriptions to Vehicle Data

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -43,6 +43,8 @@ namespace app_mngr = application_manager;
 namespace plugins = application_manager::plugin_manager;
 
 enum SubscribeStatus { SUBSCRIBE, UNSUBSCRIBE };
+bool IsSubscribedAppExist(const std::string& ivi,
+                          const app_mngr::ApplicationManager& app_manager);
 
 class VehicleInfoPlugin : public plugins::RPCPlugin {
  public:
@@ -96,7 +98,6 @@ class VehicleInfoPlugin : public plugins::RPCPlugin {
       const std::set<std::string>& list_of_subscriptions);
 
  private:
-  bool IsSubscribedAppExist(const std::string& ivi);
   bool IsAnyPendingSubscriptionExist(const std::string& ivi);
   void UnsubscribeFromRemovedVDItems();
   smart_objects::SmartObjectSPtr GetUnsubscribeIVIRequest(

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_plugin.h
@@ -42,7 +42,6 @@ class VehicleInfoAppExtension;
 namespace app_mngr = application_manager;
 namespace plugins = application_manager::plugin_manager;
 
-enum SubscribeStatus { SUBSCRIBE, UNSUBSCRIBE };
 bool IsSubscribedAppExist(const std::string& ivi,
                           const app_mngr::ApplicationManager& app_manager);
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -38,6 +38,7 @@
 #include "application_manager/resumption/resumption_data_processor.h"
 #include "utils/helpers.h"
 #include "vehicle_info_plugin/custom_vehicle_data_manager.h"
+#include "vehicle_info_plugin/vehicle_info_plugin.h"
 
 namespace vehicle_info_plugin {
 SDL_CREATE_LOG_VARIABLE("VehicleInfoPlugin")
@@ -208,6 +209,7 @@ void VehicleInfoPendingResumptionHandler::on_event(
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(pending_resumption_lock_);
   using namespace application_manager;
+
   if (pending_requests_.empty()) {
     SDL_LOG_DEBUG("Not waiting for any response");
     return;
@@ -269,7 +271,17 @@ void VehicleInfoPendingResumptionHandler::HandleResumptionSubscriptionRequest(
   SDL_LOG_TRACE("app id " << app.app_id());
   auto& ext = dynamic_cast<VehicleInfoAppExtension&>(extension);
 
-  const auto subscriptions = ext.PendingSubscriptions().GetData();
+  auto subscriptions = ext.PendingSubscriptions().GetData();
+  for (auto ivi = subscriptions.begin(); ivi != subscriptions.end();) {
+    if (IsSubscribedAppExist(*ivi, application_manager_)) {
+      ext.RemovePendingSubscription(*ivi);
+      ext.subscribeToVehicleInfo(*ivi);
+      subscriptions.erase(ivi++);
+    } else {
+      ++ivi;
+    }
+  }
+
   if (subscriptions.empty()) {
     SDL_LOG_DEBUG("Subscriptions is empty");
     return;


### PR DESCRIPTION
Fixes #[7322](https://adc.luxoft.com/jira/browse/FORDTCN-7322)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts.
Affected unit tests are updated, also new unit test is added.

### Summary
In some situations we need to handle case, when first application has already subscribed to shared data, and second application starts it's resumption by HandleResumptionSubscriptionRequest method. Before check for already existed subscriptions was located in VehicleInfoPlugin, so rarely there was race condition, when this check is performed for second application too early right before first application has completed it's subscription process. Also note, that processes of request and response handling are synchronized inside of VehicleInfoPendingResumptionHandler class by corresponding lock, so all corresponding methods are executed sequentially.
That's why root cause of this race condition is a time gap between check for existed subscriptions in VehicleInfoPlugin and further processing of pending subscriptions in HandleResumptionSubscriptionRequest method. So there is a need in replacing above-mentioned check from VehicleInfoPlugin to HandleResumptionSubscriptionRequest method, where this check will be locked and synchronized in correct way.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
