### PR TITLE
Fix for a potential SDL crash on boot

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1191,6 +1191,9 @@ class ApplicationManagerImpl
   void ApplyFunctorForEachPlugin(
       std::function<void(plugin_manager::RPCPlugin&)> functor) OVERRIDE;
 
+  ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra&
+  v4_protocol_so_factory() OVERRIDE;
+
  private:
   /**
    * @brief Adds application to registered applications list and marks it as
@@ -1610,8 +1613,10 @@ class ApplicationManagerImpl
     mobile_apis::SystemContext::eType system_context;
   };
 
-  hmi_apis::HMI_API* hmi_so_factory_;
-  mobile_apis::MOBILE_API* mobile_so_factory_;
+  hmi_apis::HMI_API hmi_so_factory_;
+  mobile_apis::MOBILE_API mobile_so_factory_;
+  ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra
+      v4_protocol_so_factory_;
 
   static uint32_t mobile_corelation_id_;
   static uint32_t corelation_id_;

--- a/src/components/application_manager/include/application_manager/rpc_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/rpc_handler_impl.h
@@ -181,8 +181,11 @@ class RPCHandlerImpl : public RPCHandler,
                           const bool validate_params = true);
   std::shared_ptr<Message> ConvertRawMsgToMessage(
       const ::protocol_handler::RawMessagePtr message);
+
   hmi_apis::HMI_API& hmi_so_factory();
   mobile_apis::MOBILE_API& mobile_so_factory();
+  ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra&
+  v4_protocol_so_factory();
 
   ApplicationManager& app_manager_;
   // Thread that pumps messages coming from mobile side.

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -174,8 +174,10 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     , policy_handler_(new policy::PolicyHandler(policy_settings, *this))
     , protocol_handler_(NULL)
     , request_ctrl_(am_settings)
-    , hmi_so_factory_(NULL)
-    , mobile_so_factory_(NULL)
+    , hmi_so_factory_(hmi_apis::HMI_API())
+    , mobile_so_factory_(mobile_apis::MOBILE_API())
+    , v4_protocol_so_factory_(
+          ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra())
     , hmi_capabilities_(new HMICapabilitiesImpl(*this))
     , unregister_reason_(
           mobile_api::AppInterfaceUnregisteredReason::INVALID_ENUM)
@@ -234,14 +236,6 @@ ApplicationManagerImpl::~ApplicationManagerImpl() {
   media_manager_ = NULL;
   hmi_handler_ = NULL;
   connection_handler_ = NULL;
-  if (hmi_so_factory_) {
-    delete hmi_so_factory_;
-    hmi_so_factory_ = NULL;
-  }
-  if (mobile_so_factory_) {
-    delete mobile_so_factory_;
-    mobile_so_factory_ = NULL;
-  }
   protocol_handler_ = NULL;
   SDL_LOG_DEBUG("Destroying Policy Handler");
   RemovePolicyObserver(this);
@@ -2670,25 +2664,16 @@ bool ApplicationManagerImpl::ConvertSOtoMessage(
 }
 
 hmi_apis::HMI_API& ApplicationManagerImpl::hmi_so_factory() {
-  if (!hmi_so_factory_) {
-    hmi_so_factory_ = new hmi_apis::HMI_API;
-    if (!hmi_so_factory_) {
-      SDL_LOG_ERROR("Out of memory");
-      NOTREACHED();
-    }
-  }
-  return *hmi_so_factory_;
+  return hmi_so_factory_;
 }
 
 mobile_apis::MOBILE_API& ApplicationManagerImpl::mobile_so_factory() {
-  if (!mobile_so_factory_) {
-    mobile_so_factory_ = new mobile_apis::MOBILE_API;
-    if (!mobile_so_factory_) {
-      SDL_LOG_ERROR("Out of memory");
-      NOTREACHED();
-    }
-  }
-  return *mobile_so_factory_;
+  return mobile_so_factory_;
+}
+
+ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra&
+ApplicationManagerImpl::v4_protocol_so_factory() {
+  return v4_protocol_so_factory_;
 }
 
 HMICapabilities& ApplicationManagerImpl::hmi_capabilities() {

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -466,8 +466,6 @@ bool RPCHandlerImpl::ConvertMessageToSO(
       break;
     }
     case protocol_handler::MajorProtocolVersion::PROTOCOL_VERSION_1: {
-      static ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra v1_shema;
-
       if (message.function_id() == 0 || message.type() == kUnknownType) {
         SDL_LOG_ERROR("Message received: UNSUPPORTED_VERSION");
 
@@ -495,7 +493,7 @@ bool RPCHandlerImpl::ConvertMessageToSO(
 
           smart_objects::SmartObjectSPtr msg_to_send =
               std::make_shared<smart_objects::SmartObject>(output);
-          v1_shema.attachSchema(*msg_to_send, false);
+          v4_protocol_so_factory().attachSchema(*msg_to_send, false);
           app_manager_.GetRPCService().SendMessageToMobile(msg_to_send);
           return false;
         }
@@ -600,6 +598,11 @@ hmi_apis::HMI_API& RPCHandlerImpl::hmi_so_factory() {
 
 mobile_apis::MOBILE_API& RPCHandlerImpl::mobile_so_factory() {
   return mobile_so_factory_;
+}
+
+ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra&
+RPCHandlerImpl::v4_protocol_so_factory() {
+  return app_manager_.v4_protocol_so_factory();
 }
 }  // namespace rpc_handler
 }  // namespace application_manager

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -42,6 +42,9 @@
 #include "connection_handler/connection_handler.h"
 #include "utils/data_accessor.h"
 
+#include "interfaces/v4_protocol_v1_2_no_extra.h"
+#include "interfaces/v4_protocol_v1_2_no_extra_schema.h"
+
 #include "application_manager/application_manager_settings.h"
 #include "application_manager/hmi_interfaces.h"
 #include "application_manager/plugin_manager/rpc_plugin_manager.h"
@@ -774,6 +777,9 @@ class ApplicationManager {
    * @return reference to hmi_interfaces component
    */
   virtual HmiInterfaces& hmi_interfaces() = 0;
+
+  virtual ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra&
+  v4_protocol_so_factory() = 0;
 
   virtual app_launch::AppLaunchCtrl& app_launch_ctrl() = 0;
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -184,6 +184,8 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                void(application_manager::ApplicationSharedPtr app));
   MOCK_METHOD1(OnApplicationSwitched,
                void(application_manager::ApplicationSharedPtr app));
+  MOCK_METHOD0(v4_protocol_so_factory,
+               ns_smart_device_link_rpc::V1::v4_protocol_v1_2_no_extra&());
   MOCK_CONST_METHOD0(connection_handler,
                      connection_handler::ConnectionHandler&());
   MOCK_CONST_METHOD0(protocol_handler, protocol_handler::ProtocolHandler&());


### PR DESCRIPTION
Fixes #[7342](https://adc.luxoft.com/jira/browse/FORDTCN-7342)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
One of the reasons why SDL is crashing on start is related to lazy initialization of the HMI/Mobile/v4
API classes. These classes are initialized on demand when some of threads are trying to get the object of that class first time. Most likely, at SDL start might be a situation when HMI/Mobile/v4 API classes are
constructing in the one thread and at that moment another thread is trying to get access to the inner data of not-yet-fully-constructed object and this causes a core crash with ~ISchemaItem() calls in stack trace. That is possible because access to these factories is not synchronized.

To avoid such situation, factory creation was moved to AM ctor and all other sub components just use getters when they need to get access to API instances.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
