### PR TITLE
Improve synchronization in WaypointsPendingResumptionHandler

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -520,6 +520,10 @@ class DynamicApplicationData {
 class Application : public virtual InitialApplicationData,
                     public virtual DynamicApplicationData {
  public:
+  /**
+   * @brief The StreamingState enum defines current streaming state
+   */
+  enum class StreamingState { kStopped, kStarted, kSuspended };
   enum ApplicationRegisterState { kRegistered = 0, kWaitingForRegistration };
 
   Application() : is_greyed_out_(false) {}
@@ -660,10 +664,8 @@ class Application : public virtual InitialApplicationData,
   /**
    * @brief Wakes up streaming process for application
    * @param service_type Type of streaming service
-   * @param timer_len The amount of time in ms the timer will wait
    */
-  virtual void WakeUpStreaming(protocol_handler::ServiceType service_type,
-                               uint32_t timer_len = 0) = 0;
+  virtual void WakeUpStreaming(protocol_handler::ServiceType service_type) = 0;
 
   virtual bool is_voice_communication_supported() const = 0;
   virtual void set_voice_communication_supported(

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -142,8 +142,7 @@ class ApplicationImpl : public virtual Application,
   void StopStreamingForce(protocol_handler::ServiceType service_type);
   void StopStreaming(protocol_handler::ServiceType service_type);
   void SuspendStreaming(protocol_handler::ServiceType service_type);
-  void WakeUpStreaming(protocol_handler::ServiceType service_type,
-                       uint32_t timer_len = 0);
+  void WakeUpStreaming(protocol_handler::ServiceType service_type);
 
   virtual bool is_voice_communication_supported() const;
   virtual void set_voice_communication_supported(bool option);

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -881,15 +881,9 @@ class ApplicationManagerImpl
       bool result,
       std::vector<std::string>& rejected_params) OVERRIDE;
 
-  /**
-   * @brief Callback calls when application starts/stops data streaming
-   * @param app_id Streaming application id
-   * @param service_type Streaming service type
-   * @param state Shows if streaming started or stopped
-   */
   void OnAppStreaming(uint32_t app_id,
                       protocol_handler::ServiceType service_type,
-                      bool state) OVERRIDE;
+                      const Application::StreamingState new_state) OVERRIDE;
 
   mobile_api::HMILevel::eType GetDefaultHmiLevel(
       ApplicationConstSharedPtr application) const;

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -703,7 +703,7 @@ class PolicyHandler : public PolicyHandlerInterface,
 
 #ifdef BUILD_TESTS
   void SetPolicyManager(std::shared_ptr<PolicyManager> pm) {
-    policy_manager_ = pm;
+    ExchangePolicyManager(pm);
   }
 #endif  // BUILD_TESTS
 
@@ -901,8 +901,28 @@ class PolicyHandler : public PolicyHandlerInterface,
    */
   void GetRegisteredLinks(std::map<std::string, std::string>& out_links) const;
 
+  /**
+   * @brief Load policy manager
+   * This method is thread safe
+   * @return Pointer to the policy manager instance or null if not inited
+   */
+  std::shared_ptr<PolicyManager> LoadPolicyManager() const;
+
+  /**
+   * @brief Exchange a policy manager
+   * This method is thread safe
+   * @param policy_manager - new policy manager
+   */
+  void ExchangePolicyManager(std::shared_ptr<PolicyManager> policy_manager);
+
   mutable sync_primitives::RWLock policy_manager_lock_;
-  std::shared_ptr<PolicyManager> policy_manager_;
+
+  /**
+   * @brief Policy manager
+   * @note Use atomic_policy_manager_ only with
+   * LoadPolicyManager and ExchangePolicyManager methods!
+   */
+  std::shared_ptr<PolicyManager> atomic_policy_manager_;
   std::shared_ptr<PolicyEventObserver> event_observer_;
   uint32_t last_activated_app_id_;
 
@@ -917,8 +937,6 @@ class PolicyHandler : public PolicyHandlerInterface,
    * @brief Contains device handles, which were sent for user consent to HMI
    */
   DeviceHandles pending_device_handles_;
-
-  inline bool CreateManager();
 
   typedef std::list<PolicyHandlerObserver*> HandlersCollection;
   HandlersCollection listeners_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/sdl_rpc_plugin.cc
@@ -115,14 +115,6 @@ void SDLRPCPlugin::ProcessResumptionSubscription(
     application_manager::Application& app, WayPointsAppExtension& ext) {
   SDL_LOG_AUTO_TRACE();
 
-  if (application_manager_->IsAnyAppSubscribedForWayPoints()) {
-    SDL_LOG_DEBUG(
-        "Subscription to waypoint already exist, no need to send "
-        "request to HMI");
-    application_manager_->SubscribeAppForWayPoints(app.app_id());
-    return;
-  }
-
   pending_resumption_handler_->HandleResumptionSubscriptionRequest(ext, app);
 }
 

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -613,6 +613,9 @@ void ApplicationImpl::StopStreaming(
 void ApplicationImpl::StopNaviStreaming() {
   SDL_LOG_AUTO_TRACE();
   video_stream_suspend_timer_.Stop();
+  application_manager_.OnAppStreaming(app_id(),
+                                      protocol_handler::ServiceType::kMobileNav,
+                                      StreamingState::kStopped);
   MessageHelper::SendNaviStopStream(app_id(), application_manager_);
   set_video_streaming_approved(false);
   set_video_stream_retry_number(0);
@@ -621,6 +624,9 @@ void ApplicationImpl::StopNaviStreaming() {
 void ApplicationImpl::StopAudioStreaming() {
   SDL_LOG_AUTO_TRACE();
   audio_stream_suspend_timer_.Stop();
+  application_manager_.OnAppStreaming(app_id(),
+                                      protocol_handler::ServiceType::kAudio,
+                                      StreamingState::kStopped);
   MessageHelper::SendAudioStopStream(app_id(), application_manager_);
   set_audio_streaming_approved(false);
   set_audio_stream_retry_number(0);
@@ -631,14 +637,17 @@ void ApplicationImpl::SuspendStreaming(
   using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
 
-  if (ServiceType::kMobileNav == service_type) {
+  if (ServiceType::kMobileNav == service_type && !video_streaming_suspended_) {
     video_stream_suspend_timer_.Stop();
-    application_manager_.OnAppStreaming(app_id(), service_type, false);
+    application_manager_.OnAppStreaming(
+        app_id(), service_type, StreamingState::kSuspended);
     sync_primitives::AutoLock lock(video_streaming_suspended_lock_);
     video_streaming_suspended_ = true;
-  } else if (ServiceType::kAudio == service_type) {
+  } else if (ServiceType::kAudio == service_type &&
+             !audio_streaming_suspended_) {
     audio_stream_suspend_timer_.Stop();
-    application_manager_.OnAppStreaming(app_id(), service_type, false);
+    application_manager_.OnAppStreaming(
+        app_id(), service_type, StreamingState::kSuspended);
     sync_primitives::AutoLock lock(audio_streaming_suspended_lock_);
     audio_streaming_suspended_ = true;
   }
@@ -647,7 +656,7 @@ void ApplicationImpl::SuspendStreaming(
 }
 
 void ApplicationImpl::WakeUpStreaming(
-    protocol_handler::ServiceType service_type, uint32_t timer_len) {
+    protocol_handler::ServiceType service_type) {
   using namespace protocol_handler;
   SDL_LOG_AUTO_TRACE();
 
@@ -659,28 +668,29 @@ void ApplicationImpl::WakeUpStreaming(
     {  // reduce the range of video_streaming_suspended_lock_
       sync_primitives::AutoLock auto_lock(video_streaming_suspended_lock_);
       if (video_streaming_suspended_) {
-        application_manager_.OnAppStreaming(app_id(), service_type, true);
+        application_manager_.OnAppStreaming(
+            app_id(), service_type, StreamingState::kStarted);
         application_manager_.ProcessOnDataStreamingNotification(
             service_type, app_id(), true);
         video_streaming_suspended_ = false;
       }
     }
-    video_stream_suspend_timer_.Start(
-        timer_len == 0 ? video_stream_suspend_timeout_ : timer_len,
-        timer::kPeriodic);
+
+    video_stream_suspend_timer_.Start(video_stream_suspend_timeout_,
+                                      timer::kPeriodic);
   } else if (ServiceType::kAudio == service_type) {
     {  // reduce the range of audio_streaming_suspended_lock_
       sync_primitives::AutoLock auto_lock(audio_streaming_suspended_lock_);
       if (audio_streaming_suspended_) {
-        application_manager_.OnAppStreaming(app_id(), service_type, true);
+        application_manager_.OnAppStreaming(
+            app_id(), service_type, StreamingState::kStarted);
         application_manager_.ProcessOnDataStreamingNotification(
             service_type, app_id(), true);
         audio_streaming_suspended_ = false;
       }
     }
-    audio_stream_suspend_timer_.Start(
-        timer_len == 0 ? audio_stream_suspend_timeout_ : timer_len,
-        timer::kPeriodic);
+    audio_stream_suspend_timer_.Start(audio_stream_suspend_timeout_,
+                                      timer::kPeriodic);
   }
 }
 

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3566,7 +3566,9 @@ void ApplicationManagerImpl::ForbidStreaming(
 }
 
 void ApplicationManagerImpl::OnAppStreaming(
-    uint32_t app_id, protocol_handler::ServiceType service_type, bool state) {
+    uint32_t app_id,
+    protocol_handler::ServiceType service_type,
+    const Application::StreamingState new_state) {
   SDL_LOG_AUTO_TRACE();
 
   ApplicationSharedPtr app = application(app_id);
@@ -3577,12 +3579,31 @@ void ApplicationManagerImpl::OnAppStreaming(
   }
   DCHECK_OR_RETURN_VOID(media_manager_);
 
-  if (state) {
-    state_ctrl_.OnVideoStreamingStarted(app);
-    media_manager_->StartStreaming(app_id, service_type);
-  } else {
-    media_manager_->StopStreaming(app_id, service_type);
-    state_ctrl_.OnVideoStreamingStopped(app);
+  SDL_LOG_DEBUG("New state for service " << static_cast<int32_t>(service_type)
+                                         << " is "
+                                         << static_cast<int32_t>(new_state));
+  switch (new_state) {
+    case Application::StreamingState::kStopped: {
+      // Stop activity in media_manager_ when service is stopped
+      // State controller has been already notified by kSuspended event
+      // received before
+      media_manager_->StopStreaming(app_id, service_type);
+      break;
+    }
+
+    case Application::StreamingState::kStarted: {
+      // Apply temporary streaming state and start activity in media_manager_
+      state_ctrl_.OnVideoStreamingStarted(app);
+      media_manager_->StartStreaming(app_id, service_type);
+      break;
+    }
+
+    case Application::StreamingState::kSuspended: {
+      // Don't stop activity in media_manager_ in that case
+      // Just cancel the temporary streaming state
+      state_ctrl_.OnVideoStreamingStopped(app);
+      break;
+    }
   }
 }
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -30,12 +30,14 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 #include "application_manager/policies/policy_handler.h"
+
 #include <dlfcn.h>
 #include <unistd.h>
 #include <algorithm>
 #include <functional>
 #include <utility>
 #include <vector>
+
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/policies/delegates/app_permission_delegate.h"
@@ -137,21 +139,24 @@ struct HMILevelPredicate
   mobile_api::HMILevel::eType level_;
 };
 
+constexpr char kLibraryNotLoadedMessage[] =
+    "The shared library of policy is not loaded";
+
 }  // namespace
 
-#define POLICY_LIB_CHECK_OR_RETURN(return_value)                   \
+#define POLICY_LIB_CHECK_OR_RETURN(policy_manager, return_value)   \
   {                                                                \
     sync_primitives::AutoReadLock lock(policy_manager_lock_);      \
-    if (!policy_manager_) {                                        \
+    if (!policy_manager) {                                         \
       SDL_LOG_DEBUG("The shared library of policy is not loaded"); \
       return return_value;                                         \
     }                                                              \
   }
 
-#define POLICY_LIB_CHECK_VOID()                                    \
+#define POLICY_LIB_CHECK_VOID(policy_manager)                      \
   {                                                                \
     sync_primitives::AutoReadLock lock(policy_manager_lock_);      \
-    if (!policy_manager_) {                                        \
+    if (!policy_manager) {                                         \
       SDL_LOG_DEBUG("The shared library of policy is not loaded"); \
       return;                                                      \
     }                                                              \
@@ -308,7 +313,7 @@ PolicyHandler::~PolicyHandler() {}
 
 PolicyEncryptionFlagGetterInterfaceSPtr
 PolicyHandler::PolicyEncryptionFlagGetter() const {
-  return policy_manager_;
+  return LoadPolicyManager();
 }
 
 bool PolicyHandler::PolicyEnabled() const {
@@ -317,55 +322,71 @@ bool PolicyHandler::PolicyEnabled() const {
 
 bool PolicyHandler::LoadPolicyLibrary() {
   SDL_LOG_AUTO_TRACE();
-  sync_primitives::AutoWriteLock lock(policy_manager_lock_);
-  if (!PolicyEnabled()) {
-    SDL_LOG_WARN(
-        "System is configured to work without policy "
-        "functionality.");
-    policy_manager_.reset();
-    return false;
-  }
 
-  if (CreateManager()) {
-    policy_manager_->set_listener(this);
-    event_observer_ = std::shared_ptr<PolicyEventObserver>(
-        new PolicyEventObserver(this, application_manager_.event_dispatcher()));
-  }
+  auto create_policy_manager_instance = [this]() {
+    if (!PolicyEnabled()) {
+      SDL_LOG_WARN(
+          "System is configured to work without policy "
+          "functionality.");
+      return std::shared_ptr<PolicyManager>();
+    }
 
-  return (policy_manager_.use_count() != 0);
-}
+    ExchangePolicyManager(nullptr);
+    sync_primitives::AutoWriteLock lock(policy_manager_lock_);
+    void* const dl_policy_handle = dlopen(kLibrary.c_str(), RTLD_LAZY);
 
-bool PolicyHandler::CreateManager() {
-  void* policy_handle = dlopen(kLibrary.c_str(), RTLD_LAZY);
-  const char* error = dlerror();
-  if (!policy_handle) {
-    SDL_LOG_ERROR((error == NULL
-                       ? "Unknown error in dlopen while loading policy table"
-                       : error));
-    return false;
-  }
+    if (!dl_policy_handle) {
+      SDL_LOG_ERROR("An error occurs while calling dlopen");
+      return std::shared_ptr<PolicyManager>();
+    }
 
-  typedef PolicyManager* (*CreateManager)(logger::Logger*);
-  typedef void (*DeleteManager)(PolicyManager*);
-  CreateManager create_manager =
-      reinterpret_cast<CreateManager>(dlsym(policy_handle, "CreateManager"));
-  DeleteManager delete_manager =
-      reinterpret_cast<DeleteManager>(dlsym(policy_handle, "DeleteManager"));
-  auto policy_destroyer = [delete_manager,
-                           policy_handle](PolicyManager* policy_manager) {
-    SDL_LOG_DEBUG("Delete Policy Manager");
-    delete_manager(policy_manager);
-    dlclose(policy_handle);
-  };
-  char* error_string = dlerror();
-  if (NULL == error_string) {
-    policy_manager_ = std::shared_ptr<PolicyManager>(
+    typedef PolicyManager* (*CreateManager)(logger::Logger*);
+    typedef void (*DeleteManager)(PolicyManager*);
+
+    CreateManager create_manager = reinterpret_cast<CreateManager>(
+        dlsym(dl_policy_handle, "CreateManager"));
+    char* error_string = dlerror();
+    if (NULL != error_string) {
+      SDL_LOG_WARN(error_string);
+      dlclose(dl_policy_handle);
+      return std::shared_ptr<PolicyManager>();
+    }
+
+    DeleteManager delete_manager = reinterpret_cast<DeleteManager>(
+        dlsym(dl_policy_handle, "DeleteManager"));
+
+    error_string = dlerror();
+    if (NULL != error_string) {
+      SDL_LOG_WARN(error_string);
+      dlclose(dl_policy_handle);
+      return std::shared_ptr<PolicyManager>();
+    }
+
+    auto policy_destroyer = [delete_manager,
+                             dl_policy_handle](PolicyManager* policy_manager) {
+      SDL_LOG_DEBUG("Delete Policy Manager");
+      delete_manager(policy_manager);
+      dlclose(dl_policy_handle);
+    };
+
+    auto policy_manager = std::shared_ptr<PolicyManager>(
         create_manager(&logger::Logger::instance()), policy_destroyer);
-  } else {
-    SDL_LOG_WARN(error_string);
-    dlclose(policy_handle);
+
+    policy_manager->set_listener(this);
+
+    return policy_manager;
+  };
+
+  auto policy_manager = create_policy_manager_instance();
+
+  if (!policy_manager) {
+    return false;
   }
-  return (policy_manager_.use_count() != 0);
+
+  ExchangePolicyManager(policy_manager);
+  event_observer_ = std::make_shared<PolicyEventObserver>(
+      this, application_manager_.event_dispatcher());
+  return true;
 }
 
 const PolicySettings& PolicyHandler::get_settings() const {
@@ -374,11 +395,13 @@ const PolicySettings& PolicyHandler::get_settings() const {
 
 bool PolicyHandler::InitPolicyTable() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false)
+
   std::string preloaded_file = get_settings().preloaded_pt_file();
   if (file_system::FileExists(preloaded_file)) {
     const bool pt_inited =
-        policy_manager_->InitPT(preloaded_file, &get_settings());
+        policy_manager->InitPT(preloaded_file, &get_settings());
     OnPTInited();
     return pt_inited;
   }
@@ -398,20 +421,22 @@ void PolicyHandler::OnPTInited() {
 
 void PolicyHandler::StopRetrySequence() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 #ifndef EXTERNAL_PROPRIETARY_MODE
   // Clear cached PTU app
   last_ptu_app_id_ = 0;
 #endif  // EXTERNAL_PROPRIETARY_MODE
-  policy_manager_->StopRetrySequence();
+  policy_manager->StopRetrySequence();
 }
 
 bool PolicyHandler::ResetPolicyTable() {
   SDL_LOG_TRACE("Reset policy table.");
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false)
   std::string preloaded_file = get_settings().preloaded_pt_file();
   if (file_system::FileExists(preloaded_file)) {
-    return policy_manager_->ResetPT(preloaded_file);
+    return policy_manager->ResetPT(preloaded_file);
   }
   SDL_LOG_WARN("The file which contains preloaded PT is not exist");
   return false;
@@ -419,8 +444,9 @@ bool PolicyHandler::ResetPolicyTable() {
 
 bool PolicyHandler::ClearUserConsent() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->ResetUserConsent();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false)
+  return policy_manager->ResetUserConsent();
 }
 
 #ifndef EXTERNAL_PROPRIETARY_MODE
@@ -454,7 +480,6 @@ void PolicyHandler::CacheRetryInfo(const uint32_t app_id,
 
 uint32_t PolicyHandler::GetAppIdForSending() const {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(0);
 
   // fix ApplicationSet access crash
   const ApplicationSet accessor = application_manager_.applications().GetData();
@@ -494,28 +519,30 @@ uint32_t PolicyHandler::GetAppIdForSending() const {
 
 void PolicyHandler::PushAppIdToPTUQueue(const uint32_t app_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   sync_primitives::AutoLock lock(app_id_queue_lock_);
   const auto result = applications_ptu_queue_.insert(app_id);
   if (result.second) {
-    policy_manager_->UpdatePTUReadyAppsCount(applications_ptu_queue_.size());
+    policy_manager->UpdatePTUReadyAppsCount(applications_ptu_queue_.size());
   }
 }
 
 void PolicyHandler::PopAppIdFromPTUQueue() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   sync_primitives::AutoLock lock(app_id_queue_lock_);
   if (applications_ptu_queue_.size() > 0) {
     applications_ptu_queue_.erase(applications_ptu_queue_.begin());
-    policy_manager_->UpdatePTUReadyAppsCount(applications_ptu_queue_.size());
+    policy_manager->UpdatePTUReadyAppsCount(applications_ptu_queue_.size());
   }
 }
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
 PTURetryHandler& PolicyHandler::ptu_retry_handler() const {
   SDL_LOG_AUTO_TRACE();
-  return *policy_manager_;
+  return *atomic_policy_manager_;
 }
 
 void PolicyHandler::OnAppPermissionConsent(
@@ -538,7 +565,8 @@ void PolicyHandler::OnAppPermissionConsent(
 void PolicyHandler::OnDeviceConsentChanged(const std::string& device_id,
                                            const bool is_allowed) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   connection_handler::DeviceHandle device_handle;
   if (!application_manager_.connection_handler().GetDeviceID(device_id,
                                                              &device_handle)) {
@@ -563,15 +591,15 @@ void PolicyHandler::OnDeviceConsentChanged(const std::string& device_id,
       // with negative data consent, there no necessity to change smth and
       // send
       // notification for such app in case of device consent is not allowed
-      if (policy_manager_->IsPredataPolicy(policy_app_id) && !is_allowed) {
+      if (policy_manager->IsPredataPolicy(policy_app_id) && !is_allowed) {
         continue;
       }
 
-      policy_manager_->ReactOnUserDevConsentForApp(
+      policy_manager->ReactOnUserDevConsentForApp(
           device_handle, policy_app_id, is_allowed);
 
-      policy_manager_->SendNotificationOnPermissionsUpdated(device_id,
-                                                            policy_app_id);
+      policy_manager->SendNotificationOnPermissionsUpdated(device_id,
+                                                           policy_app_id);
     }
   }
 }
@@ -604,8 +632,9 @@ void PolicyHandler::SendOnAppPropertiesChangeNotification(
 
 void PolicyHandler::OnPTExchangeNeeded() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->ForcePTExchange();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->ForcePTExchange();
 }
 
 void PolicyHandler::GetAvailableApps(std::queue<std::string>& apps) {
@@ -630,22 +659,26 @@ StatusNotifier PolicyHandler::AddApplication(
     const std::string& device_id,
     const std::string& application_id,
     const rpc::policy_table_interface_base::AppHmiTypes& hmi_types) {
-  POLICY_LIB_CHECK_OR_RETURN(std::make_shared<utils::CallNothing>());
-  return policy_manager_->AddApplication(device_id, application_id, hmi_types);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager,
+                             std::make_shared<utils::CallNothing>());
+  return policy_manager->AddApplication(device_id, application_id, hmi_types);
 }
 
 void PolicyHandler::AddDevice(const std::string& device_id,
                               const std::string& connection_type) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->AddDevice(device_id, connection_type);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->AddDevice(device_id, connection_type);
 }
 
 void PolicyHandler::SetDeviceInfo(const std::string& device_id,
                                   const DeviceInfo& device_info) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->SetDeviceInfo(device_id, device_info);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->SetDeviceInfo(device_id, device_info);
 }
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
@@ -661,7 +694,8 @@ void PolicyHandler::OnAppPermissionConsentInternal(
 void PolicyHandler::OnAppPermissionConsentInternal(
     const uint32_t connection_key, PermissionConsent& out_permissions) {
 #endif
-  POLICY_LIB_CHECK_VOID();
+  const std::shared_ptr<PolicyManager> policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
   if (connection_key) {
     ApplicationSharedPtr app = application_manager_.application(connection_key);
@@ -677,9 +711,9 @@ void PolicyHandler::OnAppPermissionConsentInternal(
 
     if (!out_permissions.policy_app_id.empty()) {
 #ifdef EXTERNAL_PROPRIETARY_MODE
-      policy_manager_->SetUserConsentForApp(out_permissions, mode);
+      policy_manager->SetUserConsentForApp(out_permissions, mode);
 #else
-      policy_manager_->SetUserConsentForApp(out_permissions);
+      policy_manager->SetUserConsentForApp(out_permissions);
 #endif
     }
   } else if (!app_to_device_link_.empty()) {
@@ -716,9 +750,9 @@ void PolicyHandler::OnAppPermissionConsentInternal(
       out_permissions.policy_app_id = app->policy_app_id();
       out_permissions.device_id = app->mac_address();
 #ifdef EXTERNAL_PROPRIETARY_MODE
-      policy_manager_->SetUserConsentForApp(out_permissions, mode);
+      policy_manager->SetUserConsentForApp(out_permissions, mode);
 #else
-      policy_manager_->SetUserConsentForApp(out_permissions);
+      policy_manager->SetUserConsentForApp(out_permissions);
 #endif
     }
   } else {
@@ -727,14 +761,15 @@ void PolicyHandler::OnAppPermissionConsentInternal(
         "setting common permissions.");
   }
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  if (!policy_manager_->SetExternalConsentStatus(external_consent_status)) {
+  if (!policy_manager->SetExternalConsentStatus(external_consent_status)) {
     SDL_LOG_WARN("External User Consent Settings status has not been set!");
   }
 #endif
 }
 
 void policy::PolicyHandler::SetDaysAfterEpoch() {
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   date_time::TimeDuration current_time = date_time::getCurrentTime();
   const int kSecondsInDay = 60 * 60 * 24;
   int days_after_epoch = date_time::getSecs(current_time) / kSecondsInDay;
@@ -743,8 +778,9 @@ void policy::PolicyHandler::SetDaysAfterEpoch() {
 
 #ifdef ENABLE_SECURITY
 std::string PolicyHandler::RetrieveCertificate() const {
-  POLICY_LIB_CHECK_OR_RETURN(std::string(""));
-  return policy_manager_->RetrieveCertificate();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::string());
+  return policy_manager->RetrieveCertificate();
 }
 #endif  // ENABLE_SECURITY
 
@@ -753,17 +789,18 @@ void PolicyHandler::OnGetUserFriendlyMessage(
     const std::string& language,
     uint32_t correlation_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
   const std::string active_hmi_language = application_manager::EnumToString(
       application_manager_.hmi_capabilities().active_ui_language());
   const std::vector<UserFriendlyMessage> result =
-      policy_manager_->GetUserFriendlyMessages(
+      policy_manager->GetUserFriendlyMessages(
           message_codes, language, active_hmi_language);
 #else
   const std::vector<UserFriendlyMessage> result =
-      policy_manager_->GetUserFriendlyMessages(message_codes, language);
+      policy_manager->GetUserFriendlyMessages(message_codes, language);
 #endif  // EXTERNAL_PROPRIETARY_MODE
   // Send response to HMI with gathered data
   MessageHelper::SendGetUserFriendlyMessageResponse(
@@ -774,12 +811,16 @@ void PolicyHandler::OnSystemRequestReceived() const {
 #ifdef EXTERNAL_PROPRIETARY_MODE
   ptu_retry_handler().OnSystemRequestReceived();
 #endif
-  policy_manager_->ResetTimeout();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->ResetTimeout();
 }
 
 void PolicyHandler::TriggerPTUOnStartupIfRequired() {
 #ifdef PROPRIETARY_MODE
-  policy_manager_->TriggerPTUOnStartupIfRequired();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->TriggerPTUOnStartupIfRequired();
 #endif
 }
 
@@ -793,10 +834,23 @@ void PolicyHandler::GetRegisteredLinks(
   std::for_each(it_app, it_app_end, linker);
 }
 
+std::shared_ptr<PolicyManager> PolicyHandler::LoadPolicyManager() const {
+  sync_primitives::AutoReadLock lock{policy_manager_lock_};
+  return atomic_policy_manager_;
+}
+
+void PolicyHandler::ExchangePolicyManager(
+    std::shared_ptr<PolicyManager> policy_manager) {
+  sync_primitives::AutoWriteLock lock{policy_manager_lock_};
+  atomic_policy_manager_.swap(policy_manager);
+}
+
 std::vector<policy::FunctionalGroupPermission>
 PolicyHandler::CollectRegisteredAppsPermissions() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(std::vector<policy::FunctionalGroupPermission>());
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager,
+                             std::vector<policy::FunctionalGroupPermission>());
   // If no specific app was passed, get permissions for all currently registered
   // applications
   sync_primitives::AutoLock lock(app_to_device_link_lock_);
@@ -808,7 +862,7 @@ PolicyHandler::CollectRegisteredAppsPermissions() {
   std::map<std::string, std::string>::const_iterator it =
       app_to_device_link_.begin();
   for (; it != app_to_device_link_.end(); ++it) {
-    policy_manager_->GetUserConsentForApp(
+    policy_manager->GetUserConsentForApp(
         it->first, it->second, group_permissions);
     consolidator.Consolidate(group_permissions);
   }
@@ -818,7 +872,8 @@ PolicyHandler::CollectRegisteredAppsPermissions() {
 std::vector<FunctionalGroupPermission> PolicyHandler::CollectAppPermissions(
     const uint32_t connection_key) {
   std::vector<FunctionalGroupPermission> group_permissions;
-  POLICY_LIB_CHECK_OR_RETURN(group_permissions);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, group_permissions);
 
   // Single app only
   ApplicationSharedPtr app = application_manager_.application(connection_key);
@@ -841,9 +896,9 @@ std::vector<FunctionalGroupPermission> PolicyHandler::CollectAppPermissions(
     return group_permissions;
   }
 
-  policy_manager_->GetUserConsentForApp(device_params.device_mac_address,
-                                        app->policy_app_id(),
-                                        group_permissions);
+  policy_manager->GetUserConsentForApp(device_params.device_mac_address,
+                                       app->policy_app_id(),
+                                       group_permissions);
 
   return group_permissions;
 }
@@ -851,7 +906,8 @@ std::vector<FunctionalGroupPermission> PolicyHandler::CollectAppPermissions(
 void PolicyHandler::OnGetListOfPermissions(const uint32_t connection_key,
                                            const uint32_t correlation_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
   application_manager::ApplicationSharedPtr app =
       application_manager_.application(connection_key);
@@ -871,7 +927,7 @@ void PolicyHandler::OnGetListOfPermissions(const uint32_t connection_key,
   MessageHelper::SendGetListOfPermissionsResponse(
       permissions,
 #ifdef EXTERNAL_PROPRIETARY_MODE
-      policy_manager_->GetExternalConsentStatus(),
+      policy_manager->GetExternalConsentStatus(),
 #endif  // EXTERNAL_PROPRIETARY_MODE
       correlation_id,
       application_manager_);
@@ -896,7 +952,8 @@ void PolicyHandler::LinkAppsToDevice() {
 bool PolicyHandler::IsAppSuitableForPolicyUpdate(
     const Applications::value_type value) const {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
 
   if (!value->IsRegistered()) {
     SDL_LOG_DEBUG("Application " << value->app_id()
@@ -913,7 +970,7 @@ bool PolicyHandler::IsAppSuitableForPolicyUpdate(
       application_manager_.connection_handler().get_session_observer());
 
   const bool is_device_allowed =
-      (kDeviceAllowed == policy_manager_->GetUserConsentForDevice(
+      (kDeviceAllowed == policy_manager->GetUserConsentForDevice(
                              device_params.device_mac_address));
 
   SDL_LOG_DEBUG("Is device " << device_params.device_mac_address << " allowed "
@@ -942,8 +999,9 @@ uint32_t PolicyHandler::ChooseRandomAppForPolicyUpdate(
 void PolicyHandler::OnDeviceSwitching(const std::string& device_id_from,
                                       const std::string& device_id_to) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnDeviceSwitching(device_id_from, device_id_to);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->OnDeviceSwitching(device_id_from, device_id_to);
 }
 
 void PolicyHandler::OnLockScreenDismissalStateChanged() {
@@ -957,17 +1015,19 @@ void PolicyHandler::OnLockScreenDismissalStateChanged() {
 
 void PolicyHandler::OnGetStatusUpdate(const uint32_t correlation_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   MessageHelper::SendGetStatusUpdateResponse(
-      policy_manager_->GetPolicyTableStatus(),
+      policy_manager->GetPolicyTableStatus(),
       correlation_id,
       application_manager_);
 }
 
 void PolicyHandler::OnUpdateStatusChanged(const std::string& status) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->SaveUpdateStatusRequired(policy::kUpToDate != status);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->SaveUpdateStatusRequired(policy::kUpToDate != status);
   MessageHelper::SendOnStatusUpdate(status, application_manager_);
 }
 
@@ -995,26 +1055,32 @@ std::string PolicyHandler::OnCurrentDeviceIdUpdateRequired(
 
 void PolicyHandler::OnSystemInfoChanged(const std::string& language) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->SetSystemLanguage(language);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->SetSystemLanguage(language);
 }
 
 void PolicyHandler::SetPreloadedPtFlag(const bool is_preloaded) {
   SDL_LOG_AUTO_TRACE();
-  policy_manager_->SetPreloadedPtFlag(is_preloaded);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->SetPreloadedPtFlag(is_preloaded);
 }
 
 void PolicyHandler::OnGetSystemInfo(const std::string& ccpu_version,
                                     const std::string& wers_country_code,
                                     const std::string& language) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->SetSystemInfo(ccpu_version, wers_country_code, language);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->SetSystemInfo(ccpu_version, wers_country_code, language);
 }
 
 std::string PolicyHandler::GetCCPUVersionFromPT() const {
   SDL_LOG_AUTO_TRACE();
-  return policy_manager_->GetCCPUVersionFromPT();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::string());
+  return policy_manager->GetCCPUVersionFromPT();
 }
 
 void PolicyHandler::OnVIIsReady() {
@@ -1031,7 +1097,8 @@ void PolicyHandler::OnVIIsReady() {
 
 void PolicyHandler::OnVehicleDataUpdated(
     const smart_objects::SmartObject& message) {
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 #ifdef EXTERNAL_PROPRIETARY_MODE
   if (!message.keyExists(strings::msg_params)) {
     SDL_LOG_ERROR("Message does not contains mandatory section "
@@ -1039,7 +1106,7 @@ void PolicyHandler::OnVehicleDataUpdated(
     return;
   }
   if (message[strings::msg_params].keyExists(strings::vin)) {
-    policy_manager_->SetVINValue(
+    policy_manager->SetVINValue(
         message[strings::msg_params][strings::vin].asString());
   }
 #else
@@ -1052,7 +1119,8 @@ void PolicyHandler::OnPendingPermissionChange(
   SDL_LOG_AUTO_TRACE();
   SDL_LOG_DEBUG("PolicyHandler::OnPendingPermissionChange for "
                 << policy_app_id);
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   ApplicationSharedPtr app =
       application_manager_.application(device_id, policy_app_id);
   if (app.use_count() == 0) {
@@ -1061,7 +1129,7 @@ void PolicyHandler::OnPendingPermissionChange(
   }
 
   AppPermissions permissions =
-      policy_manager_->GetAppPermissionsChanges(device_id, policy_app_id);
+      policy_manager->GetAppPermissionsChanges(device_id, policy_app_id);
 
   const uint32_t app_id = app->app_id();
 
@@ -1075,7 +1143,7 @@ void PolicyHandler::OnPendingPermissionChange(
         mobile_apis::AudioStreamingState::NOT_AUDIBLE,
         mobile_apis::VideoStreamingState::NOT_STREAMABLE,
         true);
-    policy_manager_->RemovePendingPermissionChanges(policy_app_id);
+    policy_manager->RemovePendingPermissionChanges(policy_app_id);
     return;
   }
 
@@ -1124,7 +1192,7 @@ void PolicyHandler::OnPendingPermissionChange(
         app->app_id(), permissions, application_manager_);
   }
 
-  policy_manager_->RemovePendingPermissionChanges(policy_app_id);
+  policy_manager->RemovePendingPermissionChanges(policy_app_id);
 }
 
 bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
@@ -1137,7 +1205,7 @@ bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
                                      const std::string& url,
                                      const uint32_t app_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  POLICY_LIB_CHECK_OR_RETURN(atomic_policy_manager_, false);
 
   ApplicationSharedPtr app = application_manager_.application(app_id);
 
@@ -1171,9 +1239,10 @@ bool PolicyHandler::SendMessageToSDK(const BinaryMessage& pt_string,
 
 bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
                                           const BinaryMessage& pt_string) {
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
 
-  const auto load_pt_result = policy_manager_->LoadPT(file, pt_string);
+  const auto load_pt_result = policy_manager->LoadPT(file, pt_string);
 
   SDL_LOG_INFO("Load policy table result code: " << load_pt_result);
 
@@ -1183,9 +1252,9 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
 
   if (is_ptu_successful) {
     SDL_LOG_INFO("PTU was successful.");
-    policy_manager_->CleanupUnpairedDevices();
+    policy_manager->CleanupUnpairedDevices();
     SetDaysAfterEpoch();
-    policy_manager_->OnPTUFinished(load_pt_result);
+    policy_manager->OnPTUFinished(load_pt_result);
 #ifndef EXTERNAL_PROPRIETARY_MODE
     // Clean up retry information
     last_ptu_app_id_ = 0;
@@ -1200,7 +1269,7 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
         correlation_id, vehicle_data_args, application_manager_);
   } else {
     SDL_LOG_WARN("Exchange wasn't successful");
-    policy_manager_->OnPTUFinished(load_pt_result);
+    policy_manager->OnPTUFinished(load_pt_result);
   }
 
   return is_ptu_successful;
@@ -1208,28 +1277,24 @@ bool PolicyHandler::ReceiveMessageFromSDK(const std::string& file,
 
 bool PolicyHandler::UnloadPolicyLibrary() {
   SDL_LOG_AUTO_TRACE();
-  SDL_LOG_DEBUG("policy_manager_ = " << policy_manager_);
-  bool ret = true;
   AsyncRunner::Stop();
-  sync_primitives::AutoWriteLock lock(policy_manager_lock_);
-  if (policy_manager_) {
-    policy_manager_.reset();
-  }
-  SDL_LOG_TRACE("exit");
-  return ret;
+  ExchangePolicyManager(nullptr);
+  return !atomic_policy_manager_;
 }
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
 struct SDLAlowedNotification {
-  SDLAlowedNotification(const connection_handler::DeviceHandle& device_id,
+  SDLAlowedNotification(sync_primitives::RWLock& policy_manager_lock,
+                        const connection_handler::DeviceHandle& device_id,
                         PolicyManager* policy_manager,
                         StateController& state_controller)
-      : device_id_(device_id)
+      : policy_manager_lock_(policy_manager_lock)
+      , device_id_(device_id)
       , policy_manager_(policy_manager)
       , state_controller_(state_controller) {}
 
   void operator()(const ApplicationSharedPtr& app) {
-    DCHECK_OR_RETURN_VOID(policy_manager_);
+    POLICY_LIB_CHECK_VOID(policy_manager_);
     if (app->device() == device_id_) {
       std::string hmi_level;
       mobile_apis::HMILevel::eType default_mobile_hmi;
@@ -1255,6 +1320,7 @@ struct SDLAlowedNotification {
   }
 
  private:
+  sync_primitives::RWLock& policy_manager_lock_;
   connection_handler::DeviceHandle device_id_;
   PolicyManager* policy_manager_;
   StateController& state_controller_;
@@ -1264,7 +1330,8 @@ struct SDLAlowedNotification {
 void PolicyHandler::OnAllowSDLFunctionalityNotification(
     bool is_allowed, const std::string& device_mac) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   using namespace mobile_apis;
   const bool device_specific = !device_mac.empty();
   // Common devices consents change
@@ -1284,7 +1351,7 @@ void PolicyHandler::OnAllowSDLFunctionalityNotification(
         SDL_LOG_WARN("Device with id " << device_id << " wasn't found.");
         continue;
       }
-      policy_manager_->SetUserConsentForDevice(device_id, is_allowed);
+      policy_manager->SetUserConsentForDevice(device_id, is_allowed);
       connection_handler::DeviceHandle device_handle = 0;
       if (!connection_handler.GetDeviceID(device_id, &device_handle)) {
         SDL_LOG_WARN("Device handle with mac " << device_id
@@ -1309,8 +1376,9 @@ void PolicyHandler::OnAllowSDLFunctionalityNotification(
         std::for_each(
             applications.begin(),
             applications.end(),
-            SDLAlowedNotification(device_handle,
-                                  policy_manager_.get(),
+            SDLAlowedNotification(policy_manager_lock_,
+                                  device_handle,
+                                  policy_manager.get(),
                                   application_manager_.state_controller()));
       }
 #endif  // EXTERNAL_PROPRIETARY_MODE
@@ -1320,7 +1388,7 @@ void PolicyHandler::OnAllowSDLFunctionalityNotification(
   // Case, when specific device was changed
   connection_handler::DeviceHandle device_handle = 0u;
   if (device_specific) {
-    policy_manager_->SetUserConsentForDevice(device_mac, is_allowed);
+    policy_manager->SetUserConsentForDevice(device_mac, is_allowed);
     if (!connection_handler.GetDeviceID(device_mac, &device_handle)) {
       SDL_LOG_WARN("Device hadle with mac " << device_mac << " wasn't found.");
     }
@@ -1377,8 +1445,9 @@ void PolicyHandler::OnAllowSDLFunctionalityNotification(
 
 void PolicyHandler::OnIgnitionCycleOver() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->IncrementIgnitionCycles();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->IncrementIgnitionCycles();
 }
 
 void PolicyHandler::OnActivateApp(uint32_t connection_key,
@@ -1393,15 +1462,15 @@ void PolicyHandler::OnActivateApp(uint32_t connection_key,
 
   AppPermissions permissions(policy_app_id);
 
-  sync_primitives::AutoReadLock lock(policy_manager_lock_);
-  if (!policy_manager_) {
+  const auto policy_manager = LoadPolicyManager();
+  if (!policy_manager) {
     SDL_LOG_DEBUG("The shared library of policy is not loaded");
     if (!PolicyEnabled()) {
       permissions.isSDLAllowed = true;
     }
   } else {
-    permissions = policy_manager_->GetAppPermissionsChanges(app->mac_address(),
-                                                            policy_app_id);
+    permissions = policy_manager->GetAppPermissionsChanges(app->mac_address(),
+                                                           policy_app_id);
 #ifdef EXTERNAL_PROPRIETARY_MODE
     UsageStatistics& usage = app->usage_report();
 
@@ -1411,7 +1480,7 @@ void PolicyHandler::OnActivateApp(uint32_t connection_key,
         application_manager_.connection_handler().get_session_observer());
     permissions.deviceInfo = device_params;
 
-    DeviceConsent consent = policy_manager_->GetUserConsentForDevice(
+    DeviceConsent consent = policy_manager->GetUserConsentForDevice(
         permissions.deviceInfo.device_mac_address);
     permissions.isSDLAllowed = kDeviceAllowed == consent;
 
@@ -1440,7 +1509,7 @@ void PolicyHandler::OnActivateApp(uint32_t connection_key,
 #else   // EXTERNAL_PROPRIETARY_MODE
     permissions.isSDLAllowed = true;
 #endif  // EXTERNAL_PROPRIETARY_MODE
-    policy_manager_->RemovePendingPermissionChanges(policy_app_id);
+    policy_manager->RemovePendingPermissionChanges(policy_app_id);
   }
   // If application is revoked it should not be activated
   // In this case we need to activate application
@@ -1460,14 +1529,16 @@ void PolicyHandler::OnActivateApp(uint32_t connection_key,
 
 void PolicyHandler::KmsChanged(int kilometers) {
   SDL_LOG_DEBUG("PolicyHandler::KmsChanged " << kilometers << " kilometers");
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->KmsChanged(kilometers);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->KmsChanged(kilometers);
 }
 
 void PolicyHandler::PTExchangeAtUserRequest(uint32_t correlation_id) {
   SDL_LOG_TRACE("PT exchange at user request");
-  POLICY_LIB_CHECK_VOID();
-  std::string update_status = policy_manager_->ForcePTExchangeAtUserRequest();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  std::string update_status = policy_manager->ForcePTExchangeAtUserRequest();
   MessageHelper::SendUpdateSDLResponse(
       update_status, correlation_id, application_manager_);
 }
@@ -1534,7 +1605,8 @@ void PolicyHandler::OnPermissionsUpdated(const std::string& device_id,
                                          const std::string& policy_app_id,
                                          const Permissions& permissions) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
   ApplicationSharedPtr app =
       application_manager_.application(device_id, policy_app_id);
@@ -1545,7 +1617,7 @@ void PolicyHandler::OnPermissionsUpdated(const std::string& device_id,
   }
 
   const auto require_encryption =
-      policy_manager_->GetAppEncryptionRequired(policy_app_id);
+      policy_manager->GetAppEncryptionRequired(policy_app_id);
 
   MessageHelper::SendOnPermissionsChangeNotification(
       app->app_id(), permissions, application_manager_, require_encryption);
@@ -1599,7 +1671,8 @@ void PolicyHandler::OnSnapshotCreated(
 void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
                                       const PTUIterationType iteration_type) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 #ifdef PROPRIETARY_MODE
   if (PTUIterationType::RetryIteration == iteration_type) {
     uint32_t app_id_for_sending = 0;
@@ -1619,7 +1692,7 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
     MessageHelper::SendPolicyUpdate(
         policy_snapshot_full_path,
         TimeoutExchangeSec(),
-        policy_manager_->RetrySequenceDelaysSeconds(),
+        policy_manager->RetrySequenceDelaysSeconds(),
         application_manager_);
   }
 #else   // PROPRIETARY_MODE
@@ -1636,7 +1709,8 @@ void PolicyHandler::OnSnapshotCreated(const BinaryMessage& pt_string,
 std::string PolicyHandler::GetNextUpdateUrl(
     const PTUIterationType iteration_type, uint32_t& app_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(std::string());
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::string());
   app_id = ChoosePTUApplication(iteration_type);
 
   if (0 == app_id) {
@@ -1650,7 +1724,7 @@ std::string PolicyHandler::GetNextUpdateUrl(
   }
 
   EndpointUrls endpoint_urls;
-  policy_manager_->GetUpdateUrls("0x07", endpoint_urls);
+  policy_manager->GetUpdateUrls("0x07", endpoint_urls);
 
   if (endpoint_urls.empty()) {
     SDL_LOG_ERROR("Service URLs are empty!");
@@ -1668,7 +1742,7 @@ std::string PolicyHandler::GetNextUpdateUrl(
     return application_manager_.application(app_id);
   };
 
-  AppIdURL app_url = policy_manager_->GetNextUpdateUrl(endpoint_urls);
+  AppIdURL app_url = policy_manager->GetNextUpdateUrl(endpoint_urls);
   ApplicationSharedPtr app = get_ptu_app(app_url, app_id);
   if (!app) {
     SDL_LOG_ERROR("No available applications for PTU!");
@@ -1676,7 +1750,7 @@ std::string PolicyHandler::GetNextUpdateUrl(
   }
   EndpointData& data = endpoint_urls[app_url.first];
   while (!IsUrlAppIdValid(app->policy_app_id(), data)) {
-    app_url = policy_manager_->GetNextUpdateUrl(endpoint_urls);
+    app_url = policy_manager->GetNextUpdateUrl(endpoint_urls);
     app = get_ptu_app(app_url, app_id);
     if (!app) {
       SDL_LOG_ERROR("No available applications for PTU!");
@@ -1691,8 +1765,9 @@ std::string PolicyHandler::GetNextUpdateUrl(
 
 bool PolicyHandler::GetPriority(const std::string& policy_app_id,
                                 std::string* priority) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->GetPriority(policy_app_id, priority);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->GetPriority(policy_app_id, priority);
 }
 
 void PolicyHandler::CheckPermissions(
@@ -1701,7 +1776,8 @@ void PolicyHandler::CheckPermissions(
     const PTString& rpc,
     const RPCParams& rpc_params,
     CheckPermissionResult& result) {
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   const std::string hmi_level =
       application_manager::EnumToString(app->hmi_level(window_id));
   if (hmi_level.empty()) {
@@ -1715,61 +1791,69 @@ void PolicyHandler::CheckPermissions(
   SDL_LOG_INFO("Checking permissions for  " << app->policy_app_id() << " in "
                                             << hmi_level << " on device "
                                             << device_id << " rpc " << rpc);
-  policy_manager_->CheckPermissions(
+  policy_manager->CheckPermissions(
       device_id, app->policy_app_id(), hmi_level, rpc, rpc_params, result);
 }
 
 uint32_t PolicyHandler::GetNotificationsNumber(const std::string& priority,
                                                const bool is_subtle) const {
-  POLICY_LIB_CHECK_OR_RETURN(0);
-  return policy_manager_->GetNotificationsNumber(priority, is_subtle);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, 0);
+  return policy_manager->GetNotificationsNumber(priority, is_subtle);
 }
 
 DeviceConsent PolicyHandler::GetUserConsentForDevice(
     const std::string& device_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(kDeviceDisallowed);
-  return policy_manager_->GetUserConsentForDevice(device_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, kDeviceDisallowed);
+  return policy_manager->GetUserConsentForDevice(device_id);
 }
 
 Json::Value PolicyHandler::GetPolicyTableData() const {
-  POLICY_LIB_CHECK_OR_RETURN(Json::Value());
-  return policy_manager_->GetPolicyTableData();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, Json::Value());
+  return policy_manager->GetPolicyTableData();
 }
 
 bool PolicyHandler::GetDefaultHmi(const std::string& device_id,
                                   const std::string& policy_app_id,
                                   std::string* default_hmi) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->GetDefaultHmi(device_id, policy_app_id, default_hmi);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->GetDefaultHmi(device_id, policy_app_id, default_hmi);
 }
 
 bool PolicyHandler::GetInitialAppData(const std::string& application_id,
                                       StringArray* nicknames,
                                       StringArray* app_hmi_types) {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->GetInitialAppData(
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->GetInitialAppData(
       application_id, nicknames, app_hmi_types);
 }
 
 void PolicyHandler::GetUpdateUrls(const std::string& service_type,
                                   EndpointUrls& out_end_points) const {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->GetUpdateUrls(service_type, out_end_points);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->GetUpdateUrls(service_type, out_end_points);
 }
 
 void PolicyHandler::GetUpdateUrls(const uint32_t service_type,
                                   EndpointUrls& out_end_points) const {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->GetUpdateUrls(service_type, out_end_points);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->GetUpdateUrls(service_type, out_end_points);
 }
 
 std::string PolicyHandler::GetLockScreenIconUrl(
     const std::string& policy_app_id) const {
   const std::string default_url;
-  POLICY_LIB_CHECK_OR_RETURN(default_url);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, default_url);
 
   EndpointUrls endpoints;
-  policy_manager_->GetUpdateUrls("lock_screen_icon_url", endpoints);
+  policy_manager->GetUpdateUrls("lock_screen_icon_url", endpoints);
 
   auto it_specific =
       std::find_if(endpoints.begin(),
@@ -1798,14 +1882,16 @@ std::string PolicyHandler::GetLockScreenIconUrl(
 }
 
 std::string PolicyHandler::GetIconUrl(const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(std::string(""));
-  return policy_manager_->GetIconUrl(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::string());
+  return policy_manager->GetIconUrl(policy_app_id);
 }
 
 uint32_t PolicyHandler::NextRetryTimeout() {
-  POLICY_LIB_CHECK_OR_RETURN(0);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, 0);
   SDL_LOG_AUTO_TRACE();
-  return policy_manager_->NextRetryTimeout();
+  return policy_manager->NextRetryTimeout();
 }
 
 uint32_t PolicyHandler::TimeoutExchangeSec() const {
@@ -1813,37 +1899,42 @@ uint32_t PolicyHandler::TimeoutExchangeSec() const {
 }
 
 uint32_t PolicyHandler::TimeoutExchangeMSec() const {
-  POLICY_LIB_CHECK_OR_RETURN(0);
-  return policy_manager_->TimeoutExchangeMSec();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, 0);
+  return policy_manager->TimeoutExchangeMSec();
 }
 
 void PolicyHandler::OnExceededTimeout() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
   std::for_each(listeners_.begin(),
                 listeners_.end(),
                 std::mem_fn(&PolicyHandlerObserver::OnPTUTimeoutExceeded));
 
-  policy_manager_->OnExceededTimeout();
+  policy_manager->OnExceededTimeout();
 }
 
 const boost::optional<bool> PolicyHandler::LockScreenDismissalEnabledState()
     const {
-  POLICY_LIB_CHECK_OR_RETURN(boost::optional<bool>());
-  return policy_manager_->LockScreenDismissalEnabledState();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, boost::optional<bool>());
+  return policy_manager->LockScreenDismissalEnabledState();
 }
 
 const boost::optional<std::string>
 PolicyHandler::LockScreenDismissalWarningMessage(
     const std::string& language) const {
-  POLICY_LIB_CHECK_OR_RETURN(boost::optional<std::string>());
-  return policy_manager_->LockScreenDismissalWarningMessage(language);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, boost::optional<std::string>());
+  return policy_manager->LockScreenDismissalWarningMessage(language);
 }
 
 void PolicyHandler::PTUpdatedAt(Counters counter, int value) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->PTUpdatedAt(counter, value);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->PTUpdatedAt(counter, value);
 }
 
 void PolicyHandler::add_listener(PolicyHandlerObserver* listener) {
@@ -1868,7 +1959,7 @@ PolicyHandler::GetStatisticManager() const {
 }
 
 void PolicyHandler::AddStatisticsInfo(int type) {
-  POLICY_LIB_CHECK_VOID();
+  POLICY_LIB_CHECK_VOID(atomic_policy_manager_);
   switch (static_cast<hmi_apis::Common_StatisticsType::eType>(type)) {
     case hmi_apis::Common_StatisticsType::iAPP_BUFFER_FULL: {
       usage_statistics::GlobalCounter count_of_iap_buffer_full(
@@ -1881,7 +1972,7 @@ void PolicyHandler::AddStatisticsInfo(int type) {
 }
 
 void PolicyHandler::OnSystemError(int code) {
-  POLICY_LIB_CHECK_VOID();
+  POLICY_LIB_CHECK_VOID(atomic_policy_manager_);
   switch (static_cast<hmi_apis::Common_SystemError::eType>(code)) {
     case hmi_apis::Common_SystemError::SYNC_REBOOTED: {
       usage_statistics::GlobalCounter count_of_sync_reboots(
@@ -1960,7 +2051,8 @@ void PolicyHandler::OnEmptyCertificateArrived() const {
 
 void PolicyHandler::OnCertificateDecrypted(bool is_succeeded) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
   const std::string file_name =
       file_system::GetAbsolutePath(get_settings().app_storage_folder()) + +"/" +
@@ -1986,7 +2078,7 @@ void PolicyHandler::OnCertificateDecrypted(bool is_succeeded) {
   SDL_LOG_DEBUG("Loaded decrypted certificate data: \"" << certificate_data
                                                         << '"');
 
-  policy_manager_->SetDecryptedCertificate(certificate_data);
+  policy_manager->SetDecryptedCertificate(certificate_data);
 
   sync_primitives::AutoLock lock(listeners_lock_);
   std::for_each(
@@ -2049,9 +2141,10 @@ bool PolicyHandler::CanUpdate() {
 
 void PolicyHandler::RemoveDevice(const std::string& device_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
-  policy_manager_->MarkUnpairedDevice(device_id);
+  policy_manager->MarkUnpairedDevice(device_id);
 #ifdef EXTERNAL_PROPRIETARY_MODE
   connection_handler::DeviceHandle device_uid;
   if (application_manager_.connection_handler().GetDeviceID(device_id,
@@ -2067,25 +2160,29 @@ void PolicyHandler::RemoveDevice(const std::string& device_id) {
 
 bool PolicyHandler::IsApplicationRevoked(const std::string& app_id) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
 
-  return policy_manager_->IsApplicationRevoked(app_id);
+  return policy_manager->IsApplicationRevoked(app_id);
 }
 
 void PolicyHandler::OnUpdateRequestSentToMobile() {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnUpdateStarted();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->OnUpdateStarted();
 }
 
 bool PolicyHandler::CheckKeepContext(const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->CanAppKeepContext(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->CanAppKeepContext(policy_app_id);
 }
 
 bool PolicyHandler::CheckStealFocus(const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->CanAppStealFocus(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->CanAppStealFocus(policy_app_id);
 }
 
 bool PolicyHandler::CheckSystemAction(
@@ -2108,8 +2205,9 @@ bool PolicyHandler::CheckSystemAction(
 }
 
 std::vector<std::string> PolicyHandler::GetApplicationPolicyIDs() const {
-  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
-  const auto all_policy_ids = policy_manager_->GetApplicationPolicyIDs();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::vector<std::string>());
+  const auto all_policy_ids = policy_manager->GetApplicationPolicyIDs();
   std::vector<std::string> policy_app_ids;
 
   std::copy_if(
@@ -2126,26 +2224,30 @@ std::vector<std::string> PolicyHandler::GetApplicationPolicyIDs() const {
 
 void PolicyHandler::GetEnabledCloudApps(
     std::vector<std::string>& enabled_apps) const {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->GetEnabledCloudApps(enabled_apps);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->GetEnabledCloudApps(enabled_apps);
 }
 
 bool PolicyHandler::GetAppProperties(const std::string& policy_app_id,
                                      AppProperties& out_app_properties) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->GetAppProperties(policy_app_id, out_app_properties);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->GetAppProperties(policy_app_id, out_app_properties);
 }
 
 std::vector<std::string> PolicyHandler::GetEnabledLocalApps() const {
-  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
-  return policy_manager_->GetEnabledLocalApps();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::vector<std::string>());
+  return policy_manager->GetEnabledLocalApps();
 }
 
 const bool PolicyHandler::CheckCloudAppEnabled(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
   AppProperties out_app_properties;
-  policy_manager_->GetAppProperties(policy_app_id, out_app_properties);
+  policy_manager->GetAppProperties(policy_app_id, out_app_properties);
   return out_app_properties.enabled;
 }
 
@@ -2153,14 +2255,15 @@ PolicyHandler::AppPropertiesState PolicyHandler::GetAppPropertiesStatus(
     const smart_objects::SmartObject& properties,
     const std::string& app_id) const {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(AppPropertiesState::NO_CHANGES);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, AppPropertiesState::NO_CHANGES);
 
   AppProperties app_properties;
-  policy_manager_->GetAppProperties(app_id, app_properties);
+  policy_manager->GetAppProperties(app_id, app_properties);
 
   policy::StringArray nicknames;
   policy::StringArray app_hmi_types;
-  policy_manager_->GetInitialAppData(app_id, &nicknames, &app_hmi_types);
+  policy_manager->GetInitialAppData(app_id, &nicknames, &app_hmi_types);
 
   if (properties.keyExists(strings::enabled) &&
       app_properties.enabled != properties[strings::enabled].asBool()) {
@@ -2240,34 +2343,36 @@ PolicyHandler::AppPropertiesState PolicyHandler::GetAppPropertiesStatus(
 }
 
 bool PolicyHandler::IsNewApplication(const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->IsNewApplication(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->IsNewApplication(policy_app_id);
 }
 
 void PolicyHandler::OnSetAppProperties(
     const smart_objects::SmartObject& properties) {
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
 
   const auto policy_app_id(properties[strings::policy_app_id].asString());
-  policy_manager_->InitCloudApp(policy_app_id);
+  policy_manager->InitCloudApp(policy_app_id);
 
   bool auth_token_update = false;
   if (properties.keyExists(strings::enabled)) {
     const bool enabled = properties[strings::enabled].asBool();
-    policy_manager_->SetCloudAppEnabled(policy_app_id, enabled);
+    policy_manager->SetCloudAppEnabled(policy_app_id, enabled);
   }
   if (properties.keyExists(strings::auth_token)) {
     const std::string auth_token = properties[strings::auth_token].asString();
-    policy_manager_->SetAppAuthToken(policy_app_id, auth_token);
+    policy_manager->SetAppAuthToken(policy_app_id, auth_token);
     auth_token_update = true;
   }
   if (properties.keyExists(strings::transport_type)) {
-    policy_manager_->SetAppCloudTransportType(
+    policy_manager->SetAppCloudTransportType(
         policy_app_id, properties[strings::transport_type].asString());
   }
   if (properties.keyExists(strings::endpoint)) {
-    policy_manager_->SetAppEndpoint(policy_app_id,
-                                    properties[strings::endpoint].asString());
+    policy_manager->SetAppEndpoint(policy_app_id,
+                                   properties[strings::endpoint].asString());
   }
   if (properties.keyExists(strings::nicknames)) {
     StringArray nicknames;
@@ -2276,7 +2381,7 @@ void PolicyHandler::OnSetAppProperties(
     for (size_t i = 0; i < nicknames_array.length(); ++i) {
       nicknames.push_back(nicknames_array[i].asString());
     }
-    policy_manager_->SetAppNicknames(policy_app_id, nicknames);
+    policy_manager->SetAppNicknames(policy_app_id, nicknames);
   }
   if (properties.keyExists(strings::hybrid_app_preference)) {
     std::string hybrid_app_preference;
@@ -2286,26 +2391,28 @@ void PolicyHandler::OnSetAppProperties(
     smart_objects::EnumConversionHelper<
         mobile_apis::HybridAppPreference::eType>::
         EnumToString(value, &hybrid_app_preference);
-    policy_manager_->SetHybridAppPreference(policy_app_id,
-                                            hybrid_app_preference);
+    policy_manager->SetHybridAppPreference(policy_app_id,
+                                           hybrid_app_preference);
   }
 
   if (auth_token_update) {
     AppProperties app_properties;
-    if (policy_manager_->GetAppProperties(policy_app_id, app_properties)) {
+    if (policy_manager->GetAppProperties(policy_app_id, app_properties)) {
       OnAuthTokenUpdated(policy_app_id, app_properties.auth_token);
     }
   }
 }
 
 void PolicyHandler::OnLocalAppAdded() {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnLocalAppAdded();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->OnLocalAppAdded();
 }
 
 void PolicyHandler::OnSetCloudAppProperties(
     const smart_objects::SmartObject& message) {
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   if (!message.keyExists(strings::msg_params)) {
     SDL_LOG_ERROR("Message does not contain mandatory section "
                   << strings::msg_params);
@@ -2326,21 +2433,21 @@ void PolicyHandler::OnSetCloudAppProperties(
   }
   std::string policy_app_id(properties[strings::app_id].asString());
 
-  policy_manager_->InitCloudApp(policy_app_id);
+  policy_manager->InitCloudApp(policy_app_id);
 
   bool auth_token_update = false;
   if (properties.keyExists(strings::auth_token)) {
     std::string auth_token = properties[strings::auth_token].asString();
-    policy_manager_->SetAppAuthToken(policy_app_id, auth_token);
+    policy_manager->SetAppAuthToken(policy_app_id, auth_token);
     auth_token_update = true;
   }
   if (properties.keyExists(strings::cloud_transport_type)) {
-    policy_manager_->SetAppCloudTransportType(
+    policy_manager->SetAppCloudTransportType(
         policy_app_id, properties[strings::cloud_transport_type].asString());
   }
   if (properties.keyExists(strings::endpoint)) {
-    policy_manager_->SetAppEndpoint(policy_app_id,
-                                    properties[strings::endpoint].asString());
+    policy_manager->SetAppEndpoint(policy_app_id,
+                                   properties[strings::endpoint].asString());
   }
   if (properties.keyExists(strings::nicknames)) {
     StringArray nicknames;
@@ -2349,7 +2456,7 @@ void PolicyHandler::OnSetCloudAppProperties(
     for (size_t i = 0; i < nicknames_array.length(); ++i) {
       nicknames.push_back(nicknames_array[i].asString());
     }
-    policy_manager_->SetAppNicknames(policy_app_id, nicknames);
+    policy_manager->SetAppNicknames(policy_app_id, nicknames);
   }
   if (properties.keyExists(strings::hybrid_app_preference)) {
     std::string hybrid_app_preference;
@@ -2359,12 +2466,12 @@ void PolicyHandler::OnSetCloudAppProperties(
     smart_objects::EnumConversionHelper<
         mobile_apis::HybridAppPreference::eType>::
         EnumToString(value, &hybrid_app_preference);
-    policy_manager_->SetHybridAppPreference(policy_app_id,
-                                            hybrid_app_preference);
+    policy_manager->SetHybridAppPreference(policy_app_id,
+                                           hybrid_app_preference);
   }
   if (properties.keyExists(strings::enabled)) {
     bool enabled = properties[strings::enabled].asBool();
-    policy_manager_->SetCloudAppEnabled(policy_app_id, enabled);
+    policy_manager->SetCloudAppEnabled(policy_app_id, enabled);
     if (!auth_token_update) {
       auth_token_update = enabled;
     }
@@ -2374,7 +2481,7 @@ void PolicyHandler::OnSetCloudAppProperties(
   if (auth_token_update) {
     AppProperties app_properties;
 
-    policy_manager_->GetAppProperties(policy_app_id, app_properties);
+    policy_manager->GetAppProperties(policy_app_id, app_properties);
     OnAuthTokenUpdated(policy_app_id, app_properties.auth_token);
   }
 }
@@ -2382,9 +2489,10 @@ void PolicyHandler::OnSetCloudAppProperties(
 void PolicyHandler::GetAppServiceParameters(
     const std::string& policy_app_id,
     policy_table::AppServiceParameters* app_service_parameters) const {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->GetAppServiceParameters(policy_app_id,
-                                           app_service_parameters);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->GetAppServiceParameters(policy_app_id,
+                                          app_service_parameters);
 }
 
 bool PolicyHandler::CheckAppServiceParameters(
@@ -2444,20 +2552,23 @@ bool PolicyHandler::CheckAppServiceParameters(
 bool PolicyHandler::UnknownRPCPassthroughAllowed(
     const std::string& policy_app_id) const {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->UnknownRPCPassthroughAllowed(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->UnknownRPCPassthroughAllowed(policy_app_id);
 }
 
 uint32_t PolicyHandler::HeartBeatTimeout(const std::string& app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(0);
-  return policy_manager_->HeartBeatTimeout(app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, 0);
+  return policy_manager->HeartBeatTimeout(app_id);
 }
 
 const std::string PolicyHandler::RemoteAppsUrl() const {
   const std::string default_url;
-  POLICY_LIB_CHECK_OR_RETURN(default_url);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, default_url);
   EndpointUrls endpoints;
-  policy_manager_->GetUpdateUrls("queryAppsUrl", endpoints);
+  policy_manager->GetUpdateUrls("queryAppsUrl", endpoints);
   if (endpoints.empty() || endpoints[0].url.empty()) {
     return default_url;
   }
@@ -2466,13 +2577,15 @@ const std::string PolicyHandler::RemoteAppsUrl() const {
 }
 
 void PolicyHandler::OnAppsSearchStarted() {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnAppsSearchStarted();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->OnAppsSearchStarted();
 }
 
 void PolicyHandler::OnAppsSearchCompleted(const bool trigger_ptu) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnAppsSearchCompleted(trigger_ptu);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->OnAppsSearchCompleted(trigger_ptu);
 }
 
 void PolicyHandler::OnAddedNewApplicationToAppList(
@@ -2487,27 +2600,32 @@ void PolicyHandler::OnAddedNewApplicationToAppList(
 
 void PolicyHandler::OnAppRegisteredOnMobile(const std::string& device_id,
                                             const std::string& application_id) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->OnAppRegisteredOnMobile(device_id, application_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->OnAppRegisteredOnMobile(device_id, application_id);
 }
 
 RequestType::State PolicyHandler::GetAppRequestTypeState(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(RequestType::State::UNAVAILABLE);
-  return policy_manager_->GetAppRequestTypesState(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, RequestType::State::UNAVAILABLE);
+  return policy_manager->GetAppRequestTypesState(policy_app_id);
 }
 
 RequestSubType::State PolicyHandler::GetAppRequestSubTypeState(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(RequestSubType::State::UNAVAILABLE);
-  return policy_manager_->GetAppRequestSubTypesState(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager,
+                             RequestSubType::State::UNAVAILABLE);
+  return policy_manager->GetAppRequestSubTypesState(policy_app_id);
 }
 
 bool PolicyHandler::IsRequestTypeAllowed(
     const transport_manager::DeviceHandle& device_id,
     const std::string& policy_app_id,
     mobile_apis::RequestType::eType type) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
   using namespace mobile_apis;
 
   const std::string stringified_type = RequestTypeToString(type);
@@ -2517,7 +2635,7 @@ bool PolicyHandler::IsRequestTypeAllowed(
   }
 
   const RequestType::State request_type_state =
-      policy_manager_->GetAppRequestTypesState(policy_app_id);
+      policy_manager->GetAppRequestTypesState(policy_app_id);
 
   switch (request_type_state) {
     case RequestType::State::EMPTY: {
@@ -2534,9 +2652,9 @@ bool PolicyHandler::IsRequestTypeAllowed(
       // If any of request types is available for current application - get them
       const auto request_types =
 #ifdef EXTERNAL_PROPRIETARY_MODE
-          policy_manager_->GetAppRequestTypes(device_id, policy_app_id);
+          policy_manager->GetAppRequestTypes(device_id, policy_app_id);
 #else
-          policy_manager_->GetAppRequestTypes(policy_app_id);
+          policy_manager->GetAppRequestTypes(policy_app_id);
 #endif
       return helpers::in_range(request_types, stringified_type);
     }
@@ -2548,7 +2666,8 @@ bool PolicyHandler::IsRequestTypeAllowed(
 bool PolicyHandler::IsRequestSubTypeAllowed(
     const std::string& policy_app_id,
     const std::string& request_subtype) const {
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
   using namespace mobile_apis;
 
   if (request_subtype.empty()) {
@@ -2557,7 +2676,7 @@ bool PolicyHandler::IsRequestSubTypeAllowed(
   }
 
   const RequestSubType::State request_subtype_state =
-      policy_manager_->GetAppRequestSubTypesState(policy_app_id);
+      policy_manager->GetAppRequestSubTypesState(policy_app_id);
   switch (request_subtype_state) {
     case RequestSubType::State::EMPTY: {
       // If empty array of request subtypes is assigned to app - any is allowed
@@ -2573,7 +2692,7 @@ bool PolicyHandler::IsRequestSubTypeAllowed(
       // If any of request subtypes is available for current application
       // get them all
       const auto request_subtypes =
-          policy_manager_->GetAppRequestSubTypes(policy_app_id);
+          policy_manager->GetAppRequestSubTypes(policy_app_id);
       return helpers::in_range(request_subtypes, request_subtype);
     }
     default:
@@ -2584,62 +2703,73 @@ bool PolicyHandler::IsRequestSubTypeAllowed(
 const std::vector<std::string> PolicyHandler::GetAppRequestTypes(
     const transport_manager::DeviceHandle& device_handle,
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::vector<std::string>());
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  return policy_manager_->GetAppRequestTypes(device_handle, policy_app_id);
+  return policy_manager->GetAppRequestTypes(device_handle, policy_app_id);
 #else
-  return policy_manager_->GetAppRequestTypes(policy_app_id);
+  return policy_manager->GetAppRequestTypes(policy_app_id);
 #endif
 }
 
 const std::vector<std::string> PolicyHandler::GetAppRequestSubTypes(
     const std::string& policy_app_id) const {
-  POLICY_LIB_CHECK_OR_RETURN(std::vector<std::string>());
-  return policy_manager_->GetAppRequestSubTypes(policy_app_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::vector<std::string>());
+  return policy_manager->GetAppRequestSubTypes(policy_app_id);
 }
 
 const std::vector<policy_table::VehicleDataItem>
 policy::PolicyHandler::GetVehicleDataItems() const {
-  POLICY_LIB_CHECK_OR_RETURN(std::vector<policy_table::VehicleDataItem>());
-  return policy_manager_->GetVehicleDataItems();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager,
+                             std::vector<policy_table::VehicleDataItem>());
+  return policy_manager->GetVehicleDataItems();
 }
 
 std::vector<rpc::policy_table_interface_base::VehicleDataItem>
 policy::PolicyHandler::GetRemovedVehicleDataItems() const {
-  POLICY_LIB_CHECK_OR_RETURN(std::vector<policy_table::VehicleDataItem>());
-  return policy_manager_->GetRemovedVehicleDataItems();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager,
+                             std::vector<policy_table::VehicleDataItem>());
+  return policy_manager->GetRemovedVehicleDataItems();
 }
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
 const MetaInfo PolicyHandler::GetMetaInfo() const {
-  POLICY_LIB_CHECK_OR_RETURN(MetaInfo());
-  return policy_manager_->GetMetaInfo();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, MetaInfo());
+  return policy_manager->GetMetaInfo();
 }
 #endif  // EXTERNAL_PROPRIETARY_MODE
 
 void PolicyHandler::Increment(usage_statistics::GlobalCounterId type) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->Increment(type);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->Increment(type);
 }
 
 void PolicyHandler::Increment(const std::string& app_id,
                               usage_statistics::AppCounterId type) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->Increment(app_id, type);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->Increment(app_id, type);
 }
 
 void PolicyHandler::Set(const std::string& app_id,
                         usage_statistics::AppInfoId type,
                         const std::string& value) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->Set(app_id, type, value);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->Set(app_id, type, value);
 }
 
 void PolicyHandler::Add(const std::string& app_id,
                         usage_statistics::AppStopwatchId type,
                         int32_t timespan_seconds) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->Add(app_id, type, timespan_seconds);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->Add(app_id, type, timespan_seconds);
 }
 
 bool PolicyHandler::IsUrlAppIdValid(const std::string app_id,
@@ -2675,7 +2805,7 @@ std::vector<std::string> PolicyHandler::GetDevicesIds(
 void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
                                    mobile_apis::HMILevel::eType level) {
   SDL_LOG_AUTO_TRACE();
-  DCHECK_OR_RETURN_VOID(app);
+  POLICY_LIB_CHECK_VOID(app);
   if (app->hmi_level(mobile_apis::PredefinedWindows::DEFAULT_WINDOW) ==
       mobile_apis::HMILevel::HMI_NONE) {
     // If default is FULL, send request to HMI. Notification to mobile will be
@@ -2698,14 +2828,16 @@ void PolicyHandler::UpdateHMILevel(ApplicationSharedPtr app,
 
 bool PolicyHandler::CheckModule(const PTString& app_id,
                                 const PTString& module) {
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->CheckModule(app_id, module);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->CheckModule(app_id, module);
 }
 
 void PolicyHandler::OnRemoteAppPermissionsChanged(
     const std::string& device_id, const std::string& application_id) {
-  POLICY_LIB_CHECK_VOID();
-  policy_manager_->SendAppPermissionsChanged(device_id, application_id);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->SendAppPermissionsChanged(device_id, application_id);
 }
 
 void PolicyHandler::OnUpdateHMIStatus(const std::string& device_id,
@@ -2739,8 +2871,9 @@ void PolicyHandler::OnUpdateHMIStatus(const std::string& device_id,
 bool PolicyHandler::GetModuleTypes(const std::string& policy_app_id,
                                    std::vector<std::string>* modules) const {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
-  return policy_manager_->GetModuleTypes(policy_app_id, modules);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
+  return policy_manager->GetModuleTypes(policy_app_id, modules);
 }
 
 void PolicyHandler::SetDefaultHmiTypes(
@@ -2748,7 +2881,8 @@ void PolicyHandler::SetDefaultHmiTypes(
     const std::string& application_id,
     const smart_objects::SmartObject* app_types) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_VOID();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
   std::vector<int> hmi_types;
   if (app_types && app_types->asArray()) {
     smart_objects::SmartArray* hmi_list = app_types->asArray();
@@ -2757,16 +2891,17 @@ void PolicyHandler::SetDefaultHmiTypes(
                    std::back_inserter(hmi_types),
                    SmartObjectToInt());
   }
-  policy_manager_->SetDefaultHmiTypes(device_handle, application_id, hmi_types);
+  policy_manager->SetDefaultHmiTypes(device_handle, application_id, hmi_types);
 }
 
 bool PolicyHandler::CheckHMIType(const std::string& application_id,
                                  mobile_apis::AppHMIType::eType hmi,
                                  const smart_objects::SmartObject* app_types) {
   SDL_LOG_AUTO_TRACE();
-  POLICY_LIB_CHECK_OR_RETURN(false);
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
   std::vector<int> policy_hmi_types;
-  bool ret = policy_manager_->GetHMITypes(application_id, &policy_hmi_types);
+  bool ret = policy_manager->GetHMITypes(application_id, &policy_hmi_types);
 
   std::vector<int> additional_hmi_types;
   if (app_types && app_types->asArray()) {

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -71,12 +71,6 @@ void ResumptionDataProcessorImpl::Restore(
     ResumeCtrl::ResumptionCallBack callback) {
   SDL_LOG_AUTO_TRACE();
 
-  if (!HasDataToRestore(saved_app)) {
-    SDL_LOG_DEBUG("No data to restore, resumption is successful");
-    callback(mobile_apis::Result::SUCCESS, "Data resumption succesful");
-    return;
-  }
-
   AddFiles(application, saved_app);
   AddSubmenus(application, saved_app);
   AddCommands(application, saved_app);
@@ -85,97 +79,13 @@ void ResumptionDataProcessorImpl::Restore(
   AddSubscriptions(application, saved_app);
   AddWindows(application, saved_app);
 
-  resumption_status_lock_.AcquireForReading();
   const auto app_id = application->app_id();
-  bool is_requests_list_empty = true;
-  if (resumption_status_.find(app_id) != resumption_status_.end()) {
-    is_requests_list_empty =
-        resumption_status_[app_id].list_of_sent_requests.empty();
-  }
-  resumption_status_lock_.Release();
-
-  if (!is_requests_list_empty) {
+  if (!IsResumptionFinished(app_id)) {
     sync_primitives::AutoWriteLock lock(register_callbacks_lock_);
     register_callbacks_[app_id] = callback;
   } else {
-    SDL_LOG_DEBUG("No requests to HMI for " << app_id
-                                            << " , resumption is successful");
-    callback(mobile_apis::Result::SUCCESS, "Data resumption successful");
+    FinalizeResumption(callback, app_id);
   }
-}
-
-bool ResumptionDataProcessorImpl::HasDataToRestore(
-    const smart_objects::SmartObject& saved_app) const {
-  SDL_LOG_AUTO_TRACE();
-
-  auto has_data_to_restore = [&saved_app]() -> bool {
-    return !saved_app[strings::application_files].empty() ||
-           !saved_app[strings::application_submenus].empty() ||
-           !saved_app[strings::application_commands].empty() ||
-           !saved_app[strings::application_choice_sets].empty() ||
-           !saved_app[strings::windows_info].empty();
-  };
-
-  auto has_gp_to_restore = [&saved_app]() -> bool {
-    const smart_objects::SmartObject& global_properties =
-        saved_app[strings::application_global_properties];
-
-    return !global_properties[strings::help_prompt].empty() ||
-           !global_properties[strings::keyboard_properties].empty() ||
-           !global_properties[strings::menu_icon].empty() ||
-           !global_properties[strings::menu_title].empty() ||
-           !global_properties[strings::timeout_prompt].empty() ||
-           !global_properties[strings::vr_help].empty() ||
-           !global_properties[strings::vr_help_title].empty();
-  };
-
-  auto has_subscriptions_to_restore = [&saved_app]() -> bool {
-    const smart_objects::SmartObject& subscriptions =
-        saved_app[strings::application_subscriptions];
-
-    const bool has_ivi_subscriptions =
-        !subscriptions[strings::application_vehicle_info].empty();
-
-    const bool has_button_subscriptions =
-        !subscriptions[strings::application_buttons].empty() &&
-        !(subscriptions[strings::application_buttons].length() == 1 &&
-          static_cast<hmi_apis::Common_ButtonName::eType>(
-              subscriptions[strings::application_buttons][0].asInt()) ==
-              hmi_apis::Common_ButtonName::CUSTOM_BUTTON);
-
-    const bool has_waypoints_subscriptions =
-        subscriptions[strings::subscribed_for_way_points].asBool();
-
-    const bool has_appservice_subscriptions =
-        subscriptions.keyExists(app_mngr::hmi_interface::app_service) &&
-        !subscriptions[app_mngr::hmi_interface::app_service].empty();
-
-    const bool has_system_capability_subscriptions =
-        subscriptions.keyExists(strings::system_capability) &&
-        !subscriptions[strings::system_capability].empty();
-
-    return has_ivi_subscriptions || has_button_subscriptions ||
-           has_waypoints_subscriptions || has_appservice_subscriptions ||
-           has_system_capability_subscriptions;
-  };
-
-  if (has_data_to_restore()) {
-    SDL_LOG_DEBUG("Application has data to restore");
-    return true;
-  }
-
-  if (has_gp_to_restore()) {
-    SDL_LOG_DEBUG("Application has global properties to restore");
-    return true;
-  }
-
-  if (has_subscriptions_to_restore()) {
-    SDL_LOG_DEBUG("Application has subscriptions to restore");
-    return true;
-  }
-
-  SDL_LOG_DEBUG("Application does not have any data to restore");
-  return false;
 }
 
 utils::Optional<uint32_t>
@@ -260,7 +170,7 @@ void ResumptionDataProcessorImpl::ProcessResumptionStatus(
   }
 }
 
-bool ResumptionDataProcessorImpl::IsResumptionFinished(
+void ResumptionDataProcessorImpl::EraseProcessedRequest(
     const uint32_t app_id, const ResumptionRequest& found_request) {
   SDL_LOG_AUTO_TRACE();
 
@@ -277,8 +187,19 @@ bool ResumptionDataProcessorImpl::IsResumptionFinished(
                                 found_request.request_id.function_id;
                    });
   list_of_sent_requests.erase(request_iter);
+}
 
-  return list_of_sent_requests.empty();
+bool ResumptionDataProcessorImpl::IsResumptionFinished(
+    const uint32_t app_id) const {
+  SDL_LOG_AUTO_TRACE();
+
+  sync_primitives::AutoReadLock lock(resumption_status_lock_);
+  bool is_requests_list_empty = true;
+  const auto app_status = resumption_status_.find(app_id);
+  if (app_status != resumption_status_.end()) {
+    is_requests_list_empty = app_status->second.list_of_sent_requests.empty();
+  }
+  return is_requests_list_empty;
 }
 
 utils::Optional<ResumeCtrl::ResumptionCallBack>
@@ -299,7 +220,7 @@ bool ResumptionDataProcessorImpl::IsResumptionSuccessful(
   sync_primitives::AutoReadLock lock(resumption_status_lock_);
   auto it = resumption_status_.find(app_id);
   if (resumption_status_.end() == it) {
-    return false;
+    return true;
   }
 
   const ApplicationResumptionStatus& status = it->second;
@@ -309,17 +230,27 @@ bool ResumptionDataProcessorImpl::IsResumptionSuccessful(
 }
 
 void ResumptionDataProcessorImpl::EraseAppResumptionData(
-    const uint32_t app_id,
-    const hmi_apis::FunctionID::eType function_id,
-    const int32_t corr_id) {
+    const uint32_t app_id) {
   SDL_LOG_AUTO_TRACE();
 
+  std::vector<ResumptionRequest> all_requests;
+
   resumption_status_lock_.AcquireForWriting();
+  all_requests.insert(all_requests.end(),
+                      resumption_status_[app_id].successful_requests.begin(),
+                      resumption_status_[app_id].successful_requests.end());
+  all_requests.insert(all_requests.end(),
+                      resumption_status_[app_id].error_requests.begin(),
+                      resumption_status_[app_id].error_requests.end());
+
   resumption_status_.erase(app_id);
   resumption_status_lock_.Release();
 
   request_app_ids_lock_.AcquireForWriting();
-  request_app_ids_.erase({function_id, corr_id});
+  for (auto request : all_requests) {
+    request_app_ids_.erase(
+        {request.request_id.function_id, request.request_id.correlation_id});
+  }
   request_app_ids_lock_.Release();
 
   register_callbacks_lock_.AcquireForWriting();
@@ -354,8 +285,9 @@ void ResumptionDataProcessorImpl::ProcessResponseFromHMI(
   auto request = *found_request;
 
   ProcessResumptionStatus(app_id, response, request);
+  EraseProcessedRequest(app_id, request);
 
-  if (!IsResumptionFinished(app_id, request)) {
+  if (!IsResumptionFinished(app_id)) {
     SDL_LOG_DEBUG("Resumption app "
                   << app_id << " not finished. Some requests are still waited");
     return;
@@ -367,7 +299,11 @@ void ResumptionDataProcessorImpl::ProcessResponseFromHMI(
     return;
   }
   auto callback = *found_callback;
+  FinalizeResumption(callback, app_id);
+}
 
+void ResumptionDataProcessorImpl::FinalizeResumption(
+    const ResumeCtrl::ResumptionCallBack& callback, const uint32_t app_id) {
   if (IsResumptionSuccessful(app_id)) {
     SDL_LOG_DEBUG("Resumption for app " << app_id << " successful");
     callback(mobile_apis::Result::SUCCESS, "Data resumption successful");
@@ -378,8 +314,7 @@ void ResumptionDataProcessorImpl::ProcessResponseFromHMI(
     RevertRestoredData(application_manager_.application(app_id));
     application_manager_.state_controller().DropPostponedWindows(app_id);
   }
-
-  EraseAppResumptionData(app_id, function_id, corr_id);
+  EraseAppResumptionData(app_id);
 }
 
 void ResumptionDataProcessorImpl::HandleOnTimeOut(

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -837,7 +837,6 @@ TEST_F(ApplicationImplTest, StartStreaming_StreamingApproved) {
 TEST_F(ApplicationImplTest, SuspendNaviStreaming) {
   protocol_handler::ServiceType type =
       protocol_handler::ServiceType::kMobileNav;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   app_impl->SuspendStreaming(type);
@@ -845,7 +844,6 @@ TEST_F(ApplicationImplTest, SuspendNaviStreaming) {
 
 TEST_F(ApplicationImplTest, SuspendAudioStreaming) {
   protocol_handler::ServiceType type = protocol_handler::ServiceType::kAudio;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   app_impl->SuspendStreaming(type);
@@ -854,12 +852,16 @@ TEST_F(ApplicationImplTest, SuspendAudioStreaming) {
 // TODO {AKozoriz} : Fix tests with streaming (APPLINK-19289)
 TEST_F(ApplicationImplTest, DISABLED_Suspend_WakeUpAudioStreaming) {
   protocol_handler::ServiceType type = protocol_handler::ServiceType::kAudio;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kSuspended));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, false, _));
   app_impl->SuspendStreaming(type);
 
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, true));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStarted));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, true, _));
   app_impl->WakeUpStreaming(type);
@@ -868,12 +870,16 @@ TEST_F(ApplicationImplTest, DISABLED_Suspend_WakeUpAudioStreaming) {
 TEST_F(ApplicationImplTest, DISABLED_Suspend_WakeUpNaviStreaming) {
   protocol_handler::ServiceType type =
       protocol_handler::ServiceType::kMobileNav;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kSuspended));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, false, _));
   app_impl->SuspendStreaming(type);
 
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, true));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStarted));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
               SendOnDataStreaming(type, true, _));
   app_impl->WakeUpStreaming(type);
@@ -885,7 +891,9 @@ TEST_F(ApplicationImplTest, StopStreaming_StreamingApproved) {
       protocol_handler::ServiceType::kMobileNav;
   app_impl->set_video_streaming_approved(true);
 
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStopped));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),
@@ -897,7 +905,9 @@ TEST_F(ApplicationImplTest, StopStreaming_StreamingApproved) {
   // Stop audio streaming
   app_impl->set_audio_streaming_approved(true);
   type = protocol_handler::ServiceType::kAudio;
-  EXPECT_CALL(mock_application_manager_, OnAppStreaming(app_id, type, false));
+  EXPECT_CALL(
+      mock_application_manager_,
+      OnAppStreaming(app_id, type, Application::StreamingState::kStopped));
   EXPECT_CALL(mock_application_manager_,
               ProcessOnDataStreamingNotification(type, app_id, false));
   EXPECT_CALL(*MockMessageHelper::message_helper_mock(),

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -88,9 +88,8 @@ class MockApplication : public ::application_manager::Application {
                void(protocol_handler::ServiceType service_type));
   MOCK_METHOD1(SuspendStreaming,
                void(protocol_handler::ServiceType service_type));
-  MOCK_METHOD2(WakeUpStreaming,
-               void(protocol_handler::ServiceType service_type,
-                    uint32_t timer_len));
+  MOCK_METHOD1(WakeUpStreaming,
+               void(protocol_handler::ServiceType service_type));
   MOCK_CONST_METHOD0(is_voice_communication_supported, bool());
   MOCK_METHOD1(set_voice_communication_supported,
                void(bool is_voice_communication_supported));

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -3058,16 +3058,12 @@ TEST_F(PolicyHandlerTest, GetAppPropertiesStatus_HybridAppNotChanged_SUCCESS) {
 }
 
 TEST_F(PolicyHandlerTest, GetAppPropertiesStatus_PolicyDisabled_FAIL) {
-  ChangePolicyManagerToMock();
-
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
   policy_handler_.LoadPolicyLibrary();
 
   smart_objects::SmartObject properties;
   properties[strings::app_id] = kPolicyAppId_;
 
-  EXPECT_CALL(*mock_policy_manager_, GetAppProperties(_, _)).Times(0);
-  EXPECT_CALL(*mock_policy_manager_, GetInitialAppData(_, _, _)).Times(0);
   const auto expected_app_properties_state =
       policy::PolicyHandlerInterface::AppPropertiesState::NO_CHANGES;
   EXPECT_EQ(expected_app_properties_state,
@@ -3099,16 +3095,11 @@ TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyEnabled_SUCCESS) {
 }
 
 TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
-  ChangePolicyManagerToMock();
-
-  const uint32_t expected_apps_count = 0u;
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
-  EXPECT_CALL(*mock_policy_manager_,
-              UpdatePTUReadyAppsCount(expected_apps_count))
-      .Times(0);
 
   policy_handler_.LoadPolicyLibrary();
   policy_handler_.PushAppIdToPTUQueue(kAppId1_);
+  const uint32_t expected_apps_count = 0u;
   EXPECT_EQ(expected_apps_count,
             policy_handler_.applications_ptu_queue_.size());
 }
@@ -3116,16 +3107,6 @@ TEST_F(PolicyHandlerTest, PushAppIdToPTUQueue_PolicyDisabled_FAIL) {
 TEST_F(PolicyHandlerTest, StopRetrySequence_PolicyEnabled_SUCCESS) {
   ChangePolicyManagerToMock();
   EXPECT_CALL(*mock_policy_manager_, StopRetrySequence());
-  policy_handler_.StopRetrySequence();
-}
-
-TEST_F(PolicyHandlerTest, StopRetrySequence_PolicyDisabled_FAIL) {
-  ChangePolicyManagerToMock();
-
-  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
-  EXPECT_CALL(*mock_policy_manager_, StopRetrySequence()).Times(0);
-
-  policy_handler_.LoadPolicyLibrary();
   policy_handler_.StopRetrySequence();
 }
 
@@ -3139,10 +3120,7 @@ TEST_F(PolicyHandlerTest, GetPolicyTableData_PolicyEnabled_SUCCESS) {
 }
 
 TEST_F(PolicyHandlerTest, GetPolicyTableData_PolicyDisabled_FAIL) {
-  ChangePolicyManagerToMock();
-
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
-  EXPECT_CALL(*mock_policy_manager_, GetPolicyTableData()).Times(0);
 
   policy_handler_.LoadPolicyLibrary();
 
@@ -3170,10 +3148,7 @@ TEST_F(PolicyHandlerTest, GetRemovedVehicleDataItems_PolicyEnabled_SUCCESS) {
 TEST_F(PolicyHandlerTest, GetRemovedVehicleDataItems_PolicyDisabled_FAIL) {
   using rpc::policy_table_interface_base::VehicleDataItem;
 
-  ChangePolicyManagerToMock();
-
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
-  EXPECT_CALL(*mock_policy_manager_, GetRemovedVehicleDataItems()).Times(0);
 
   policy_handler_.LoadPolicyLibrary();
 
@@ -3211,16 +3186,6 @@ TEST_F(PolicyHandlerTest, OnLocalAppAdded_PolicyEnabled_SUCCESS) {
   policy_handler_.OnLocalAppAdded();
 }
 
-TEST_F(PolicyHandlerTest, OnLocalAppAdded_PolicyDisabled_FAIL) {
-  ChangePolicyManagerToMock();
-
-  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
-  EXPECT_CALL(*mock_policy_manager_, OnLocalAppAdded()).Times(0);
-
-  policy_handler_.LoadPolicyLibrary();
-  policy_handler_.OnLocalAppAdded();
-}
-
 TEST_F(PolicyHandlerTest, OnPermissionsUpdated_PolicyEnabled_SUCCESS) {
   ChangePolicyManagerToMock();
 
@@ -3240,14 +3205,10 @@ TEST_F(PolicyHandlerTest, OnPermissionsUpdated_PolicyEnabled_SUCCESS) {
 }
 
 TEST_F(PolicyHandlerTest, OnPermissionsUpdated_PolicyDisabled_FAIL) {
-  ChangePolicyManagerToMock();
-
   EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
   policy_handler_.LoadPolicyLibrary();
 
   EXPECT_CALL(app_manager_, application(kDeviceId_, kPolicyAppId_)).Times(0);
-  EXPECT_CALL(*mock_policy_manager_, GetAppEncryptionRequired(kPolicyAppId_))
-      .Times(0);
   EXPECT_CALL(*mock_app_, app_id()).Times(0);
 
   Permissions app_permissions;
@@ -3264,16 +3225,6 @@ TEST_F(PolicyHandlerTest, IsNewApplication_PolicyEnabled_SUCCESS) {
   EXPECT_CALL(*mock_policy_manager_, IsNewApplication(kPolicyAppId_))
       .WillOnce(Return(true));
   EXPECT_TRUE(policy_handler_.IsNewApplication(kPolicyAppId_));
-}
-
-TEST_F(PolicyHandlerTest, IsNewApplication_PolicyDisabled_FAIL) {
-  ChangePolicyManagerToMock();
-
-  EXPECT_CALL(policy_settings_, enable_policy()).WillOnce(Return(false));
-  policy_handler_.LoadPolicyLibrary();
-
-  EXPECT_CALL(*mock_policy_manager_, IsNewApplication(kPolicyAppId_)).Times(0);
-  EXPECT_FALSE(policy_handler_.IsNewApplication(kPolicyAppId_));
 }
 
 }  // namespace policy_handler_test

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -251,25 +251,6 @@ class ResumeCtrlTest : public ::testing::Test {
  * @brief  Group of tests which check starting resumption with different data
  */
 
-TEST_F(ResumeCtrlTest, StartResumption_AppWithGrammarId) {
-  smart_objects::SmartObject saved_app;
-  saved_app[application_manager::strings::hash_id] = kHash_;
-  saved_app[application_manager::strings::grammar_id] = kTestGrammarId_;
-
-  // Check RestoreApplicationData
-  GetInfoFromApp();
-  ON_CALL(mock_app_mngr_, GetDefaultHmiLevel(const_app_))
-      .WillByDefault(Return(kDefaultTestLevel_));
-  ON_CALL(*mock_storage_,
-          GetSavedApplication(kTestPolicyAppId_, kMacAddress_, _))
-      .WillByDefault(DoAll(SetArgReferee<2>(saved_app), Return(true)));
-
-  EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
-
-  const bool res = res_ctrl_->StartResumption(mock_app_, kHash_, callback_);
-  EXPECT_TRUE(res);
-}
-
 MATCHER_P4(CheckAppFile, is_persistent, is_download, file_name, file_type, "") {
   application_manager::AppFile app_file = arg;
   return app_file.is_persistent == is_persistent &&

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -813,11 +813,11 @@ class ApplicationManager {
    * @brief Callback calls when application starts/stops data streaming
    * @param app_id Streaming application id
    * @param service_type Streaming service type
-   * @param state Shows if streaming started or stopped
+   * @param new_state Defines new streaming state
    */
   virtual void OnAppStreaming(uint32_t app_id,
                               protocol_handler::ServiceType service_type,
-                              bool state) = 0;
+                              const Application::StreamingState new_state) = 0;
 
   /**
    * @brief CreateRegularState create regular HMI state for application

--- a/src/components/include/media_manager/media_manager.h
+++ b/src/components/include/media_manager/media_manager.h
@@ -70,14 +70,6 @@ class MediaManager {
    */
   virtual const MediaManagerSettings& settings() const = 0;
 
-  /**
-   * \brief Convert an amount of audio bytes to an estimated time in ms
-   * \param data_size number of bytes to be played
-   * \return milliseconds required to play <data_size> many bytes with
-   *          the current pcm stream capabilities
-   */
-  virtual uint32_t DataSizeToMilliseconds(uint64_t data_size) const = 0;
-
   virtual ~MediaManager() {}
 };
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -309,10 +309,11 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD1(OnAppUnauthorized, void(const uint32_t& app_id));
   MOCK_METHOD1(ActivateApplication,
                bool(application_manager::ApplicationSharedPtr app));
-  MOCK_METHOD3(OnAppStreaming,
-               void(uint32_t app_id,
-                    protocol_handler::ServiceType service_type,
-                    bool state));
+  MOCK_METHOD3(
+      OnAppStreaming,
+      void(uint32_t app_id,
+           protocol_handler::ServiceType service_type,
+           application_manager::Application::StreamingState new_state));
   MOCK_CONST_METHOD6(CreateRegularState,
                      application_manager::HmiStatePtr(
                          application_manager::ApplicationSharedPtr app,

--- a/src/components/include/test/media_manager/mock_media_manager.h
+++ b/src/components/include/test/media_manager/mock_media_manager.h
@@ -64,7 +64,6 @@ class MockMediaManager : public media_manager::MediaManager {
   MOCK_METHOD2(FramesProcessed,
                void(int32_t application_key, int32_t frame_number));
   MOCK_CONST_METHOD0(settings, const media_manager::MediaManagerSettings&());
-  MOCK_CONST_METHOD1(DataSizeToMilliseconds, uint32_t(uint64_t data_size));
 };
 
 }  // namespace media_manager_test

--- a/src/components/media_manager/include/media_manager/media_manager_impl.h
+++ b/src/components/media_manager/include/media_manager/media_manager_impl.h
@@ -33,7 +33,6 @@
 #ifndef SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 #define SRC_COMPONENTS_MEDIA_MANAGER_INCLUDE_MEDIA_MANAGER_MEDIA_MANAGER_IMPL_H_
 
-#include <chrono>
 #include <map>
 #include <string>
 #include "interfaces/MOBILE_API.h"
@@ -80,7 +79,6 @@ class MediaManagerImpl : public MediaManager,
                               protocol_handler::ServiceType service_type);
   virtual void StopStreaming(int32_t application_key,
                              protocol_handler::ServiceType service_type);
-
   virtual void SetProtocolHandler(
       protocol_handler::ProtocolHandler* protocol_handler);
   virtual void OnMessageReceived(
@@ -90,8 +88,6 @@ class MediaManagerImpl : public MediaManager,
   virtual void FramesProcessed(int32_t application_key, int32_t frame_number);
 
   virtual const MediaManagerSettings& settings() const OVERRIDE;
-
-  virtual uint32_t DataSizeToMilliseconds(uint64_t data_size) const OVERRIDE;
 
 #ifdef BUILD_TESTS
   void set_mock_a2dp_player(MediaAdapter* media_adapter);
@@ -117,12 +113,6 @@ class MediaManagerImpl : public MediaManager,
 
   std::map<protocol_handler::ServiceType, MediaAdapterImplPtr> streamer_;
   std::map<protocol_handler::ServiceType, MediaListenerPtr> streamer_listener_;
-
-  uint32_t bits_per_sample_;
-  uint32_t sampling_rate_;
-  uint64_t stream_data_size_;
-  std::chrono::time_point<std::chrono::system_clock>
-      socket_audio_stream_start_time_;
 
   application_manager::ApplicationManager& application_manager_;
 

--- a/src/components/media_manager/include/media_manager/streamer_adapter.h
+++ b/src/components/media_manager/include/media_manager/streamer_adapter.h
@@ -87,7 +87,7 @@ class StreamerAdapter : public MediaAdapterImpl {
   };
 
  private:
-  int32_t current_application_;
+  std::atomic_int current_application_;
   utils::MessageQueue<protocol_handler::RawMessagePtr> messages_;
 
   Streamer* streamer_;

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -35,8 +35,6 @@
 #include "application_manager/application_impl.h"
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
-#include "application_manager/smart_object_keys.h"
-#include "interfaces/MOBILE_API.h"
 #include "media_manager/audio/from_mic_recorder_listener.h"
 #include "media_manager/streamer_listener.h"
 #include "protocol_handler/protocol_handler.h"
@@ -66,9 +64,6 @@ MediaManagerImpl::MediaManagerImpl(
     , protocol_handler_(NULL)
     , a2dp_player_(NULL)
     , from_mic_recorder_(NULL)
-    , bits_per_sample_(16)
-    , sampling_rate_(16000)
-    , stream_data_size_(0ull)
     , application_manager_(application_manager) {
   Init();
 }
@@ -164,23 +159,6 @@ void MediaManagerImpl::Init() {
   if (streamer_[ServiceType::kAudio]) {
     streamer_[ServiceType::kAudio]->AddListener(
         streamer_listener_[ServiceType::kAudio]);
-  }
-
-  if (application_manager_.hmi_capabilities().pcm_stream_capabilities()) {
-    const auto pcm_caps =
-        application_manager_.hmi_capabilities().pcm_stream_capabilities();
-
-    if (pcm_caps->keyExists(application_manager::strings::bits_per_sample)) {
-      bits_per_sample_ =
-          pcm_caps->getElement(application_manager::strings::bits_per_sample)
-              .asUInt();
-    }
-
-    if (pcm_caps->keyExists(application_manager::strings::sampling_rate)) {
-      sampling_rate_ =
-          pcm_caps->getElement(application_manager::strings::sampling_rate)
-              .asUInt();
-    }
   }
 }
 
@@ -298,8 +276,6 @@ void MediaManagerImpl::StopStreaming(
     int32_t application_key, protocol_handler::ServiceType service_type) {
   SDL_LOG_AUTO_TRACE();
 
-  stream_data_size_ = 0ull;
-
   if (streamer_[service_type]) {
     streamer_[service_type]->StopActivity(application_key);
   }
@@ -337,25 +313,7 @@ void MediaManagerImpl::OnMessageReceived(
 
   ApplicationSharedPtr app = application_manager_.application(streaming_app_id);
   if (app) {
-    if (ServiceType::kAudio == service_type &&
-        "socket" == settings().audio_server_type()) {
-      if (stream_data_size_ == 0) {
-        socket_audio_stream_start_time_ = std::chrono::system_clock::now();
-      }
-
-      stream_data_size_ += message->data_size();
-      uint32_t ms_for_all_data = DataSizeToMilliseconds(stream_data_size_);
-      uint32_t ms_since_stream_start =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::system_clock::now() -
-              socket_audio_stream_start_time_)
-              .count();
-      uint32_t ms_stream_remaining = ms_for_all_data - ms_since_stream_start;
-
-      app->WakeUpStreaming(service_type, ms_stream_remaining);
-    } else {
-      app->WakeUpStreaming(service_type);
-    }
+    app->WakeUpStreaming(service_type);
     streamer_[service_type]->SendData(streaming_app_id, message);
   }
 }
@@ -378,8 +336,7 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
     auto video_stream = std::dynamic_pointer_cast<StreamerAdapter>(
         streamer_[protocol_handler::ServiceType::kMobileNav]);
 
-    if (audio_stream.use_count() != 0 &&
-        "pipe" == settings().audio_server_type()) {
+    if (audio_stream.use_count() != 0) {
       size_t audio_queue_size = audio_stream->GetMsgQueueSize();
       SDL_LOG_DEBUG("# Messages in audio queue = " << audio_queue_size);
       if (audio_queue_size > 0) {
@@ -387,8 +344,7 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
       }
     }
 
-    if (video_stream.use_count() != 0 &&
-        "pipe" == settings().video_server_type()) {
+    if (video_stream.use_count() != 0) {
       size_t video_queue_size = video_stream->GetMsgQueueSize();
       SDL_LOG_DEBUG("# Messages in video queue = " << video_queue_size);
       if (video_queue_size > 0) {
@@ -400,12 +356,6 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
 
 const MediaManagerSettings& MediaManagerImpl::settings() const {
   return settings_;
-}
-
-uint32_t MediaManagerImpl::DataSizeToMilliseconds(uint64_t data_size) const {
-  constexpr uint16_t latency_compensation = 500;
-  return 1000 * data_size / (sampling_rate_ * bits_per_sample_ / 8) +
-         latency_compensation;
 }
 
 }  //  namespace media_manager

--- a/src/components/media_manager/src/streamer_adapter.cc
+++ b/src/components/media_manager/src/streamer_adapter.cc
@@ -59,7 +59,6 @@ void StreamerAdapter::StartActivity(int32_t application_key) {
                                               << " has been already started");
     return;
   }
-  messages_.Reset();
 
   DCHECK(thread_);
   const size_t kStackSize = 16384;
@@ -87,6 +86,7 @@ void StreamerAdapter::StopActivity(int32_t application_key) {
 
   DCHECK(streamer_);
   streamer_->exitThreadMain();
+  messages_.Reset();
 
   for (std::set<MediaListenerPtr>::iterator it = media_listeners_.begin();
        media_listeners_.end() != it;

--- a/src/components/media_manager/test/media_manager_impl_test.cc
+++ b/src/components/media_manager/test/media_manager_impl_test.cc
@@ -35,7 +35,6 @@
 #include "application_manager/message.h"
 #include "application_manager/mock_application.h"
 #include "application_manager/mock_application_manager.h"
-#include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/resumption/resume_ctrl.h"
 #include "application_manager/state_controller.h"
 #include "gmock/gmock.h"
@@ -110,10 +109,6 @@ class MediaManagerImplTest : public ::testing::Test {
         .WillByDefault(ReturnRef(kDefaultValue));
     ON_CALL(mock_media_manager_settings_, audio_server_type())
         .WillByDefault(ReturnRef(kDefaultValue));
-    ON_CALL(mock_hmi_capabilities_, pcm_stream_capabilities())
-        .WillByDefault(Return(nullptr));
-    ON_CALL(app_mngr_, hmi_capabilities())
-        .WillByDefault(ReturnRef(mock_hmi_capabilities_));
     mock_app_ = std::make_shared<MockApp>();
     media_manager_impl_.reset(
         new MediaManagerImpl(app_mngr_, mock_media_manager_settings_));
@@ -181,7 +176,7 @@ class MediaManagerImplTest : public ::testing::Test {
         .WillOnce(Return(true));
     EXPECT_CALL(app_mngr_, application(kConnectionKey))
         .WillOnce(Return(mock_app_));
-    EXPECT_CALL(*mock_app_, WakeUpStreaming(service_type, 0ull));
+    EXPECT_CALL(*mock_app_, WakeUpStreaming(service_type));
     MockMediaAdapterImplPtr mock_media_streamer =
         std::make_shared<MockMediaAdapterImpl>();
     media_manager_impl_->set_mock_streamer(service_type, mock_media_streamer);
@@ -211,7 +206,6 @@ class MediaManagerImplTest : public ::testing::Test {
   const ::testing::NiceMock<MockMediaManagerSettings>
       mock_media_manager_settings_;
   std::shared_ptr<MediaManagerImpl> media_manager_impl_;
-  application_manager_test::MockHMICapabilities mock_hmi_capabilities_;
 };
 
 TEST_F(MediaManagerImplTest,

--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_connection.h
@@ -86,7 +86,7 @@ class UsbConnection : public Connection {
 
   std::list<protocol_handler::RawMessagePtr> out_messages_;
   protocol_handler::RawMessagePtr current_out_message_;
-  sync_primitives::Lock out_messages_mutex_;
+  sync_primitives::RecursiveLock out_messages_mutex_;
   size_t bytes_sent_;
   bool disconnecting_;
   bool waiting_in_transfer_cancel_;


### PR DESCRIPTION
Fixes #[7812](https://adc.luxoft.com/jira/browse/FORDTCN-7812)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

### Summary
In some situations we need to handle case, when first application has already subscribed to shared data, and second application starts it's resumption by HandleResumptionSubscriptionRequest method. Now check for already existed subscriptions is located in SDLRPCPlugin, so rarely there is a race condition, when this check is performed for second application too early right before first application has completed it's subscription process. Also note that now processes of request and response handling aren't synchronized inside of WaypointsPendingResumptionHandler, so all invoked methods of this class executed in random order.

That's why root cause of this race condition is a time gap between check for existed subscriptions in SDLRPCPlugin and further processing of pending subscriptions in HandleResumptionSubscriptionRequest method, and also absence of certain order of execution of methods from WaypointsPendingResumptionHandler class. So there is a need in replacing above-mentioned check from SDLRPCPlugin to HandleResumptionSubscriptionRequest method, and also adding corresponding lock, due to which this check will be locked and synchronized properly.

In addition, some refactoring was completed to make methods from WaypointsPendingResumptionHandler class clearer and easier to understand, and also to align with common design approach, used in other PendingResumptionHandler classes.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
