### PR TITLE
Add missed NACK reasons

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -870,19 +870,12 @@ class ApplicationManagerImpl
   void ForbidStreaming(uint32_t app_id,
                        protocol_handler::ServiceType service_type) OVERRIDE;
 
-  /**
-   * @brief Called when application completes streaming configuration
-   * @param app_id Streaming application id
-   * @param service_type Streaming service type
-   * @param result true if configuration is successful, false otherwise
-   * @param rejected_params list of rejected parameters' name. Valid
-   *                        only when result is false.
-   */
-  void OnStreamingConfigured(
-      uint32_t app_id,
-      protocol_handler::ServiceType service_type,
-      bool result,
-      std::vector<std::string>& rejected_params) OVERRIDE;
+  void OnStreamingSuccessfulConfiguration(
+      uint32_t app_id, protocol_handler::ServiceType service_type) OVERRIDE;
+
+  void OnStreamingConfigurationFailed(uint32_t app_id,
+                                      std::vector<std::string>& rejected_params,
+                                      const std::string& reason) OVERRIDE;
 
   void OnAppStreaming(uint32_t app_id,
                       protocol_handler::ServiceType service_type,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_set_video_config_request.cc
@@ -93,16 +93,15 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
       const hmi_apis::Common_Result::eType code =
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt());
-      bool result = false;
-      std::vector<std::string> rejected_params;
 
       if (code == hmi_apis::Common_Result::SUCCESS) {
         SDL_LOG_DEBUG("Received SetVideoConfig success response");
-        result = true;
+        application_manager_.OnStreamingSuccessfulConfiguration(
+            app->app_id(), protocol_handler::ServiceType::kMobileNav);
       } else {
         SDL_LOG_DEBUG("Received SetVideoConfig failure response (" << event.id()
                                                                    << ")");
-        result = false;
+        std::vector<std::string> rejected_params;
         if (message[strings::msg_params].keyExists(strings::rejected_params)) {
           const smart_objects::SmartArray* list =
               message[strings::msg_params][strings::rejected_params].asArray();
@@ -118,13 +117,12 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
             }
           }
         }
+
+        application_manager_.OnStreamingConfigurationFailed(
+            app->app_id(), rejected_params, std::string());
+
+        break;
       }
-      application_manager_.OnStreamingConfigured(
-          app->app_id(),
-          protocol_handler::ServiceType::kMobileNav,
-          result,
-          rejected_params);
-      break;
     }
     default:
       SDL_LOG_ERROR("Received unknown event " << event.id());
@@ -143,8 +141,8 @@ void NaviSetVideoConfigRequest::onTimeOut() {
   }
 
   std::vector<std::string> empty;
