### PR TITLE
Add check for non-existent parent ID to AddSubMenuRequest

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
@@ -96,13 +96,22 @@ void AddSubMenuRequest::Run() {
     return;
   }
 
-  const std::string& menu_name =
-      received_msg_params[strings::menu_name].asString();
-
   const uint32_t parent_id =
       received_msg_params.keyExists(strings::parent_id)
           ? received_msg_params[strings::parent_id].asUInt()
           : 0;
+
+  if (0 != parent_id) {
+    smart_objects::SmartObject parent = app->FindSubMenu(parent_id);
+    if (smart_objects::SmartType_Null == parent.getType()) {
+      SDL_LOG_ERROR("Parent ID " << parent_id << " doesn't exist");
+      SendResponse(false, mobile_apis::Result::INVALID_ID);
+      return;
+    }
+  }
+
+  const std::string& menu_name =
+      received_msg_params[strings::menu_name].asString();
 
   if (app->IsSubMenuNameAlreadyExist(menu_name, parent_id)) {
     SDL_LOG_ERROR("Menu name " << menu_name << " is duplicated.");

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_sub_menu_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_sub_menu_request_test.cc
@@ -104,6 +104,31 @@ TEST_F(AddSubMenuRequestTest, Run_ImageVerificationFailed_EXPECT_INVALID_DATA) {
   request_ptr->Run();
 }
 
+TEST_F(AddSubMenuRequestTest, Run_NonExistentParentID_EXPECT_INVALID_ID) {
+  const uint32_t menu_id = 10;
+  const uint32_t parent_id = 4;
+  MessageSharedPtr msg = CreateMsgParams();
+  SmartObject& msg_params = (*msg)[am::strings::msg_params];
+
+  msg_params[am::strings::menu_id] = menu_id;
+  msg_params[am::strings::menu_name] = "test";
+  msg_params[am::strings::parent_id] = parent_id;
+
+  SmartObject sub_menu(smart_objects::SmartType_Null);
+  EXPECT_CALL(*mock_app, FindSubMenu(menu_id)).WillOnce(Return(sub_menu));
+
+  SmartObject parent(smart_objects::SmartType_Null);
+  EXPECT_CALL(*mock_app, FindSubMenu(parent_id)).WillOnce(Return(parent));
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  MobileResultCodeIs(mobile_apis::Result::INVALID_ID), _));
+  std::shared_ptr<AddSubMenuRequest> request_ptr =
+      CreateCommand<AddSubMenuRequest>(msg);
+
+  request_ptr->Run();
+}
+
 TEST_F(AddSubMenuRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
   const uint32_t menu_id = 10u;
   MessageSharedPtr msg = CreateMessage(smart_objects::SmartType_Map);


### PR DESCRIPTION
Fixes #[7948](https://adc.luxoft.com/jira/browse/FORDTCN-7948)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test script.
New unit test is added.

### Summary
Because SDL transfers AddSubMenu request with non-existent parentID parameter to HMI, there is a need in additional check for presence of this parentID in SubMenu map. That's why this check is added to AddSubMenuRequest::Run() method.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
