### PR TITLE
Fix/on system cap updated for widget after resumption

### DIFF
--- a/src/components/application_manager/include/application_manager/display_capabilities_builder.h
+++ b/src/components/application_manager/include/application_manager/display_capabilities_builder.h
@@ -79,15 +79,30 @@ class DisplayCapabilitiesBuilder {
 
   /**
    * @brief ResetDisplayCapabilities resets stored notification
-   */
-  void ResetDisplayCapabilities();
-
-  /**
-   * @brief StopWaitingForWindow stop waiting for window resumption by removing
-   * window_id from windows pending resumption
+   * and stops waiting for window_id resumption
    * @param window_id window id to be removed
    */
-  void StopWaitingForWindow(const WindowID window_id);
+  void ResetDisplayCapabilities(const WindowID window_id);
+
+  /**
+   * @brief StopWaitingForMainWindow stops waiting for main window resumption
+   * by removing DEFAULT_WINDOW window_id from windows pending resumption
+   */
+  void StopWaitingForMainWindow();
+
+  /**
+   * @brief StopWaitingForWidgets stops waiting for widgets resumption
+   * by setting the is_widget_windows_resumption_ flag to false
+   * Will be called with the resume callback invoked
+   */
+  void StopWaitingForWidgets();
+
+  /**
+   * @brief StopWaitingForWindows stops waiting for windows resumption by
+   * clearing the window_ids_to_resume_ set
+   * Will be called if data resumption fails
+   */
+  void StopWaitingForWindows();
 
   /**
    * @brief retreives stored notification data

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -457,8 +457,7 @@ void FinishSendingResponseToMobile(const smart_objects::SmartObject& msg_params,
 
   // Once HMI level is set we can safely forward system capabilities for the
   // main window and it won't be blocked by policies
-  application->display_capabilities_builder().StopWaitingForWindow(
-      mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
+  application->display_capabilities_builder().StopWaitingForMainWindow();
 
   if (notify_upd_manager) {
     (*notify_upd_manager)();

--- a/src/components/application_manager/src/display_capabilities_builder.cc
+++ b/src/components/application_manager/src/display_capabilities_builder.cc
@@ -154,7 +154,7 @@ bool DisplayCapabilitiesBuilder::IsWaitingForWindowCapabilities(
   return false;
 }
 
-void DisplayCapabilitiesBuilder::ResetDisplayCapabilities() {
+void DisplayCapabilitiesBuilder::StopWaitingForWindows() {
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(display_capabilities_lock_);
   for (auto& window_id : window_ids_to_resume_) {
@@ -162,6 +162,15 @@ void DisplayCapabilitiesBuilder::ResetDisplayCapabilities() {
       window_ids_to_resume_.erase(window_id);
     }
   }
+}
+
+void DisplayCapabilitiesBuilder::ResetDisplayCapabilities(
+    const WindowID window_id) {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(display_capabilities_lock_);
+
+  SDL_LOG_DEBUG("Window id " << window_id << " will be erased");
+  window_ids_to_resume_.erase(window_id);
 
   if (display_capabilities_) {
     auto* cur_window_caps_ptr =
@@ -180,14 +189,17 @@ void DisplayCapabilitiesBuilder::ResetDisplayCapabilities() {
   }
 }
 
-void DisplayCapabilitiesBuilder::StopWaitingForWindow(
-    const WindowID window_id) {
+void DisplayCapabilitiesBuilder::StopWaitingForMainWindow() {
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(display_capabilities_lock_);
-  SDL_LOG_DEBUG("Window id " << window_id << " will be erased");
-  window_ids_to_resume_.erase(window_id);
+  window_ids_to_resume_.erase(mobile_apis::PredefinedWindows::DEFAULT_WINDOW);
 
   InvokeResumeCallback();
+}
+
+void DisplayCapabilitiesBuilder::StopWaitingForWidgets() {
+  SDL_LOG_AUTO_TRACE();
+  is_widget_windows_resumption_ = false;
 }
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -662,6 +662,8 @@ void ResumeCtrlImpl::StartWaitingForDisplayCapabilitiesUpdate(
              const smart_objects::SmartObject& display_capabilities) -> void {
     SDL_LOG_AUTO_TRACE();
     ProcessSystemCapabilityUpdated(app, display_capabilities);
+    auto& builder = app.display_capabilities_builder();
+    builder.StopWaitingForWidgets();
   };
   auto& builder = application->display_capabilities_builder();
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -311,8 +311,11 @@ void ResumptionDataProcessorImpl::FinalizeResumption(
   } else {
     SDL_LOG_ERROR("Resumption for app " << app_id << " failed");
     callback(mobile_apis::Result::RESUME_FAILED, "Data resumption failed");
-    RevertRestoredData(application_manager_.application(app_id));
+    auto app = application_manager_.application(app_id);
+    RevertRestoredData(app);
     application_manager_.state_controller().DropPostponedWindows(app_id);
+    auto& builder = app->display_capabilities_builder();
+    builder.StopWaitingForWindows();
   }
   EraseAppResumptionData(app_id);
 }
@@ -1096,7 +1099,7 @@ void ResumptionDataProcessorImpl::CheckCreateWindowResponse(
     SDL_LOG_ERROR("UI_CreateWindow for correlation id: " << correlation_id
                                                          << " has failed");
     auto& builder = application->display_capabilities_builder();
-    builder.ResetDisplayCapabilities();
+    builder.ResetDisplayCapabilities(window_id);
     return;
   }
 


### PR DESCRIPTION
Fixes https://adc.luxoft.com/jira/browse/FORDTCN-7857

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF test scripts from https://github.com/LuxoftSDL/sdl_atf_test_scripts/pull/84

### Summary
After the widgets resumption, SDL doesn't resend the OnSCU notification with updates for the widget to the mobile app (If HMI sends this notification after the resumption is finished). 

This is happening because [here](https://github.com/LuxoftSDL/sdl_core/blob/release/7.0.0/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_system_capability_updated_notification.cc#L221)  we are checking the values of two flags: `is_resuming_` and `is_widget_windows_resumption_` and they both are `true` (during all ign cycle) if the application was resumed and it had widgets to resume. 

I think that purpose of these flags is not an obvious and better approach do not use them at all. But it may require significant changes, so for now I just changed the `is_widget_windows_resumption_` to false (`StopWaitingForWidgets` function), if widget resumption already finished and [SDL sent OnSCU notification after registration](https://github.com/LuxoftSDL/sdl_core/pull/143/files#diff-89664857793adc72d087a6958999865d16e2ee4c595fb4c23fa4e397bad4e93eL660), in order to allow processing of subsequent OnSCU notifications.

Also, the `window_ids_to_resume_` set was cleared after receiving the unsuccessful response for at least one UI.CreateWindow. But SDL may send another UI.CreateWindow after that and receive OnSCU notification from HMI, this sequence [still should be a part of resumption](https://github.com/LuxoftSDL/sdl_core/blob/fix/on_system_cap_updated_for_widget_after_resumption/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_bc_system_capability_updated_notification_from_hmi.cc#L93) (SDL shouldn't resend this notification to the mobile). 
So we shouldn't clear the window_ids_to_resume_ set till the resumption is finished, but we still need to reset the display capabilities after receiving the unsuccessful response for at least one UI.CreateWindow. This is why I modified the `ResetDisplayCapabilities` function - it deletes only one window and resets the capabilities, and added the new one `StopWaitingForWindows` - it clears the window_ids_to_resume_ set.

Also `StopWaitingForWindow` renamed to the `StopWaitingForMainWindow` because we use it only for Main window [here](https://github.com/LuxoftSDL/sdl_core/blob/fix/on_system_cap_updated_for_widget_after_resumption/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc#L460)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