-  application_manager_.OnStreamingConfigured(
-      app->app_id(), protocol_handler::ServiceType::kMobileNav, false, empty);
+  application_manager_.OnStreamingConfigurationFailed(
+      app->app_id(), empty, std::string());
 
   application_manager_.TerminateRequest(
       connection_key(), correlation_id(), function_id());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -101,11 +101,9 @@ TEST_F(NaviSetVideoConfigRequestTest, OnEventWithSuccessResponse) {
   Event event(kEventID);
   event.set_smart_object(*event_msg);
 
-  std::vector<std::string> empty;
-  EXPECT_CALL(
-      app_mngr_,
-      OnStreamingConfigured(
-          kAppId, protocol_handler::ServiceType::kMobileNav, true, empty))
+  EXPECT_CALL(app_mngr_,
+              OnStreamingSuccessfulConfiguration(
+                  kAppId, protocol_handler::ServiceType::kMobileNav))
       .Times(1);
 
   command->on_event(event);
@@ -151,10 +149,9 @@ TEST_F(NaviSetVideoConfigRequestTest, OnEventWithRejectedResponse) {
   event.set_smart_object(*event_msg);
 
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(app_mngr_,
-              OnStreamingConfigured(
-                  kAppId, protocol_handler::ServiceType::kMobileNav, false, _))
-      .WillOnce(SaveArg<3>(&rejected_params));
+  const std::string reason;
+  EXPECT_CALL(app_mngr_, OnStreamingConfigurationFailed(kAppId, _, reason))
+      .WillOnce(SaveArg<1>(&rejected_params));
 
   command->on_event(event);
 
@@ -181,10 +178,8 @@ TEST_F(NaviSetVideoConfigRequestTest,
   event.set_smart_object(*event_msg);
 
   std::vector<std::string> empty;
-  EXPECT_CALL(
-      app_mngr_,
-      OnStreamingConfigured(
-          kAppId, protocol_handler::ServiceType::kMobileNav, false, empty))
+  const std::string reason;
+  EXPECT_CALL(app_mngr_, OnStreamingConfigurationFailed(kAppId, empty, reason))
       .WillOnce(Return());
 
   command->on_event(event);
@@ -198,10 +193,8 @@ TEST_F(NaviSetVideoConfigRequestTest, OnTimeout) {
       CreateCommand<NaviSetVideoConfigRequest>(request_msg);
 
   std::vector<std::string> empty;
-  EXPECT_CALL(
-      app_mngr_,
-      OnStreamingConfigured(
-          kAppId, protocol_handler::ServiceType::kMobileNav, false, empty))
+  const std::string reason;
+  EXPECT_CALL(app_mngr_, OnStreamingConfigurationFailed(kAppId, empty, reason))
       .WillOnce(Return());
 
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(1);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -1926,7 +1926,7 @@ bool ApplicationManagerImpl::StartNaviService(
       }
 
       if (!rejected_params.empty()) {
-        OnStreamingConfigured(app_id, service_type, false, rejected_params);
+        OnStreamingConfigurationFailed(app_id, rejected_params, std::string());
         return false;
       } else if (!converted_params.empty()) {
         SDL_LOG_INFO("Sending video configuration params");
@@ -1939,82 +1939,80 @@ bool ApplicationManagerImpl::StartNaviService(
       }
     }
     // no configuration is needed, or SetVideoConfig is not sent
-    std::vector<std::string> empty;
-    OnStreamingConfigured(app_id, service_type, true, empty);
+    OnStreamingSuccessfulConfiguration(app_id, service_type);
     return true;
   }
   SDL_LOG_WARN("Refused navi service by HMI level");
   std::vector<std::string> empty;
-  OnStreamingConfigured(app_id, service_type, false, empty);
+  OnStreamingConfigurationFailed(
+      app_id,
+      empty,
+      "Service type: " + std::to_string(service_type) +
+          " disallowed with current HMI level");
   return false;
 }
 
-void ApplicationManagerImpl::OnStreamingConfigured(
-    uint32_t app_id,
-    protocol_handler::ServiceType service_type,
-    bool result,
-    std::vector<std::string>& rejected_params) {
-  using namespace protocol_handler;
+void ApplicationManagerImpl::OnStreamingSuccessfulConfiguration(
+    uint32_t app_id, protocol_handler::ServiceType service_type) {
   SDL_LOG_AUTO_TRACE();
 
-  SDL_LOG_INFO("OnStreamingConfigured called for service "
-               << service_type << ", result=" << result);
+  SDL_LOG_INFO("Streaming configuration successful for service "
+               << service_type);
+  std::vector<std::string> empty;
+  std::string reason;
+  {
+    sync_primitives::AutoLock lock(navi_service_status_lock_);
 
-  if (result) {
-    std::vector<std::string> empty;
-    std::string reason;
+    NaviServiceStatusMap::iterator it = navi_service_status_.find(app_id);
+    if (navi_service_status_.end() == it) {
+      SDL_LOG_WARN("Application not found in navi status map");
+      connection_handler().NotifyServiceStartedResult(
+          app_id, false, empty, reason);
+      return;
+    }
+
+    // Fill NaviServices map. Set true to first value of pair if
+    // we've started video service or to second value if we've
+    // started audio service
+    service_type == protocol_handler::ServiceType::kMobileNav
+        ? it->second.first = true
+        : it->second.second = true;
+
     {
-      sync_primitives::AutoLock lock(navi_service_status_lock_);
-
-      NaviServiceStatusMap::iterator it = navi_service_status_.find(app_id);
-      if (navi_service_status_.end() == it) {
-        SDL_LOG_WARN("Application not found in navi status map");
-        connection_handler().NotifyServiceStartedResult(
-            app_id, false, empty, reason);
-        return;
-      }
-
-      // Fill NaviServices map. Set true to first value of pair if
-      // we've started video service or to second value if we've
-      // started audio service
-      service_type == ServiceType::kMobileNav ? it->second.first = true
-                                              : it->second.second = true;
-
-      {
-        sync_primitives::AutoLock lock(navi_app_to_stop_lock_);
-        for (size_t i = 0; i < navi_app_to_stop_.size(); ++i) {
-          if (app_id == navi_app_to_stop_[i]) {
-            sync_primitives::AutoLock lock(close_app_timer_pool_lock_);
-            close_app_timer_pool_.erase(close_app_timer_pool_.begin() + i);
-            navi_app_to_stop_.erase(navi_app_to_stop_.begin() + i);
-            break;
-          }
+      sync_primitives::AutoLock lock(navi_app_to_stop_lock_);
+      for (size_t i = 0; i < navi_app_to_stop_.size(); ++i) {
+        if (app_id == navi_app_to_stop_[i]) {
+          sync_primitives::AutoLock lock(close_app_timer_pool_lock_);
+          close_app_timer_pool_.erase(close_app_timer_pool_.begin() + i);
+          navi_app_to_stop_.erase(navi_app_to_stop_.begin() + i);
+          break;
         }
       }
     }
-
-    application(app_id)->StartStreaming(service_type);
-    connection_handler().NotifyServiceStartedResult(
-        app_id, true, empty, reason);
-
-    // Fix: For wifi Secondary
-    // Should erase appid from deque of ForbidStreaming() push in the last time
-    std::deque<uint32_t>::const_iterator iter = std::find(
-        navi_app_to_end_stream_.begin(), navi_app_to_end_stream_.end(), app_id);
-    if (navi_app_to_end_stream_.end() != iter) {
-      navi_app_to_end_stream_.erase(iter);
-    }
-  } else {
-    std::string reason;
-    if (rejected_params.empty()) {
-      reason = "Service type: " + std::to_string(service_type) +
-               " disallowed with current HMI level";
-    }
-    std::vector<std::string> converted_params =
-        ConvertRejectedParamList(rejected_params);
-    connection_handler().NotifyServiceStartedResult(
-        app_id, false, converted_params, reason);
   }
+
+  application(app_id)->StartStreaming(service_type);
+  connection_handler().NotifyServiceStartedResult(app_id, true, empty, reason);
+
+  // Fix: For wifi Secondary
+  // Should erase appid from deque of ForbidStreaming() push in the last time
+  std::deque<uint32_t>::const_iterator iter = std::find(
+      navi_app_to_end_stream_.begin(), navi_app_to_end_stream_.end(), app_id);
+  if (navi_app_to_end_stream_.end() != iter) {
+    navi_app_to_end_stream_.erase(iter);
+  }
+}
+
+void ApplicationManagerImpl::OnStreamingConfigurationFailed(
+    uint32_t app_id,
+    std::vector<std::string>& rejected_params,
+    const std::string& reason) {
+  SDL_LOG_AUTO_TRACE();
+
+  std::vector<std::string> converted_params =
+      ConvertRejectedParamList(rejected_params);
+  connection_handler().NotifyServiceStartedResult(
+      app_id, false, converted_params, reason);
 }
 
 void ApplicationManagerImpl::StopNaviService(

--- a/src/components/application_manager/test/application_manager_impl_test.cc
+++ b/src/components/application_manager/test/application_manager_impl_test.cc
@@ -541,7 +541,7 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_RpcService) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   app_manager_impl_->OnServiceStartedCallback(
@@ -563,7 +563,7 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_UnknownApp) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   app_manager_impl_->OnServiceStartedCallback(
@@ -585,7 +585,7 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_UnknownService) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   app_manager_impl_->OnServiceStartedCallback(
@@ -616,7 +616,7 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_VideoServiceStart) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() should not be called, StartStreaming() is called
@@ -647,7 +647,7 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() and StartStreaming() should not be called
@@ -684,7 +684,7 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() and StartStreaming() should not be called
@@ -720,7 +720,7 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;
@@ -809,7 +809,7 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;
@@ -888,7 +888,7 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;
@@ -928,7 +928,7 @@ TEST_F(ApplicationManagerImplTest, OnServiceStartedCallback_AudioServiceStart) {
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   // check: SetVideoConfig() should not be called, StartStreaming() is called
@@ -963,7 +963,7 @@ TEST_F(ApplicationManagerImplTest,
 
   bool result = false;
   std::vector<std::string> rejected_params;
-  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _))
+  EXPECT_CALL(mock_connection_handler_, NotifyServiceStartedResult(_, _, _, _))
       .WillOnce(DoAll(SaveArg<1>(&result), SaveArg<2>(&rejected_params)));
 
   BsonObject input_params;

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -606,10 +606,10 @@ class ConnectionHandlerImpl
    * \note This is invoked only once but can be invoked by multiple threads.
    * Also it can be invoked before OnServiceStartedCallback() returns.
    **/
-  virtual void NotifyServiceStartedResult(
-      uint32_t session_key,
-      bool result,
-      std::vector<std::string>& rejected_params);
+  void NotifyServiceStartedResult(uint32_t session_key,
+                                  bool result,
+                                  std::vector<std::string>& rejected_params,
+                                  const std::string& reason) OVERRIDE;
 
   /**
    * \brief Called when secondary transport with given session ID is established

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -520,7 +520,7 @@ void ConnectionHandlerImpl::OnSessionStartedCallback(
           context,
           rejected_params,
           "Cannot start " +
-              std::string(is_protected ? "a protected" : " an unprotected") +
+              std::string(is_protected ? "a protected" : "an unprotected") +
               " service of type " + std::to_string(service_type) + ". " +
               err_reason);
       return;
@@ -550,7 +550,8 @@ void ConnectionHandlerImpl::OnSessionStartedCallback(
         params);
   } else {
     if (protocol_handler_) {
-      protocol_handler_->NotifySessionStarted(context, rejected_params);
+      protocol_handler_->NotifySessionStarted(
+          context, rejected_params, std::string());
     }
   }
 }
@@ -558,7 +559,8 @@ void ConnectionHandlerImpl::OnSessionStartedCallback(
 void ConnectionHandlerImpl::NotifyServiceStartedResult(
     uint32_t session_key,
     bool result,
-    std::vector<std::string>& rejected_params) {
+    std::vector<std::string>& rejected_params,
+    const std::string& reason) {
   SDL_LOG_AUTO_TRACE();
 
   protocol_handler::SessionContext context;
@@ -599,7 +601,7 @@ void ConnectionHandlerImpl::NotifyServiceStartedResult(
   }
 
   if (protocol_handler_ != NULL) {
-    protocol_handler_->NotifySessionStarted(context, rejected_params);
+    protocol_handler_->NotifySessionStarted(context, rejected_params, reason);
   }
 }
 

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -65,9 +65,9 @@ using ::testing::ReturnRefOfCopy;
 using ::testing::SaveArg;
 using ::testing::SaveArgPointee;
 
-// custom action to call a member function with 3 arguments
-ACTION_P5(InvokeMemberFuncWithArg3, ptr, memberFunc, a, b, c) {
-  (ptr->*memberFunc)(a, b, c);
+// custom action to call a member function with 4 arguments
+ACTION_P6(InvokeMemberFuncWithArg4, ptr, memberFunc, a, b, c, d) {
+  (ptr->*memberFunc)(a, b, c, d);
 }
 
 namespace {
@@ -1307,16 +1307,18 @@ TEST_F(ConnectionHandlerTest, SessionStarted_WithRpc) {
   connection_handler_->set_connection_handler_observer(
       &mock_connection_handler_observer);
   std::vector<std::string> empty;
+  std::string reason;
   uint32_t session_key =
       connection_handler_->KeyFromPair(uid_, out_context_.initial_session_id_);
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(device_handle_, _, kRpc, NULL))
-      .WillOnce(InvokeMemberFuncWithArg3(
+      .WillOnce(InvokeMemberFuncWithArg4(
           connection_handler_,
           &ConnectionHandler::NotifyServiceStartedResult,
           session_key,
           true,
-          ByRef(empty)));
+          ByRef(empty),
+          reason));
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
   EXPECT_CALL(mock_protocol_handler_, NotifySessionStarted(_, _, _))
@@ -1345,15 +1347,17 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_SUCCESS) {
   uint32_t session_key =
       connection_handler_->KeyFromPair(uid_, out_context_.new_session_id_);
   std::vector<std::string> empty;
+  std::string reason;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(
                   device_handle_, session_key, kMobileNav, dummy_params))
-      .WillOnce(InvokeMemberFuncWithArg3(
+      .WillOnce(InvokeMemberFuncWithArg4(
           connection_handler_,
           &ConnectionHandler::NotifyServiceStartedResult,
           session_key,
           true,
-          ByRef(empty)));
+          ByRef(empty),
+          reason));
 
   // confirm that NotifySessionStarted() is called
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
@@ -1385,15 +1389,17 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_FAILURE) {
   uint32_t session_key =
       connection_handler_->KeyFromPair(uid_, out_context_.new_session_id_);
   std::vector<std::string> empty;
+  std::string reason;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceStartedCallback(
                   device_handle_, session_key, kMobileNav, dummy_params))
-      .WillOnce(InvokeMemberFuncWithArg3(
+      .WillOnce(InvokeMemberFuncWithArg4(
           connection_handler_,
           &ConnectionHandler::NotifyServiceStartedResult,
           session_key,
           false,
-          ByRef(empty)));
+          ByRef(empty),
+          reason));
 
   // confirm that NotifySessionStarted() is called
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
@@ -1455,6 +1461,8 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_Multiple) {
       connection_handler_->KeyFromPair(uid_, context_second.new_session_id_);
 
   std::vector<std::string> empty;
+  std::string reason;
+
   ChangeProtocol(uid_,
                  context_first.new_session_id_,
                  protocol_handler::PROTOCOL_VERSION_3);
@@ -1472,18 +1480,20 @@ TEST_F(ConnectionHandlerTest, ServiceStarted_Video_Multiple) {
                   device_handle_, session_key2, kMobileNav, dummy_params))
       // call NotifyServiceStartedResult() twice, first for the second session
       // then for the first session
-      .WillOnce(DoAll(InvokeMemberFuncWithArg3(
+      .WillOnce(DoAll(InvokeMemberFuncWithArg4(
                           connection_handler_,
                           &ConnectionHandler::NotifyServiceStartedResult,
                           session_key2,
                           false,
-                          ByRef(empty)),
-                      InvokeMemberFuncWithArg3(
+                          ByRef(empty),
+                          reason),
+                      InvokeMemberFuncWithArg4(
                           connection_handler_,
                           &ConnectionHandler::NotifyServiceStartedResult,
                           session_key1,
                           true,
-                          ByRef(empty))));
+                          ByRef(empty),
+                          reason)));
 
   // verify that connection handler will not mix up the two results
   SessionContext new_context_first, new_context_second;

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -873,18 +873,24 @@ class ApplicationManager {
                                protocol_handler::ServiceType service_type) = 0;
 
   /**
-   * @brief Called when application completes streaming configuration
+   * @brief Called when application successfully completes streaming
+   * configuration
    * @param app_id Streaming application id
    * @param service_type Streaming service type
-   * @param result true if configuration is successful, false otherwise
-   * @param rejected_params list of rejected parameters' name. Valid
-   *                        only when result is false.
    */
-  virtual void OnStreamingConfigured(
+  virtual void OnStreamingSuccessfulConfiguration(
+      uint32_t app_id, protocol_handler::ServiceType service_type) = 0;
+
+  /**
+   * @brief Called when application fails streaming configuration
+   * @param app_id Streaming application id
+   * @param rejected_params list of rejected parameters' name
+   * @param reason NACK reason
+   */
+  virtual void OnStreamingConfigurationFailed(
       uint32_t app_id,
-      protocol_handler::ServiceType service_type,
-      bool result,
-      std::vector<std::string>& rejected_params) = 0;
+      std::vector<std::string>& rejected_params,
+      const std::string& reason) = 0;
 
   virtual const ApplicationManagerSettings& get_settings() const = 0;
   // Extract the app ID to use internally based on the UseFullAppID .ini setting

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -297,7 +297,8 @@ class ConnectionHandler {
   virtual void NotifyServiceStartedResult(
       uint32_t session_key,
       bool result,
-      std::vector<std::string>& rejected_params) = 0;
+      std::vector<std::string>& rejected_params,
+      const std::string& reason) = 0;
 
   /**
    * \brief Called when secondary transport with given session ID is established

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -134,11 +134,12 @@ class ProtocolHandler {
    * @param rejected_params list of parameters name that are rejected.
    * Only valid when generated_session_id is 0. Note, even if
    * generated_session_id is 0, the list may be empty.
+   * @param err_reason string with NACK reason. Only valid when
+   * generated_session_id is 0.
    */
-  virtual void NotifySessionStarted(
-      const SessionContext& context,
-      std::vector<std::string>& rejected_params,
-      const std::string err_reason = std::string()) = 0;
+  virtual void NotifySessionStarted(const SessionContext& context,
+                                    std::vector<std::string>& rejected_params,
+                                    const std::string& err_reason) = 0;
 
   virtual bool IsRPCServiceSecure(const uint32_t connection_key) const = 0;
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -377,11 +377,13 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_METHOD0(OnTimerSendTTSGlobalProperties, void());
   MOCK_METHOD0(OnLowVoltage, void());
   MOCK_METHOD0(OnWakeUp, void());
-  MOCK_METHOD4(OnStreamingConfigured,
+  MOCK_METHOD2(OnStreamingSuccessfulConfiguration,
                void(uint32_t app_id,
-                    protocol_handler::ServiceType service_type,
-                    bool result,
-                    std::vector<std::string>& rejected_params));
+                    protocol_handler::ServiceType service_type));
+  MOCK_METHOD3(OnStreamingConfigurationFailed,
+               void(uint32_t app_id,
+                    std::vector<std::string>& rejected_params,
+                    const std::string& reason));
   MOCK_METHOD2(ProcessReconnection,
                void(application_manager::ApplicationSharedPtr application,
                     const uint32_t connection_key));

--- a/src/components/include/test/connection_handler/mock_connection_handler.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler.h
@@ -123,10 +123,11 @@ class MockConnectionHandler : public connection_handler::ConnectionHandler {
                    transport_manager::ConnectionUID secondary_transport_id));
   MOCK_CONST_METHOD1(GetSessionTransports,
                      const SessionTransports(uint8_t session_id));
-  MOCK_METHOD3(NotifyServiceStartedResult,
+  MOCK_METHOD4(NotifyServiceStartedResult,
                void(uint32_t session_key,
                     bool result,
-                    std::vector<std::string>& rejected_params));
+                    std::vector<std::string>& rejected_params,
+                    const std::string& reason));
   MOCK_METHOD3(
       OnSecondaryTransportStarted,
       bool(transport_manager::ConnectionUID& primary_connection_handle,

--- a/src/components/include/test/protocol_handler/mock_protocol_handler.h
+++ b/src/components/include/test/protocol_handler/mock_protocol_handler.h
@@ -64,13 +64,10 @@ class MockProtocolHandler : public ::protocol_handler::ProtocolHandler {
   MOCK_CONST_METHOD0(get_settings,
                      const ::protocol_handler::ProtocolHandlerSettings&());
   MOCK_METHOD0(get_session_observer, protocol_handler::SessionObserver&());
-  MOCK_METHOD2(NotifySessionStarted,
-               void(const ::protocol_handler::SessionContext& context,
-                    std::vector<std::string>& rejected_params));
   MOCK_METHOD3(NotifySessionStarted,
                void(const ::protocol_handler::SessionContext& context,
                     std::vector<std::string>& rejected_params,
-                    const std::string err_reason));
+                    const std::string& err_reason));
   MOCK_METHOD0(NotifyOnGetSystemTimeFailed, void());
   MOCK_CONST_METHOD1(IsRPCServiceSecure, bool(const uint32_t connection_key));
   MOCK_METHOD0(ProcessFailedPTU, void());

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -379,7 +379,7 @@ class ProtocolHandlerImpl
                             uint8_t session_id,
                             uint8_t protocol_version,
                             uint8_t service_type,
-                            const std::string reason);
+                            const std::string& reason);
 
   /**
    * \brief Sends fail of starting session to mobile application
@@ -395,7 +395,7 @@ class ProtocolHandlerImpl
                             uint8_t protocol_version,
                             uint8_t service_type,
                             std::vector<std::string>& rejectedParams,
-                            const std::string reason);
+                            const std::string& reason);
 
   /**
    * \brief Sends acknowledgement of end session/service to mobile application
@@ -457,7 +457,7 @@ class ProtocolHandlerImpl
    */
   void NotifySessionStarted(const SessionContext& context,
                             std::vector<std::string>& rejected_params,
-                            const std::string err_reason) OVERRIDE;
+                            const std::string& err_reason) OVERRIDE;
 
 #ifdef BUILD_TESTS
   const impl::FromMobileQueue& get_from_mobile_queue() const {

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -3954,7 +3954,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_NACKReason_DisallowedBySettings) {
   bson_object_initialize_default(&bson_nack_params);
   // NAK reason param
   std::string reason = "Service type: " + std::to_string(service_type) +
-                       " disallowed by settings";
+                       " disallowed by settings.";
   bson_object_put_string(&bson_nack_params,
                          protocol_handler::strings::reason,
                          const_cast<char*>(reason.c_str()));


### PR DESCRIPTION
Fixes #[7972](https://adc.luxoft.com/jira/browse/FORDTCN-7972)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Affected UTs are updated

### Summary
In several cases there is a need in adding or rewording reasons of NACK, related to Video/Audio services. To fix cases with wrong application types and wrong HMI Levels there is a need in adding new reason parameter to two methods: ConnectionHandlerImpl::NotifyServiceStartedResult and ApplicationManagerImpl::OnStreamingConfigured.

Also there is a need in adding additional clarification to reasons, related to protected or unprotected services. That's why corresponding checks and clarifications were added.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
