### PR TITLE
Fix application activation after resumption

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl.h
@@ -84,9 +84,8 @@ class ResumeCtrl {
   /**
    * @brief Set application HMI Level and ausio_state as saved
    * @param application is application witch HMI Level is need to restore
-   * @return true if success, otherwise return false
    */
-  virtual bool RestoreAppHMIState(
+  virtual void RestoreAppHMIState(
       application_manager::ApplicationSharedPtr application) = 0;
 
   /**
@@ -255,7 +254,7 @@ class ResumeCtrl {
    * @param application - application to restore hmi level
    * and audio streaming state
    */
-  virtual bool StartAppHmiStateResumption(
+  virtual void StartAppHmiStateResumption(
       application_manager::ApplicationSharedPtr application) = 0;
 
   /**

--- a/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resume_ctrl_impl.h
@@ -83,9 +83,8 @@ class ResumeCtrlImpl : public ResumeCtrl {
   /**
    * @brief Set application HMI Level and ausio_state as saved
    * @param application is application witch HMI Level is need to restore
-   * @return true if success, otherwise return false
    */
-  bool RestoreAppHMIState(app_mngr::ApplicationSharedPtr application) OVERRIDE;
+  void RestoreAppHMIState(app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**
    * @brief Set application HMI Level as stored in policy
@@ -234,9 +233,8 @@ class ResumeCtrlImpl : public ResumeCtrl {
    * @brief Resume HMI Level and audio streaming state if needed
    * @param application - application to restore hmi level
    * and audio streaming state
-   * @return true if success otherwise false
    */
-  bool StartAppHmiStateResumption(
+  void StartAppHmiStateResumption(
       app_mngr::ApplicationSharedPtr application) OVERRIDE;
 
   /**

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -264,9 +264,8 @@ void ResumeCtrlImpl::ApplicationResumptiOnTimer() {
       SDL_LOG_ERROR("Invalid app_id = " << *it);
       continue;
     }
-    if (!StartAppHmiStateResumption(app)) {
-      app->set_is_resuming(false);
-    }
+    StartAppHmiStateResumption(app);
+    app->set_is_resuming(false);
   }
   is_resumption_active_ = false;
   waiting_for_timer_.clear();

--- a/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
+++ b/src/components/application_manager/test/include/application_manager/mock_resume_ctrl.h
@@ -96,11 +96,11 @@ class MockResumeCtrl : public resumption::ResumeCtrl {
   MOCK_CONST_METHOD2(GetSavedAppHmiLevel,
                      int32_t(const std::string&, const std::string&));
   MOCK_METHOD1(RestoreAppHMIState,
-               bool(application_manager::ApplicationSharedPtr application));
+               void(application_manager::ApplicationSharedPtr application));
   MOCK_METHOD1(SetupDefaultHMILevel,
                bool(application_manager::ApplicationSharedPtr application));
   MOCK_METHOD1(StartAppHmiStateResumption,
-               bool(application_manager::ApplicationSharedPtr application));
+               void(application_manager::ApplicationSharedPtr application));
   MOCK_METHOD3(SetAppHMIState,
                bool(application_manager::ApplicationSharedPtr application,
                     const mobile_apis::HMILevel::eType hmi_level,

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -967,8 +967,7 @@ TEST_F(ResumeCtrlTest, RestoreAppHMIState_RestoreHMILevelFull) {
   ON_CALL(mock_app_mngr_, GetUserConsentForDevice("12345"))
       .WillByDefault(Return(policy::kDeviceAllowed));
 
-  const bool res = res_ctrl_->RestoreAppHMIState(mock_app_);
-  EXPECT_TRUE(res);
+  res_ctrl_->RestoreAppHMIState(mock_app_);
 }
 
 TEST_F(ResumeCtrlTest, SetupDefaultHMILevel) {


### PR DESCRIPTION
Fixes #[10647](https://adc.luxoft.com/jira/browse/FORDTCN-10647)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test script

### Summary
There is a case when media application acquires wrong HMI Level (NONE instead of FULL) during activation. Root cause of this issue is a `true` value of `is_resuming` flag for application, which in fact completed resumption process. Before this flag was set to `false` only for applications with failed resumption, so there is a need to assign it to `false` for all already resumed applications regardless of successfulness of resumption.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
