### PR TITLE
Make correlation ID counter atomic

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1613,9 +1613,9 @@ class ApplicationManagerImpl
   hmi_apis::HMI_API* hmi_so_factory_;
   mobile_apis::MOBILE_API* mobile_so_factory_;
 
-  static uint32_t mobile_corelation_id_;
-  static uint32_t corelation_id_;
-  static const uint32_t max_corelation_id_;
+  std::atomic_uint32_t mobile_corelation_id_;
+  std::atomic_uint32_t corelation_id_;
+  const uint32_t max_corelation_id_;
 
   std::unique_ptr<HMICapabilities> hmi_capabilities_;
   // The reason of HU shutdown

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -145,10 +145,6 @@ struct PolicyAppIdComparator {
   const std::string& policy_app_id_;
 };
 
-uint32_t ApplicationManagerImpl::mobile_corelation_id_ = 0;
-uint32_t ApplicationManagerImpl::corelation_id_ = 0;
-const uint32_t ApplicationManagerImpl::max_corelation_id_ = UINT_MAX;
-
 namespace formatters = ns_smart_device_link::ns_json_handler::formatters;
 namespace jhs = ns_smart_device_link::ns_json_handler::strings;
 
@@ -176,6 +172,9 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     , request_ctrl_(am_settings)
     , hmi_so_factory_(NULL)
     , mobile_so_factory_(NULL)
+    , mobile_corelation_id_(0)
+    , corelation_id_(0)
+    , max_corelation_id_(UINT_MAX)
     , hmi_capabilities_(new HMICapabilitiesImpl(*this))
     , unregister_reason_(
           mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM)


### PR DESCRIPTION
Fixes #[10218](https://adc.luxoft.com/jira/browse/FORDTCN-10218)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
There is a situation when messages are simultaneously created for different requests. During message creation process `GetNextHMICorrelationID`/`GetNextMobileCorrelationID` methods are invoked, and inside this methods corresponding counters are incremented. But now these counters aren't synchronized properly, because several threads may increment these counters at the same time, so `GetNextHMICorrelationID`/`GetNextMobileCorrelationID` methods may return same values for different requests. To avoid these situations type of this counters need to be changed from `uint32_t` to `atomic_uint_32_t`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
