### PR TITLE
Unsubscribe from event in VehicleInfoPendingResumptionHandler

### DIFF
--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
@@ -80,6 +80,7 @@ void VISubscribeVehicleDataRequest::Run() {
 void VISubscribeVehicleDataRequest::onTimeOut() {
   event_engine::Event timeout_event(
       hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData);
+  SDL_LOG_AUTO_TRACE();
 
   auto error_response = MessageHelper::CreateNegativeResponseFromHmi(
       function_id(),

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -138,6 +138,7 @@ void VehicleInfoPendingResumptionHandler::RaiseFinishedPendingResumption(
     ext.subscribeToVehicleInfo(subscription);
   }
 
+  unsubscribe_from_event(VehicleInfo_SubscribeVehicleData);
   auto fake_response =
       CreateFakeResponseFromHMI(pending_resumption.subscription_results_,
                                 pending_resumption.fake_corr_id_);


### PR DESCRIPTION
Fixes #[7479](https://adc.luxoft.com/jira/browse/FORDTCN-7479)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Now VehicleInfoPendingResumptionHandler doesn't unsubscribe from already processed event, so there is a case, when VehicleInfoPendingResumptionHandler can catch request with same correlation ID repeatedly. That's why corresponding call is added to function, invoked during processing of corresponding event.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
