### PR TITLE
Fix/ccb 3141 change command request inheritance structure

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -700,6 +700,15 @@ class ApplicationManagerImpl
                         const uint32_t corr_id,
                         const int32_t function_id) OVERRIDE;
 
+  bool RetainRequestInstance(const uint32_t connection_key,
+                             const uint32_t correlation_id) OVERRIDE;
+
+  void RemoveRetainedRequest(const uint32_t connection_key,
+                             const uint32_t correlation_id) OVERRIDE;
+
+  bool IsStillWaitingForResponse(const uint32_t connection_key,
+                                 const uint32_t correlation_id) const OVERRIDE;
+
   void OnQueryAppsRequest(
       const connection_handler::DeviceHandle device) OVERRIDE;
 

--- a/src/components/application_manager/include/application_manager/commands/command.h
+++ b/src/components/application_manager/include/application_manager/commands/command.h
@@ -115,7 +115,14 @@ class Command {
    * has exceed it's limit
    *
    */
-  virtual void onTimeOut() = 0;
+  virtual void HandleTimeOut() = 0;
+
+  /**
+   * @brief Function is called by RequestInfo when request controller
+   * updates request timeout
+   * Function sets request state to "AwaitingResponse"
+   */
+  virtual void OnUpdateTimeOut() = 0;
 
   /**
    * @brief AllowedToTerminate tells if request controller is allowed

--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -131,7 +131,7 @@ class CommandImpl : public Command {
    * has exceed it's limit
    *
    */
-  void onTimeOut() OVERRIDE;
+  void HandleTimeOut() OVERRIDE;
 
   /**
    * @brief AllowedToTerminate tells request Controller if it can terminate this
@@ -148,6 +148,8 @@ class CommandImpl : public Command {
    * If true, request controller will terminate request on response
    */
   void SetAllowedToTerminate(const bool allowed) OVERRIDE;
+
+  void OnUpdateTimeOut() OVERRIDE;
 
   /**
    * @brief Calculates command`s internal consecutive number

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -1,22 +1,17 @@
-﻿/*
+/*
  Copyright (c) 2016, Ford Motor Company
  All rights reserved.
-
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
-
  Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
-
  Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following
  disclaimer in the documentation and/or other materials provided with the
  distribution.
-
  Neither the name of the Ford Motor Company nor the names of its contributors
  may be used to endorse or promote products derived from this software
  without specific prior written permission.
-
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,185 +28,60 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_COMMAND_REQUEST_IMPL_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_COMMAND_REQUEST_IMPL_H_
 
+#include <memory>
+
+#include "application_manager/application_manager.h"
 #include "application_manager/commands/command_impl.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "application_manager/hmi_interfaces.h"
+#include "application_manager/smart_object_keys.h"
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
 #include "smart_objects/smart_object.h"
 #include "utils/lock.h"
 
 namespace application_manager {
+
 namespace commands {
-
-struct ResponseInfo {
-  ResponseInfo();
-  ResponseInfo(const hmi_apis::Common_Result::eType result,
-               const HmiInterfaces::InterfaceID hmi_interface,
-               ApplicationManager& application_manager);
-  hmi_apis::Common_Result::eType result_code;
-  HmiInterfaces::InterfaceID interface;
-  HmiInterfaces::InterfaceState interface_state;
-  bool is_ok;
-  bool is_unsupported_resource;
-  bool is_not_used;
-};
-
-namespace ns_smart = ns_smart_device_link::ns_smart_objects;
-
 /**
- * @brief MergeInfos merge 2 infos in one string
- * @param first - info string that should be first in result info
- * @param second - info string that should be second in result info
- * @return if first is empty return second
- *         if second is empty return first
- *         if both are empty return empty string
- *         if both are not empty return empty first +", " + second
- */
-std::string MergeInfos(const std::string& first, const std::string& second);
-
-/**
- * @brief MergeInfos merge 2 infos into one string with info
- * @param first_info -contains result_code from HMI response and
- * interface that returns response
- * @param first_str - info string that should be first in result info
- * @param second_info -contains result_code from HMI response and
- * interface that returns response
- * @param second_str - info string that should be second in result info
- * @return if first_info is not available and second_str not empty return second
- *         if second_info is not available and first_str not empty return first
- *         other cases return result MergeInfos for 2 params
- */
-std::string MergeInfos(const ResponseInfo& first_info,
-                       const std::string& first_str,
-                       const ResponseInfo& second_info,
-                       const std::string& second_str);
-
-/**
- * @brief MergeInfos merge 3 infos in one string
- * @param first - info string that should be first in result info
- * @param second - info string that should be second in result info
- * @param third - info string that should be second in result info
- * @return resulting string contain merge all incoming parameters
- */
-std::string MergeInfos(const std::string& first,
-                       const std::string& second,
-                       const std::string& third);
-
+ * @brief Class is intended to encapsulate RPC as an object
+ **/
 class CommandRequestImpl : public CommandImpl,
                            public event_engine::EventObserver {
  public:
-  enum RequestState { kAwaitingHMIResponse = 0, kTimedOut, kCompleted };
+  enum RequestState {
+    kAwaitingResponse = 0,
+    kTimedOut,
+    kProcessEvent,
+  };
 
   /**
-   * @brief The HashUpdateMode enum defines whether request has to update
-   * hash after its execution is finished
-   */
-  enum HashUpdateMode { kSkipHashUpdate, kDoHashUpdate };
-
+   * @brief CommandRequestImpl class constructor
+   *
+   * @param message Incoming SmartObject message
+   **/
   CommandRequestImpl(const MessageSharedPtr& message,
                      ApplicationManager& application_manager,
                      rpc_service::RPCService& rpc_service,
                      HMICapabilities& hmi_capabilities,
                      policy::PolicyHandlerInterface& policy_handler);
 
-  ~CommandRequestImpl();
-
   /**
-   * @brief Checks command permissions according to policy table
-   */
-  bool CheckPermissions() OVERRIDE;
-
-  /**
-   * @brief Init sets hash update mode for request
-   */
-  bool Init() OVERRIDE;
-
-  /**
-   * @brief Cleanup all resources used by command
+   * @brief CommandRequestImpl class destructor
+   *
    **/
-  bool CleanUp() OVERRIDE;
-
-  /**
-   * @brief Execute corresponding command by calling the action on reciever
-   **/
-  void Run() OVERRIDE;
-
-  /*
-   * @brief Function is called by RequestController when request execution time
-   * has exceed it's limit
-   *
-   */
-  virtual void onTimeOut();
-
-  /**
-   * @brief Default EvenObserver's pure virtual method implementation
-   *
-   * @param event The received event
-   */
-  virtual void on_event(const event_engine::Event& event);
-
-  virtual void on_event(const event_engine::MobileEvent& event);
-
-  /*
-   * @brief Creates Mobile response
-   *
-   * @param success true if successful; false, if failed
-   * @param result_code Result code (SUCCESS, INVALID_DATA, e.t.c)
-   * @param info Provides additional human readable info regarding the result
-   * @param response_params Additional params in response
-   */
-  void SendResponse(
-      const bool success,
-      const mobile_apis::Result::eType& result_code,
-      const char* info = NULL,
-      const smart_objects::SmartObject* response_params = NULL,
-      const std::vector<uint8_t> binary_data = std::vector<uint8_t>());
-
-  void SendProviderRequest(
-      const mobile_apis::FunctionID::eType& mobile_function_id,
-      const hmi_apis::FunctionID::eType& hmi_function_id,
-      const smart_objects::SmartObject* msg,
-      bool use_events = false);
+  virtual ~CommandRequestImpl();
 
   void SendMobileRequest(const mobile_apis::FunctionID::eType& function_id,
                          smart_objects::SmartObjectSPtr msg,
                          bool use_events = false);
-
-  /*
-   * @brief Sends HMI request
-   *
-   * @param function_id HMI request ID
-   * @param msg_params HMI request msg params
-   * @param use_events true if we need subscribe on event(HMI request)
-   * @return hmi correlation id
-   */
-  uint32_t SendHMIRequest(const hmi_apis::FunctionID::eType& function_id,
-                          const smart_objects::SmartObject* msg_params = NULL,
-                          bool use_events = false);
-
-  /*
-   * @brief Creates HMI request
-   *
-   * @param function_id HMI request ID
-   * @param msg_params HMI request msg params
-   */
-  void CreateHMINotification(const hmi_apis::FunctionID::eType& function_id,
-                             const ns_smart::SmartObject& msg_params) const;
-
-  /**
-   * @brief Converts HMI result code to Mobile result code
-   *
-   * @param hmi_code HMI result code
-   * @return Mobile result code
-   */
-  mobile_apis::Result::eType GetMobileResultCode(
-      const hmi_apis::Common_Result::eType& hmi_code) const;
 
   /**
    * @brief Checks Mobile result code for single RPC
    * @param result_code contains result code from response to Mobile
    * @return true if result code complies to successful result codes,
    * false otherwise.
-   */
+   **/
   static bool IsMobileResultSuccess(
       const mobile_apis::Result::eType result_code);
 
@@ -220,9 +90,49 @@ class CommandRequestImpl : public CommandImpl,
    * @param result_code contains result code from HMI response
    * @return true if result code complies to successful result codes,
    * false otherwise.
-   */
+   **/
   static bool IsHMIResultSuccess(
       const hmi_apis::Common_Result::eType result_code);
+
+  /**
+   * @brief Execute corresponding command by calling the action on reciever
+   **/
+  void Run() OVERRIDE;
+
+  virtual void on_event(const event_engine::MobileEvent& event);
+
+  /*
+   * @brief Function is called by RequestController when request execution time
+   * has exceed it's limit
+   *
+   */
+  void HandleTimeOut() FINAL;
+
+  /**
+   * @brief Default EvenObserver's pure virtual method implementation
+   *
+   * @param event The received event
+   */
+  void HandleOnEvent(const event_engine::Event& event) FINAL;
+
+  /**
+   * @brief Default EvenObserver's pure virtual method implementation
+   *
+   * @param event The received event
+   */
+  void HandleOnEvent(const event_engine::MobileEvent& event) FINAL;
+
+  /**
+   * @brief Function is called by RequestController when request execution time
+   * has exceeded its limit
+   * @note default value is required as a lot of requests don't use it
+   * as they use automatically generated reason
+   */
+  virtual void OnTimeOut();
+
+  virtual void on_event(const event_engine::Event&);
+
+  void OnUpdateTimeOut() OVERRIDE;
 
  protected:
   /**
@@ -235,113 +145,13 @@ class CommandRequestImpl : public CommandImpl,
   bool CheckAllowedParameters(const Command::CommandSource source);
 
   /**
-   * @brief Checks HMI capabilities for specified button support
-   * @param button Button to check
-   * @return true if button is present in HMI capabilities
-   * otherwise returns false
+   * @brief Adds interface to be awaited by SDL request
+   * @param interface_id interface from which SDL expects response in given time
    */
-  bool CheckHMICapabilities(const mobile_apis::ButtonName::eType button) const;
+  void StartAwaitForInterface(const HmiInterfaces::InterfaceID& interface_id);
 
   /**
-   * @brief Adds disallowed parameters back to response with appropriate
-   * reasons
-   * @param response Response message, which should be extended with blocked
-   * parameters reasons
-   */
-  void AddDisallowedParameters(smart_objects::SmartObject& response);
-
-  /**
-   * @brief Checks if any request param was marked as disallowed by policy
-   * @return true if any param was marked as disallowed
-   */
-  bool HasDisallowedParams() const;
-
-  /**
-   * @brief Checks result code from HMI for single RPC
-   * and returns parameter for sending to mobile app.
-   * @param result_code contains result code from HMI response
-   * @param interface contains interface for which HMI sent response
-   * @return true if result code complies successful result cods
-   * otherwise returns false.
-   */
-  bool PrepareResultForMobileResponse(
-      hmi_apis::Common_Result::eType result_code,
-      HmiInterfaces::InterfaceID interface) const;
-
-  /**
-   * @brief Checks result code from HMI for splitted RPC
-   * and returns parameter for sending to mobile app.
-   * @param first contains result_code from HMI response and
-   * interface that returns response
-   * @param second contains result_code from HMI response and
-   * interface that returns response
-   * @return true if result code complies successful result code
-   * otherwise returns false
-   */
-  bool PrepareResultForMobileResponse(ResponseInfo& out_first,
-                                      ResponseInfo& out_second) const;
-
-  /**
-   * @brief If message from HMI contains returns this info
-   * or process result code from HMI and checks state of interface
-   * and create info.
-   * @param interface contains interface for which HMI sent response
-   * @param result_code contains result code from HMI
-   * @param response_from_hmi contains response from HMI
-   * @param out_info contain info for sending to application
-   */
-  void GetInfo(const smart_objects::SmartObject& response_from_hmi,
-               std::string& out_info);
-
-  /**
-   * @brief Prepare result code for sending to mobile application
-   * @param first contains result_code from HMI response and
-   * interface that returns response
-   * @param second contains result_code from HMI response and
-   * interface that returns response.
-   * @return resulting code for sending to mobile application.
-   */
-  mobile_apis::Result::eType PrepareResultCodeForResponse(
-      const ResponseInfo& first, const ResponseInfo& second);
-
-  /**
-   * @brief Resolves if the return code must be
-   * UNSUPPORTED_RESOURCE
-   * @param first contains result_code from HMI response and
-   * interface that returns response
-   * @param second contains result_code from HMI response and
-   * interface that returns response.
-   * @return True, if the communication return code must be
-   * UNSUPPORTED_RESOURCE, otherwise false.
-   */
-  bool IsResultCodeUnsupported(const ResponseInfo& first,
-                               const ResponseInfo& second) const;
-
-  /**
-   * @brief CheckResult checks whether the overall result
-   * of the responses is successful
-   * @param first response
-   * @param second response
-   * @return true if the overall result is successful
-   * otherwise - false
-   */
-  bool CheckResult(const ResponseInfo& first, const ResponseInfo& second) const;
-
- protected:
-  /**
-   * @brief Returns policy parameters permissions
-   * @return Parameters permissions struct reference
-   */
-  const CommandParametersPermissions& parameters_permissions() const;
-
-  /**
-   * @brief Adds interface to be awaited for by sdl request command
-     @param interface_id interface which SDL expects to response in given time
-  */
-  void StartAwaitForInterface(const HmiInterfaces::InterfaceID interface_id);
-
-  /**
-   * @brief Gets interface await state.
+   * @brief Gets interface awaiting state.
    * @param interface_id interface which SDL awaits for response in given time
    * @return true if SDL awaits for response from given interface in
    * interface_id
@@ -349,11 +159,36 @@ class CommandRequestImpl : public CommandImpl,
   bool IsInterfaceAwaited(const HmiInterfaces::InterfaceID& interface_id) const;
 
   /**
-   * @brief Sets given HMI interface await status to false
-   * @param interface_id interface which SDL no longer awaits for response in
-   * given time
+   * @brief Stops SDL awaiting from given HMI interface
+   * @param interface_id interface from which SDL no longer awaits
+   * for response in given time
    */
   void EndAwaitForInterface(const HmiInterfaces::InterfaceID& interface_id);
+
+  /**
+   * @brief Checks if there some not delivered hmi responses exist
+   * @return true if pending responses exist, otherwise - false
+   */
+  bool IsPendingResponseExist() const;
+
+  /**
+   * @brief Checks if there some not delivered hmi responses exist
+   * @return true if pending responses exist, otherwise - false
+   */
+
+  /**
+   * @brief Returns current state of request
+   * @return current request state. E.g. kAwaitingResponse, kTimedOut,
+   * kResponded
+   */
+  virtual RequestState current_state() const;
+
+  /**
+   * @brief Sets current state of request
+   * @param request state to set. E.g. kAwaitingResponse, kTimedOut,
+   * kResponded
+   */
+  virtual void set_current_state(const RequestState state);
 
   /**
    * @brief This set stores all the interfaces which are awaited by SDL to
@@ -363,60 +198,30 @@ class CommandRequestImpl : public CommandImpl,
 
   mutable sync_primitives::Lock awaiting_response_interfaces_lock_;
 
-  RequestState current_state_;
-  sync_primitives::Lock state_lock_;
-
   /**
-   * @brief hash_update_mode_ Defines whether request must update hash value of
-   * application or not
+   * @brief This lock is used to guarantee thread safe access to request state
    */
-  HashUpdateMode hash_update_mode_;
+  mutable sync_primitives::RecursiveLock state_lock_;
+
+  RequestState current_state_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(CommandRequestImpl);
 
   /**
-   * @brief Adds param to disallowed parameters enumeration
-   * @param info string with disallowed params enumeration
-   * @param param disallowed param
+   * @brief Changes request state to "kProcessEvent", retain request instance
+   * @return false if request is already in timeout state.
+   * If request is succesfully retained returns true/
    */
-  void AddDisallowedParameterToInfoString(std::string& info,
-                                          const std::string& param) const;
+  bool StartOnEventHandling();
 
   /**
-   * @brief Adds disallowed parameters to response info
-   * @param response Response message, which info should be extended
+   * @brief Changes request state to "kAwaitingResponse", removes request
+   * instance retained before
    */
-  void AddDisallowedParametersToInfo(
-      smart_objects::SmartObject& response) const;
-
-  bool ProcessHMIInterfacesAvailability(
-      const uint32_t hmi_correlation_id,
-      const hmi_apis::FunctionID::eType& function_id);
-
-  /**
-   * @brief UpdateHash updates hash field for application and sends
-   * OnHashChanged notification to mobile side in case of approriate hash mode
-   * is set
-   */
-  void UpdateHash();
-
-  /**
-   * @brief is_success_result_ Defines whether request succeded, at the moment
-   * it is value of 'success' field of appropriate response sent to mobile
-   */
-  bool is_success_result_;
-
-  /**
-   * @brief Add information for the component of response in case of timeout
-   * @param response Response message, which info should be extended
-   */
-  void AddTimeOutComponentInfoToMessage(
-      smart_objects::SmartObject& response) const;
+  void FinalizeOnEventHandling();
 };
 
 }  // namespace commands
-
 }  // namespace application_manager
-
 #endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_COMMAND_REQUEST_IMPL_H_

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -1,17 +1,22 @@
 /*
  Copyright (c) 2016, Ford Motor Company
  All rights reserved.
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
+
  Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
+
  Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following
  disclaimer in the documentation and/or other materials provided with the
  distribution.
+
  Neither the name of the Ford Motor Company nor the names of its contributors
  may be used to endorse or promote products derived from this software
  without specific prior written permission.
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -72,9 +77,16 @@ class CommandRequestImpl : public CommandImpl,
    **/
   virtual ~CommandRequestImpl();
 
+  /**
+   * @brief Send request to mobile
+   * @param function_id Function id
+   * @param msg Request to mobile
+   * @param use_event - true if request should be subscribed to an event,
+   * otherwise false
+   **/
   void SendMobileRequest(const mobile_apis::FunctionID::eType& function_id,
                          smart_objects::SmartObjectSPtr msg,
-                         bool use_events = false);
+                         bool use_events);
 
   /**
    * @brief Checks Mobile result code for single RPC
@@ -203,6 +215,9 @@ class CommandRequestImpl : public CommandImpl,
    */
   mutable sync_primitives::RecursiveLock state_lock_;
 
+  /**
+   * @brief Current state of request to synchronize its life cycle
+   */
   RequestState current_state_;
 
  private:
@@ -210,8 +225,8 @@ class CommandRequestImpl : public CommandImpl,
 
   /**
    * @brief Changes request state to "kProcessEvent", retain request instance
-   * @return false if request is already in timeout state.
-   * If request is succesfully retained returns true/
+   * @return false if request is not ready to handle event right now.
+   * If request is succesfully retained returns true
    */
   bool StartOnEventHandling();
 

--- a/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_REQUEST_FROM_HMI_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_REQUEST_FROM_HMI_H_
 
-#include "application_manager/commands/command_impl.h"
+#include "application_manager/commands/command_request_impl.h"
 #include "interfaces/HMI_API.h"
 #include "smart_objects/smart_object.h"
 
@@ -43,7 +43,7 @@ namespace commands {
 
 namespace ns_smart = ns_smart_device_link::ns_smart_objects;
 
-class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
+class RequestFromHMI : public CommandRequestImpl {
  public:
   RequestFromHMI(const MessageSharedPtr& message,
                  ApplicationManager& application_manager,
@@ -54,8 +54,11 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
   virtual bool Init();
   virtual bool CleanUp();
   virtual void Run();
-  virtual void on_event(const event_engine::Event& event);
+
+  void on_event(const event_engine::Event& event);
   void on_event(const event_engine::MobileEvent& event) OVERRIDE;
+  void OnTimeOut() OVERRIDE;
+
   /**
    * @brief SendResponse allows to send response to hmi
    * @param correlation_id the correlation id for the rfesponse.

--- a/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
@@ -94,7 +94,7 @@ class RequestFromHMI : public CommandRequestImpl {
       const mobile_apis::FunctionID::eType& mobile_function_id,
       const hmi_apis::FunctionID::eType& hmi_function_id,
       const smart_objects::SmartObject* msg,
-      bool use_events = false);
+      bool use_events);
 
   void SendMobileRequest(const mobile_apis::FunctionID::eType& function_id,
                          const ApplicationSharedPtr app,

--- a/src/components/application_manager/include/application_manager/commands/request_from_mobile_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/request_from_mobile_impl.h
@@ -1,0 +1,346 @@
+﻿/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_REQUEST_FROM_MOBILE_IMPL_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_REQUEST_FROM_MOBILE_IMPL_H_
+
+#include "application_manager/commands/command_request_impl.h"
+#include "interfaces/HMI_API.h"
+#include "interfaces/MOBILE_API.h"
+#include "smart_objects/smart_object.h"
+#include "utils/lock.h"
+
+namespace application_manager {
+namespace commands {
+
+struct ResponseInfo {
+  ResponseInfo();
+  ResponseInfo(const hmi_apis::Common_Result::eType result,
+               const HmiInterfaces::InterfaceID hmi_interface,
+               ApplicationManager& application_manager);
+  hmi_apis::Common_Result::eType result_code;
+  HmiInterfaces::InterfaceID interface;
+  HmiInterfaces::InterfaceState interface_state;
+  bool is_ok;
+  bool is_unsupported_resource;
+  bool is_not_used;
+};
+
+/**
+ * @brief MergeInfos merge 2 infos in one string
+ * @param first - info string that should be first in result info
+ * @param second - info string that should be second in result info
+ * @return if first is empty return second
+ *         if second is empty return first
+ *         if both are empty return empty string
+ *         if both are not empty return empty first +", " + second
+ */
+std::string MergeInfos(const std::string& first, const std::string& second);
+
+/**
+ * @brief MergeInfos merge 2 infos into one string with info
+ * @param first_info -contains result_code from HMI response and
+ * interface that returns response
+ * @param first_str - info string that should be first in result info
+ * @param second_info -contains result_code from HMI response and
+ * interface that returns response
+ * @param second_str - info string that should be second in result info
+ * @return if first_info is not available and second_str not empty return second
+ *         if second_info is not available and first_str not empty return first
+ *         other cases return result MergeInfos for 2 params
+ */
+std::string MergeInfos(const ResponseInfo& first_info,
+                       const std::string& first_str,
+                       const ResponseInfo& second_info,
+                       const std::string& second_str);
+
+/**
+ * @brief MergeInfos merge 3 infos in one string
+ * @param first - info string that should be first in result info
+ * @param second - info string that should be second in result info
+ * @param third - info string that should be second in result info
+ * @return resulting string contain merge all incoming parameters
+ */
+std::string MergeInfos(const std::string& first,
+                       const std::string& second,
+                       const std::string& third);
+
+class RequestFromMobileImpl : public CommandRequestImpl {
+ public:
+  /**
+   * @brief The HashUpdateMode enum defines whether request has to update
+   * hash after its execution is finished
+   */
+  enum HashUpdateMode { kSkipHashUpdate, kDoHashUpdate };
+
+  RequestFromMobileImpl(const MessageSharedPtr& message,
+                        ApplicationManager& application_manager,
+                        rpc_service::RPCService& rpc_service,
+                        HMICapabilities& hmi_capabilities,
+                        policy::PolicyHandlerInterface& policy_handler);
+
+  /**
+   * @brief RequestFromMobileImpl class destructor
+   *
+   **/
+  virtual ~RequestFromMobileImpl();
+
+  /**
+   * @brief Checks command permissions according to policy table
+   */
+  bool CheckPermissions() OVERRIDE;
+
+  /**
+   * @brief Init sets hash update mode for request
+   */
+  bool Init() OVERRIDE;
+
+  /**
+   * @brief Cleanup all resources used by command
+   **/
+  bool CleanUp() OVERRIDE;
+
+  /**
+   * @brief Execute corresponding command by calling the action on reciever
+   **/
+  void Run() OVERRIDE;
+
+  void on_event(const event_engine::Event& event) OVERRIDE;
+  void on_event(const event_engine::MobileEvent& event) OVERRIDE;
+
+  void OnTimeOut() OVERRIDE;
+
+  void SendProviderRequest(
+      const mobile_apis::FunctionID::eType& mobile_function_id,
+      const hmi_apis::FunctionID::eType& hmi_function_id,
+      const smart_objects::SmartObject* msg,
+      bool use_events = false);
+
+  /*
+   * @brief Creates Mobile response
+   *
+   * @param success true if successful; false, if failed
+   * @param result_code Result code (SUCCESS, INVALID_DATA, e.t.c)
+   * @param info Provides additional human readable info regarding the result
+   * @param response_params Additional params in response
+   */
+  void SendResponse(
+      const bool success,
+      const mobile_apis::Result::eType& result_code,
+      const char* info = NULL,
+      const smart_objects::SmartObject* response_params = NULL,
+      const std::vector<uint8_t> binary_data = std::vector<uint8_t>());
+  /*
+   * @brief Sends HMI request
+   *
+   * @param function_id HMI request ID
+   * @param msg_params HMI request msg params
+   * @param use_events true if we need subscribe on event(HMI request)
+   * @return hmi correlation id
+   */
+  uint32_t SendHMIRequest(const hmi_apis::FunctionID::eType& function_id,
+                          const smart_objects::SmartObject* msg_params = NULL,
+                          bool use_events = false);
+
+  /*
+   * @brief Creates HMI request
+   *
+   * @param function_id HMI request ID
+   * @param msg_params HMI request msg params
+   */
+  void CreateHMINotification(
+      const hmi_apis::FunctionID::eType& function_id,
+      const ns_smart_device_link::ns_smart_objects::SmartObject& msg_params)
+      const;
+
+  /**
+   * @brief Converts HMI result code to Mobile result code
+   *
+   * @param hmi_code HMI result code
+   * @return Mobile result code
+   */
+  mobile_apis::Result::eType GetMobileResultCode(
+      const hmi_apis::Common_Result::eType& hmi_code) const;
+
+ protected:
+  /**
+   * @brief Checks HMI capabilities for specified button support
+   * @param button Button to check
+   * @return true if button is present in HMI capabilities
+   * otherwise returns false
+   */
+  bool CheckHMICapabilities(const mobile_apis::ButtonName::eType button) const;
+
+  /**
+   * @brief Remove from current message parameters disallowed by policy table
+   */
+  void RemoveDisallowedParameters();
+
+  /**
+   * @brief Adds disallowed parameters back to response with appropriate
+   * reasons
+   * @param response Response message, which should be extended with blocked
+   * parameters reasons
+   */
+  void AddDisallowedParameters(smart_objects::SmartObject& response);
+
+  /**
+   * @brief Checks if any request param was marked as disallowed by policy
+   * @return true if any param was marked as disallowed
+   */
+  bool HasDisallowedParams() const;
+
+  /**
+   * @brief Checks result code from HMI for single RPC
+   * and returns parameter for sending to mobile app.
+   * @param result_code contains result code from HMI response
+   * @param interface contains interface for which HMI sent response
+   * @return true if result code complies successful result cods
+   * otherwise returns false.
+   */
+  bool PrepareResultForMobileResponse(
+      hmi_apis::Common_Result::eType result_code,
+      HmiInterfaces::InterfaceID interface) const;
+
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
+  bool PrepareResultForMobileResponse(ResponseInfo& out_first,
+                                      ResponseInfo& out_second) const;
+
+  /**
+   * @brief If message from HMI contains returns this info
+   * or process result code from HMI and checks state of interface
+   * and create info.
+   * @param interface contains interface for which HMI sent response
+   * @param result_code contains result code from HMI
+   * @param response_from_hmi contains response from HMI
+   * @param out_info contain info for sending to application
+   */
+  void GetInfo(const smart_objects::SmartObject& response_from_hmi,
+               std::string& out_info);
+
+  /**
+   * @brief Prepare result code for sending to mobile application
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response.
+   * @return resulting code for sending to mobile application.
+   */
+  mobile_apis::Result::eType PrepareResultCodeForResponse(
+      const ResponseInfo& first, const ResponseInfo& second);
+
+  /**
+   * @brief Resolves if the return code must be
+   * UNSUPPORTED_RESOURCE
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response.
+   * @return True, if the communication return code must be
+   * UNSUPPORTED_RESOURCE, otherwise false.
+   */
+  bool IsResultCodeUnsupported(const ResponseInfo& first,
+                               const ResponseInfo& second) const;
+
+  bool CheckResultCode(const ResponseInfo& first,
+                       const ResponseInfo& second) const;
+
+ protected:
+  /**
+   * @brief Returns policy parameters permissions
+   * @return Parameters permissions struct reference
+   */
+  const CommandParametersPermissions& parameters_permissions() const;
+
+  /**
+   * @brief hash_update_mode_ Defines whether request must update hash value of
+   * application or not
+   */
+  HashUpdateMode hash_update_mode_;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(RequestFromMobileImpl);
+
+  /**
+   * @brief Adds param to disallowed parameters enumeration
+   * @param info string with disallowed params enumeration
+   * @param param disallowed param
+   */
+  void AddDissalowedParameterToInfoString(std::string& info,
+                                          const std::string& param) const;
+
+  /**
+   * @brief Adds disallowed parameters to response info
+   * @param response Response message, which info should be extended
+   */
+  void AddDisallowedParametersToInfo(
+      smart_objects::SmartObject& response) const;
+
+  bool ProcessHMIInterfacesAvailability(
+      const uint32_t hmi_correlation_id,
+      const hmi_apis::FunctionID::eType& function_id);
+
+  /**
+   * @brief UpdateHash updates hash field for application and sends
+   * OnHashChanged notification to mobile side in case of approriate hash mode
+   * is set
+   */
+  void UpdateHash();
+
+  /**
+   * @brief Add information for the component of response in case of timeout
+   * @param response Response message, which info should be extended
+   */
+  void AddTimeOutComponentInfoToMessage(
+      smart_objects::SmartObject& response) const;
+
+  /**
+   * @brief is_success_result_ Defines whether request succeded, at the moment
+   * it is value of 'success' field of appropriate response sent to mobile
+   */
+  bool is_success_result_;
+};
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_COMMANDS_REQUEST_FROM_MOBILE_IMPL_H_

--- a/src/components/application_manager/include/application_manager/commands/request_from_mobile_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/request_from_mobile_impl.h
@@ -143,7 +143,7 @@ class RequestFromMobileImpl : public CommandRequestImpl {
       const mobile_apis::FunctionID::eType& mobile_function_id,
       const hmi_apis::FunctionID::eType& hmi_function_id,
       const smart_objects::SmartObject* msg,
-      bool use_events = false);
+      bool use_events);
 
   /*
    * @brief Creates Mobile response
@@ -224,7 +224,7 @@ class RequestFromMobileImpl : public CommandRequestImpl {
    * and returns parameter for sending to mobile app.
    * @param result_code contains result code from HMI response
    * @param interface contains interface for which HMI sent response
-   * @return true if result code complies successful result cods
+   * @return true if result code complies successful result code
    * otherwise returns false.
    */
   bool PrepareResultForMobileResponse(
@@ -234,9 +234,9 @@ class RequestFromMobileImpl : public CommandRequestImpl {
   /**
    * @brief Checks result code from HMI for splitted RPC
    * and returns parameter for sending to mobile app.
-   * @param first contains result_code from HMI response and
+   * @param out_first contains result_code from HMI response and
    * interface that returns response
-   * @param second contains result_code from HMI response and
+   * @param out_second contains result_code from HMI response and
    * interface that returns response
    * @return true if result code complies successful result code
    * otherwise returns false
@@ -248,13 +248,11 @@ class RequestFromMobileImpl : public CommandRequestImpl {
    * @brief If message from HMI contains returns this info
    * or process result code from HMI and checks state of interface
    * and create info.
-   * @param interface contains interface for which HMI sent response
-   * @param result_code contains result code from HMI
    * @param response_from_hmi contains response from HMI
    * @param out_info contain info for sending to application
    */
   void GetInfo(const smart_objects::SmartObject& response_from_hmi,
-               std::string& out_info);
+               std::string& out_info) const;
 
   /**
    * @brief Prepare result code for sending to mobile application
@@ -280,10 +278,19 @@ class RequestFromMobileImpl : public CommandRequestImpl {
   bool IsResultCodeUnsupported(const ResponseInfo& first,
                                const ResponseInfo& second) const;
 
+  /**
+   * @brief Checks result code from HMI for splitted RPC
+   * and returns parameter for sending to mobile app.
+   * @param first contains result_code from HMI response and
+   * interface that returns response
+   * @param second contains result_code from HMI response and
+   * interface that returns response
+   * @return true if result code complies successful result code
+   * otherwise returns false
+   */
   bool CheckResultCode(const ResponseInfo& first,
                        const ResponseInfo& second) const;
 
- protected:
   /**
    * @brief Returns policy parameters permissions
    * @return Parameters permissions struct reference
@@ -314,6 +321,11 @@ class RequestFromMobileImpl : public CommandRequestImpl {
   void AddDisallowedParametersToInfo(
       smart_objects::SmartObject& response) const;
 
+  /**
+   * @brief Checks if HMI interface is available for the target function
+   * @param hmi_correlation_id HMI correlation id
+   * @param function_id Response message, which info should be extended
+   */
   bool ProcessHMIInterfacesAvailability(
       const uint32_t hmi_correlation_id,
       const hmi_apis::FunctionID::eType& function_id);

--- a/src/components/application_manager/include/application_manager/commands/request_to_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/request_to_hmi.h
@@ -35,6 +35,7 @@
 
 #include "application_manager/application_manager.h"
 #include "application_manager/commands/command_impl.h"
+#include "application_manager/commands/command_request_impl.h"
 
 namespace application_manager {
 
@@ -61,7 +62,7 @@ bool ChangeInterfaceState(ApplicationManager& application_manager,
                           const smart_objects::SmartObject& response_from_hmi,
                           HmiInterfaces::InterfaceID interface);
 
-class RequestToHMI : public CommandImpl {
+class RequestToHMI : public CommandRequestImpl {
  public:
   RequestToHMI(const MessageSharedPtr& message,
                ApplicationManager& application_manager,

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher.h
@@ -64,6 +64,15 @@ class EventDispatcher {
   /*
    * @brief Unsubscribes the observer from specific event
    *
+   * @param event_id    The event ID to subscribe for
+   * @param hmi_correlation_id  The event HMI correlation ID
+   */
+  virtual void remove_observer(const Event::EventID& event_id,
+                               const int32_t hmi_correlation_id) = 0;
+
+  /*
+   * @brief Unsubscribes the observer from specific event
+   *
    * @param event_id    The event ID to unsubscribe from
    * @param observer    The observer to be unsubscribed
    */

--- a/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_dispatcher_impl.h
@@ -83,6 +83,9 @@ class EventDispatcherImpl : public EventDispatcher {
    */
   void raise_event(const Event& event) OVERRIDE;
 
+  void remove_observer(const Event::EventID& event_id,
+                       const int32_t hmi_correlation_id) OVERRIDE;
+
   /*
    * @brief Subscribe the observer to event
    *

--- a/src/components/application_manager/include/application_manager/event_engine/event_observer.h
+++ b/src/components/application_manager/include/application_manager/event_engine/event_observer.h
@@ -70,9 +70,9 @@ class EventObserver {
    *
    * @param event The received event
    */
-  virtual void on_event(const Event& event) = 0;
+  virtual void HandleOnEvent(const Event& event) = 0;
 
-  virtual void on_event(const MobileEvent& event);
+  virtual void HandleOnEvent(const MobileEvent& event);
 
  protected:
   /*

--- a/src/components/application_manager/include/application_manager/hmi_language_handler.h
+++ b/src/components/application_manager/include/application_manager/hmi_language_handler.h
@@ -78,7 +78,7 @@ class HMILanguageHandler : public event_engine::EventObserver {
    */
   hmi_apis::Common_Language::eType get_language_for(Interface interface) const;
 
-  void on_event(const event_engine::Event& event) OVERRIDE;
+  void HandleOnEvent(const event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Trigger waiting for response

--- a/src/components/application_manager/include/application_manager/policies/external/policy_event_observer.h
+++ b/src/components/application_manager/include/application_manager/policies/external/policy_event_observer.h
@@ -47,8 +47,10 @@ class PolicyEventObserver
       policy::PolicyHandlerInterface* const policy_handler,
       application_manager::event_engine::EventDispatcher& event_dispatcher);
   void set_policy_handler(policy::PolicyHandlerInterface* const policy_handler);
-  void on_event(const application_manager::event_engine::Event& event);
-  void on_event(const application_manager::event_engine::MobileEvent& event);
+  void HandleOnEvent(
+      const application_manager::event_engine::Event& event) OVERRIDE;
+  void HandleOnEvent(
+      const application_manager::event_engine::MobileEvent& event) OVERRIDE;
   void subscribe_on_event(
       const application_manager::event_engine::Event::EventID& event_id,
       int32_t hmi_correlation_id = 0);

--- a/src/components/application_manager/include/application_manager/policies/regular/policy_event_observer.h
+++ b/src/components/application_manager/include/application_manager/policies/regular/policy_event_observer.h
@@ -47,8 +47,9 @@ class PolicyEventObserver
       policy::PolicyHandlerInterface* const policy_handler,
       application_manager::event_engine::EventDispatcher& event_dispatcher);
   void set_policy_handler(policy::PolicyHandlerInterface* const policy_handler);
-  void on_event(const application_manager::event_engine::Event& event);
-  void on_event(const application_manager::event_engine::MobileEvent& event);
+  void HandleOnEvent(const application_manager::event_engine::Event& event);
+  void HandleOnEvent(
+      const application_manager::event_engine::MobileEvent& event);
   void subscribe_on_event(
       const application_manager::event_engine::Event::EventID& event_id,
       int32_t hmi_correlation_id = 0);

--- a/src/components/application_manager/include/application_manager/policies/regular/policy_event_observer.h
+++ b/src/components/application_manager/include/application_manager/policies/regular/policy_event_observer.h
@@ -47,9 +47,10 @@ class PolicyEventObserver
       policy::PolicyHandlerInterface* const policy_handler,
       application_manager::event_engine::EventDispatcher& event_dispatcher);
   void set_policy_handler(policy::PolicyHandlerInterface* const policy_handler);
-  void HandleOnEvent(const application_manager::event_engine::Event& event);
   void HandleOnEvent(
-      const application_manager::event_engine::MobileEvent& event);
+      const application_manager::event_engine::Event& event) OVERRIDE;
+  void HandleOnEvent(
+      const application_manager::event_engine::MobileEvent& event) OVERRIDE;
   void subscribe_on_event(
       const application_manager::event_engine::Event::EventID& event_id,
       int32_t hmi_correlation_id = 0);

--- a/src/components/application_manager/include/application_manager/request_info.h
+++ b/src/components/application_manager/include/application_manager/request_info.h
@@ -39,7 +39,7 @@
 #include <stdint.h>
 #include <set>
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "commands/request_to_hmi.h"
 
 #include "utils/date_time.h"
@@ -199,7 +199,7 @@ class RequestInfoSet {
    * @return founded request or shared_ptr with NULL
    */
   RequestInfoPtr Find(const uint32_t connection_key,
-                      const uint32_t correlation_id);
+                      const uint32_t correlation_id) const;
 
   /*
    * @brief Get request with smalest end_time_
@@ -212,6 +212,15 @@ class RequestInfoSet {
    * @return founded request or shared_ptr with NULL
    */
   RequestInfoPtr FrontWithNotNullTimeout();
+
+  /**
+   * @brief GetRequestsByConnectionKey gets all pending requests by provided
+   * connection key
+   * @param connection_key connection key for related requests
+   * @return list of all pending requests for a specified connection key
+   */
+  std::list<RequestInfoPtr> GetRequestsByConnectionKey(
+      const uint32_t connection_key);
 
   /*
    * @brief Erase request from colletion by log(n) time
@@ -269,7 +278,7 @@ class RequestInfoSet {
   TimeSortedRequestInfoSet time_sorted_pending_requests_;
   HashSortedRequestInfoSet hash_sorted_pending_requests_;
 
-  sync_primitives::Lock pending_requests_lock_;
+  mutable sync_primitives::Lock pending_requests_lock_;
 };
 
 /**

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
@@ -79,7 +79,11 @@ class ResumptionDataProcessorImpl
                smart_objects::SmartObject& saved_app,
                ResumeCtrl::ResumptionCallBack callback) override;
 
-  void on_event(const app_mngr::event_engine::Event& event) override;
+  /**
+   * @brief Event, that raised if application get resumption response from HMI
+   * @param event : event object, that contains smart_object with HMI message
+   */
+  void HandleOnEvent(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   void HandleOnTimeOut(const uint32_t correlation_id,
                        const hmi_apis::FunctionID::eType function_id) override;

--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
@@ -79,10 +79,6 @@ class ResumptionDataProcessorImpl
                smart_objects::SmartObject& saved_app,
                ResumeCtrl::ResumptionCallBack callback) override;
 
-  /**
-   * @brief Event, that raised if application get resumption response from HMI
-   * @param event : event object, that contains smart_object with HMI message
-   */
   void HandleOnEvent(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   void HandleOnTimeOut(const uint32_t correlation_id,

--- a/src/components/application_manager/include/application_manager/state_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/state_controller_impl.h
@@ -103,6 +103,10 @@ class StateControllerImpl : public event_engine::EventObserver,
       ApplicationSharedPtr app,
       const mobile_apis::HMILevel::eType default_level) OVERRIDE;
 
+  // EventObserver interface
+  void HandleOnEvent(const event_engine::Event& event) OVERRIDE;
+  void HandleOnEvent(const event_engine::MobileEvent& event) OVERRIDE;
+
   void OnAppWindowAdded(
       ApplicationSharedPtr app,
       const WindowID window_id,
@@ -120,10 +124,6 @@ class StateControllerImpl : public event_engine::EventObserver,
 
   bool IsStateActive(HmiState::StateID state_id) const OVERRIDE;
 
-  // EventObserver interface
-  void on_event(const event_engine::Event& event) OVERRIDE;
-  void on_event(const event_engine::MobileEvent& event) OVERRIDE;
-
   void ActivateDefaultWindow(ApplicationSharedPtr app) OVERRIDE;
   void ExitDefaultWindow(ApplicationSharedPtr app) OVERRIDE;
   void DeactivateApp(ApplicationSharedPtr app,
@@ -139,6 +139,7 @@ class StateControllerImpl : public event_engine::EventObserver,
   int64_t RequestHMIStateChange(ApplicationConstSharedPtr app,
                                 hmi_apis::Common_HMILevel::eType level,
                                 bool send_policy_priority);
+
   /**
    * @brief The HmiLevelConflictResolver struct
    * Move other application to HmiStates if applied moved to FULL or LIMITED

--- a/src/components/application_manager/include/application_manager/system_time/system_time_handler_impl.h
+++ b/src/components/application_manager/include/application_manager/system_time/system_time_handler_impl.h
@@ -70,7 +70,8 @@ class SystemTimeHandlerImpl : public utils::SystemTimeHandler,
    * in order to send system time query and GetSystemTimeResponse in order
    * to retrieve utc time and notify all the listeners with new time value.
    */
-  void on_event(const application_manager::event_engine::Event& event) FINAL;
+  void HandleOnEvent(
+      const application_manager::event_engine::Event& event) FINAL;
 
   /**
    * @brief DoSystemTimeQuery sends the appropriate request to the system

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_get_app_service_data_request_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_get_app_service_data_request_from_hmi.h
@@ -71,7 +71,7 @@ class ASGetAppServiceDataRequestFromHMI
   /**
    * @brief onTimeOut from request controller
    */
-  virtual void onTimeOut();
+  virtual void OnTimeOut();
 
   /**
    * @brief on_event allows to handle events

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_get_app_service_data_request_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_get_app_service_data_request_from_hmi.h
@@ -71,7 +71,7 @@ class ASGetAppServiceDataRequestFromHMI
   /**
    * @brief onTimeOut from request controller
    */
-  virtual void OnTimeOut();
+  void OnTimeOut() FINAL;
 
   /**
    * @brief on_event allows to handle events

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_perform_app_service_interaction_request_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_perform_app_service_interaction_request_from_hmi.h
@@ -86,7 +86,7 @@ class ASPerformAppServiceInteractionRequestFromHMI
   /**
    * @brief onTimeOut from request controller
    */
-  virtual void onTimeOut();
+  virtual void OnTimeOut();
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ASPerformAppServiceInteractionRequestFromHMI);

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_perform_app_service_interaction_request_from_hmi.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/hmi/as_perform_app_service_interaction_request_from_hmi.h
@@ -86,7 +86,7 @@ class ASPerformAppServiceInteractionRequestFromHMI
   /**
    * @brief onTimeOut from request controller
    */
-  virtual void OnTimeOut();
+  void OnTimeOut() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ASPerformAppServiceInteractionRequestFromHMI);

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/get_app_service_data_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/get_app_service_data_request.h
@@ -34,7 +34,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_GET_APP_SERVICE_DATA_REQUEST_H_
 
 #include "app_service_rpc_plugin/app_service_rpc_plugin.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace app_service_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -44,7 +44,8 @@ namespace commands {
 /**
  * @brief GetAppServiceDataRequest command class
  **/
-class GetAppServiceDataRequest : public app_mngr::commands::CommandRequestImpl {
+class GetAppServiceDataRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief GetAppServiceDataRequest class constructor

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/perform_app_service_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/perform_app_service_interaction_request.h
@@ -34,7 +34,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_PERFORM_APP_SERVICE_INTERACTION_REQUEST_H_
 
 #include "app_service_rpc_plugin/app_service_rpc_plugin.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace app_service_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -45,7 +45,7 @@ namespace commands {
  * @brief PerformAppServiceInteractionRequest command class
  **/
 class PerformAppServiceInteractionRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief PerformAppServiceInteractionRequest class constructor

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/publish_app_service_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/publish_app_service_request.h
@@ -34,7 +34,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_PUBLISH_APP_SERVICE_REQUEST_H_
 
 #include "app_service_rpc_plugin/app_service_rpc_plugin.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace app_service_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -44,7 +44,8 @@ namespace commands {
 /**
  * @brief PublishAppServiceRequest command class
  **/
-class PublishAppServiceRequest : public app_mngr::commands::CommandRequestImpl {
+class PublishAppServiceRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief PublishAppServiceRequest class constructor

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/include/app_service_rpc_plugin/commands/mobile/unpublish_app_service_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_APP_SERVICE_RPC_PLUGIN_INCLUDE_APP_SERVICE_RPC_PLUGIN_COMMANDS_MOBILE_UNPUBLISH_APP_SERVICE_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace app_service_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -44,7 +44,7 @@ namespace commands {
  * @brief UnpublishAppServiceRequest command class
  **/
 class UnpublishAppServiceRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief UnpublishAppServiceRequest class constructor

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_get_app_service_data_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_get_app_service_data_request_from_hmi.cc
@@ -275,7 +275,7 @@ void ASGetAppServiceDataRequestFromHMI::on_event(
   }
 }
 
-void ASGetAppServiceDataRequestFromHMI::onTimeOut() {
+void ASGetAppServiceDataRequestFromHMI::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   SendErrorResponse(correlation_id(),
                     hmi_apis::FunctionID::AppService_GetAppServiceData,

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
@@ -149,7 +149,7 @@ void ASPerformAppServiceInteractionRequestFromHMI::on_event(
                application_manager::commands::Command::SOURCE_SDL_TO_HMI);
 }
 
-void ASPerformAppServiceInteractionRequestFromHMI::onTimeOut() {
+void ASPerformAppServiceInteractionRequestFromHMI::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   smart_objects::SmartObject response_params;
   response_params[strings::info] =

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/get_app_service_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/get_app_service_data_request.cc
@@ -50,11 +50,11 @@ GetAppServiceDataRequest::GetAppServiceDataRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 GetAppServiceDataRequest::~GetAppServiceDataRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
@@ -49,11 +49,11 @@ PerformAppServiceInteractionRequest::PerformAppServiceInteractionRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 PerformAppServiceInteractionRequest::~PerformAppServiceInteractionRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/publish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/publish_app_service_request.cc
@@ -51,11 +51,11 @@ PublishAppServiceRequest::PublishAppServiceRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 PublishAppServiceRequest::~PublishAppServiceRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/unpublish_app_service_request.cc
@@ -49,11 +49,11 @@ UnpublishAppServiceRequest::UnpublishAppServiceRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 UnpublishAppServiceRequest::~UnpublishAppServiceRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_get_interior_vehicle_data_request.h
@@ -51,7 +51,7 @@ class RCGetInteriorVehicleDataRequest
       const RCCommandParams& params);
 
   void Run() OVERRIDE;
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
   ~RCGetInteriorVehicleDataRequest();
 };

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/rc_command_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/rc_command_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_COMMANDS_RC_COMMAND_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_RC_RPC_PLUGIN_INCLUDE_RC_RPC_PLUGIN_COMMANDS_RC_COMMAND_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "rc_rpc_plugin/commands/rc_command_params.h"
 #include "rc_rpc_plugin/interior_data_cache.h"
 #include "rc_rpc_plugin/rc_app_extension.h"
@@ -48,7 +48,7 @@ enum TypeAccess { kDisallowed, kAllowed };
 
 namespace commands {
 
-class RCCommandRequest : public app_mngr::commands::CommandRequestImpl {
+class RCCommandRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief RCCommandRequest class constructor
@@ -65,11 +65,11 @@ class RCCommandRequest : public app_mngr::commands::CommandRequestImpl {
 
   virtual ~RCCommandRequest();
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
   void Run() OVERRIDE;
 
-  virtual void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  protected:
   bool is_subscribed;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_pending_resumption_handler.h
@@ -22,7 +22,8 @@ class RCPendingResumptionHandler : public resumption::PendingResumptionHandler {
       application_manager::ApplicationManager& application_manager,
       rc_rpc_plugin::InteriorDataCache& interior_data_cache);
 
-  void on_event(const application_manager::event_engine::Event& event) override;
+  void HandleOnEvent(
+      const application_manager::event_engine::Event& event) override;
 
   void HandleResumptionSubscriptionRequest(
       application_manager::AppExtension& extension,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_request.cc
@@ -57,7 +57,7 @@ void RCGetInteriorVehicleDataRequest::Run() {
   SendRequest();
 }
 
-void RCGetInteriorVehicleDataRequest::onTimeOut() {
+void RCGetInteriorVehicleDataRequest::OnTimeOut() {
   SDL_LOG_TRACE("function_id: " << function_id()
                                 << " correlation_id: " << correlation_id());
   using namespace application_manager;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
@@ -125,7 +125,7 @@ AcquireResult::eType ButtonPressRequest::AcquireResource(
   SDL_LOG_AUTO_TRACE();
   const std::string module_type = ModuleType();
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(RequestFromMobileImpl::connection_key());
 
   return resource_allocation_manager_.AcquireResource(
       module_type, ModuleId(), app->app_id());
@@ -141,8 +141,7 @@ void ButtonPressRequest::SetResourceState(const std::string& module_type,
                                           const ResourceState::eType state) {
   SDL_LOG_AUTO_TRACE();
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
-
+      application_manager_.application(RequestFromMobileImpl::connection_key());
   resource_allocation_manager_.SetResourceState(
       module_type, ModuleId(), app->app_id(), state);
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -317,7 +317,7 @@ void GetInteriorVehicleDataRequest::ProccessSubscription(
       const_cast<smart_objects::SmartObject&>(hmi_response);
 
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(RequestFromMobileImpl::connection_key());
   const auto extension = RCHelpers::GetRCExtension(*app);
   const char* module_type;
   ns_smart_device_link::ns_smart_objects::
@@ -405,8 +405,8 @@ bool GetInteriorVehicleDataRequest::HasRequestExcessiveSubscription() {
           message_params::kSubscribe);
 
   if (is_subscribe_present_in_request) {
-    app_mngr::ApplicationSharedPtr app =
-        application_manager_.application(CommandRequestImpl::connection_key());
+    app_mngr::ApplicationSharedPtr app = application_manager_.application(
+        RequestFromMobileImpl::connection_key());
     const auto extension = RCHelpers::GetRCExtension(*app);
 
     const std::string module_type = ModuleType();

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -372,7 +372,7 @@ AcquireResult::eType SetInteriorVehicleDataRequest::AcquireResource(
   SDL_LOG_AUTO_TRACE();
   const std::string module_type = ModuleType();
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(RequestFromMobileImpl::connection_key());
 
   return resource_allocation_manager_.AcquireResource(
       module_type, ModuleId(), app->app_id());
@@ -387,7 +387,7 @@ void SetInteriorVehicleDataRequest::SetResourceState(
     const std::string& module_type, const ResourceState::eType state) {
   SDL_LOG_AUTO_TRACE();
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(RequestFromMobileImpl::connection_key());
   resource_allocation_manager_.SetResourceState(
       module_type, ModuleId(), app->app_id(), state);
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -31,7 +31,9 @@
  */
 
 #include "rc_rpc_plugin/commands/rc_command_request.h"
+
 #include <sstream>
+
 #include "application_manager/hmi_interfaces.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/policies/policy_handler_interface.h"
@@ -49,7 +51,7 @@ namespace commands {
 RCCommandRequest::RCCommandRequest(
     const app_mngr::commands::MessageSharedPtr& message,
     const RCCommandParams& params)
-    : application_manager::commands::CommandRequestImpl(
+    : application_manager::commands::RequestFromMobileImpl(
           message,
           params.application_manager_,
           params.rpc_service_,
@@ -74,18 +76,18 @@ bool RCCommandRequest::IsInterfaceAvailable(
   return app_mngr::HmiInterfaces::STATE_NOT_AVAILABLE != state;
 }
 
-void RCCommandRequest::onTimeOut() {
+void RCCommandRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   const std::string module_type = ModuleType();
   SetResourceState(module_type, ResourceState::FREE);
-  SendResponse(
-      false, mobile_apis::Result::GENERIC_ERROR, "Request timeout expired");
+
+  RequestFromMobileImpl::OnTimeOut();
 }
 
 bool RCCommandRequest::CheckDriverConsent() {
   SDL_LOG_AUTO_TRACE();
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(connection_key());
 
   const std::string module_type = ModuleType();
   rc_rpc_plugin::TypeAccess access = CheckModule(module_type, app);
@@ -131,7 +133,7 @@ void RCCommandRequest::SendDisallowed(rc_rpc_plugin::TypeAccess access) {
 void RCCommandRequest::Run() {
   SDL_LOG_AUTO_TRACE();
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(connection_key());
 
   if (!IsInterfaceAvailable(app_mngr::HmiInterfaces::HMI_INTERFACE_RC)) {
     SDL_LOG_WARN("HMI interface RC is not available");
@@ -224,19 +226,19 @@ void RCCommandRequest::on_event(const app_mngr::event_engine::Event& event) {
 void RCCommandRequest::ProcessAccessResponse(
     const app_mngr::event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
-  app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+
+  auto app = application_manager_.application(connection_key());
   const std::string module_type = ModuleType();
   const std::string module_id = ModuleId();
+
   if (!app) {
     SDL_LOG_ERROR("NULL pointer.");
     SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED, "");
     return;
   }
 
-  const smart_objects::SmartObject& message = event.smart_object();
-
-  mobile_apis::Result::eType result_code =
+  const auto& message = event.smart_object();
+  const auto result_code =
       GetMobileResultCode(static_cast<hmi_apis::Common_Result::eType>(
           message[app_mngr::strings::params][app_mngr::hmi_response::code]
               .asUInt()));
@@ -323,7 +325,7 @@ void RCCommandRequest::SendGetUserConsent(
     const smart_objects::SmartObject& module_ids) {
   SDL_LOG_AUTO_TRACE();
   app_mngr::ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(connection_key());
   DCHECK(app);
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/rc_pending_resumption_handler.cc
@@ -14,7 +14,7 @@ RCPendingResumptionHandler::RCPendingResumptionHandler(
     , rpc_service_(application_manager.GetRPCService())
     , interior_data_cache_(interior_data_cache) {}
 
-void RCPendingResumptionHandler::on_event(
+void RCPendingResumptionHandler::HandleOnEvent(
     const application_manager::event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
   namespace am_strings = application_manager::strings;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -108,7 +108,7 @@ class RCGetInteriorVehicleDataConsentTest
       , command_holder(app_mngr_)
       , rc_capabilities_(std::make_shared<smart_objects::SmartObject>(
             smart_objects::SmartType::SmartType_Array))
-      , request_controller(mock_request_controler)
+      , request_controller(mock_request_controler, event_dispatcher_)
       , rpc_protection_manager_(
             std::make_shared<application_manager::MockRPCProtectionManager>())
       , rpc_service_(app_mngr_,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/rc_pending_resumption_handler_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/rc_pending_resumption_handler_test.cc
@@ -369,7 +369,7 @@ TEST_F(RCPendingResumptionHandlerTest,
 
   EXPECT_CALL(event_dispatcher_mock_, raise_event(EventCheck(kAppId_2)));
 
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
 }
 
 TEST_F(RCPendingResumptionHandlerTest,
@@ -415,7 +415,7 @@ TEST_F(RCPendingResumptionHandlerTest,
   EXPECT_CALL(mock_rpc_service_,
               ManageHMICommand(MessageCheck(kAppId_2), kSourceHMI));
 
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
 }
 
 }  // namespace rc_rpc_plugin_test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/basic_communication_get_system_time_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/basic_communication_get_system_time_request.h
@@ -61,12 +61,7 @@ class BasicCommunicationGetSystemTimeRequest
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handler);
 
-  /**
-   * @brief onTimeOut allows to handle case when
-   * system does not respond for certain request in
-   * appropriate time window.
-   */
-  void onTimeOut() FINAL;
+  void OnTimeOut() FINAL;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/button_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/button_get_capabilities_request.h
@@ -64,7 +64,7 @@ class ButtonGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ButtonGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/get_system_info_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/get_system_info_request.h
@@ -67,9 +67,9 @@ class GetSystemInfoRequest : public app_mngr::commands::RequestToHMI {
   void Run() OVERRIDE;
 
   /**
-   * @brief onTimeOut from request controller
+   * @brief OnTimeOut from request controller
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(GetSystemInfoRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_audio_start_stream_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_audio_start_stream_request.h
@@ -43,8 +43,7 @@ namespace commands {
 /**
  * @brief AudioStartStreamRequest command class
  **/
-class AudioStartStreamRequest : public app_mngr::commands::RequestToHMI,
-                                public app_mngr::event_engine::EventObserver {
+class AudioStartStreamRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief AudioStartStreamRequest class constructor
@@ -62,10 +61,7 @@ class AudioStartStreamRequest : public app_mngr::commands::RequestToHMI,
    **/
   virtual ~AudioStartStreamRequest();
 
-  /**
-   * @brief onTimeOut from requrst Controller
-   */
-  virtual void onTimeOut();
+  void OnTimeOut() FINAL;
 
   /**
    * @brief Execute command
@@ -75,7 +71,7 @@ class AudioStartStreamRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief On event callback
    **/
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_audio_start_stream_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_audio_start_stream_request.h
@@ -71,7 +71,7 @@ class AudioStartStreamRequest : public app_mngr::commands::RequestToHMI {
   /**
    * @brief On event callback
    **/
-  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_is_ready_request.h
@@ -43,8 +43,7 @@ namespace commands {
 /**
  * @brief NaviIsReadyRequest command class
  **/
-class NaviIsReadyRequest : public app_mngr::commands::RequestToHMI,
-                           public app_mngr::event_engine::EventObserver {
+class NaviIsReadyRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief NaviIsReadyRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_set_video_config_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_set_video_config_request.h
@@ -43,8 +43,7 @@ namespace commands {
 /**
  * @brief NaviSetVideoConfigRequest command class
  **/
-class NaviSetVideoConfigRequest : public app_mngr::commands::RequestToHMI,
-                                  public app_mngr::event_engine::EventObserver {
+class NaviSetVideoConfigRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief NaviSetVideoConfigRequest class constructor
@@ -76,7 +75,7 @@ class NaviSetVideoConfigRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief onTimeOut callback
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviSetVideoConfigRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_start_stream_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_start_stream_request.h
@@ -43,8 +43,7 @@ namespace commands {
 /**
  * @brief NaviStartStreamRequest command class
  **/
-class NaviStartStreamRequest : public app_mngr::commands::RequestToHMI,
-                               public app_mngr::event_engine::EventObserver {
+class NaviStartStreamRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief NaviStartStreamRequest class constructor
@@ -70,12 +69,9 @@ class NaviStartStreamRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief On event callback
    **/
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
-  /**
-   * @brief onTimeOut from requrst Controller
-   */
-  virtual void onTimeOut();
+  void OnTimeOut() FINAL;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_start_stream_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_start_stream_request.h
@@ -69,7 +69,7 @@ class NaviStartStreamRequest : public app_mngr::commands::RequestToHMI {
   /**
    * @brief On event callback
    **/
-  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
   void OnTimeOut() FINAL;
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/navi_subscribe_way_points_request.h
@@ -65,7 +65,7 @@ class NaviSubscribeWayPointsRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(NaviSubscribeWayPointsRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_get_capabilities_request.h
@@ -63,7 +63,7 @@ class RCGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RCGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/rc_is_ready_request.h
@@ -43,8 +43,7 @@ namespace commands {
 /**
  * @brief RCIsReadyRequest command class
  **/
-class RCIsReadyRequest : public app_mngr::commands::RequestToHMI,
-                         public app_mngr::event_engine::EventObserver {
+class RCIsReadyRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief RCIsReadyRequest class constructor
@@ -75,7 +74,7 @@ class RCIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief onTimeOut from requrst Controller
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RCIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/sdl_activate_app_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/sdl_activate_app_request.h
@@ -76,7 +76,7 @@ class SDLActivateAppRequest : public app_mngr::commands::RequestFromHMI {
    * @brief onTimeOut allows to process case when timeout has appeared
    * during request execution.
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
   /**
    * @brief on_event allows to handle events

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_capabilities_request.h
@@ -63,7 +63,7 @@ class TTSGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_language_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_language_request.h
@@ -63,7 +63,7 @@ class TTSGetLanguageRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSGetLanguageRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_supported_languages_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_get_supported_languages_request.h
@@ -65,7 +65,7 @@ class TTSGetSupportedLanguagesRequest
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSGetSupportedLanguagesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_is_ready_request.h
@@ -45,8 +45,7 @@ namespace commands {
 /**
  * @brief TTSIsReadyRequest command class
  **/
-class TTSIsReadyRequest : public app_mngr::commands::RequestToHMI,
-                          public app_mngr::event_engine::EventObserver {
+class TTSIsReadyRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief TTSIsReadyRequest class constructor
@@ -77,7 +76,7 @@ class TTSIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief onTimeOut from requrst Controller
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/tts_set_global_properties_request.h
@@ -67,7 +67,7 @@ class TTSSetGlobalPropertiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TTSSetGlobalPropertiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_command_request.h
@@ -66,7 +66,7 @@ class UIAddCommandRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIAddCommandRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_add_submenu_request.h
@@ -66,7 +66,7 @@ class UIAddSubmenuRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIAddSubmenuRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_create_window_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_create_window_request.h
@@ -55,7 +55,7 @@ class UICreateWindowRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() FINAL;
 
-  void onTimeOut() FINAL;
+  void OnTimeOut() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UICreateWindowRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_capabilities_request.h
@@ -63,7 +63,7 @@ class UIGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_language_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_language_request.h
@@ -63,7 +63,7 @@ class UIGetLanguageRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIGetLanguageRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_supported_languages_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_get_supported_languages_request.h
@@ -64,7 +64,7 @@ class UIGetSupportedLanguagesRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIGetSupportedLanguagesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_is_ready_request.h
@@ -45,8 +45,7 @@ namespace commands {
 /**
  * @brief UIIsReadyRequest command class
  **/
-class UIIsReadyRequest : public app_mngr::commands::RequestToHMI,
-                         public app_mngr::event_engine::EventObserver {
+class UIIsReadyRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief UIIsReadyRequest class constructor
@@ -77,7 +76,7 @@ class UIIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief onTimeOut from requrst Controller
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UIIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/ui_set_global_properties_request.h
@@ -67,7 +67,7 @@ class UISetGlobalPropertiesRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UISetGlobalPropertiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/update_device_list_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/update_device_list_request.h
@@ -46,8 +46,7 @@ namespace commands {
 /**
  * @brief UpdateDeviceListRequest command class
  **/
-class UpdateDeviceListRequest : public app_mngr::commands::RequestToHMI,
-                                public app_mngr::event_engine::EventObserver {
+class UpdateDeviceListRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief UpdateDeviceListRequest class constructor
@@ -76,7 +75,7 @@ class UpdateDeviceListRequest : public app_mngr::commands::RequestToHMI,
    * when HMI will be ready
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Need to stop execution StopMethod if HMI did not started

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_add_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_add_command_request.h
@@ -66,7 +66,7 @@ class VRAddCommandRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRAddCommandRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_capabilities_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_capabilities_request.h
@@ -63,7 +63,7 @@ class VRGetCapabilitiesRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRGetCapabilitiesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_language_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_language_request.h
@@ -63,7 +63,7 @@ class VRGetLanguageRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRGetLanguageRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_supported_languages_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_get_supported_languages_request.h
@@ -64,7 +64,7 @@ class VRGetSupportedLanguagesRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRGetSupportedLanguagesRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/vr_is_ready_request.h
@@ -45,8 +45,7 @@ namespace commands {
 /**
  * @brief VRIsReadyRequest command class
  **/
-class VRIsReadyRequest : public app_mngr::commands::RequestToHMI,
-                         public app_mngr::event_engine::EventObserver {
+class VRIsReadyRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief VRIsReadyRequest class constructor
@@ -77,7 +76,7 @@ class VRIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief onTimeOut from requrst Controller
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VRIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/add_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/add_command_request.h
@@ -37,7 +37,7 @@
 #include <string>
 
 #include "application_manager/application.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -48,7 +48,7 @@ namespace commands {
 /**
  * @brief AddCommandRequest command class
  **/
-class AddCommandRequest : public app_mngr::commands::CommandRequestImpl {
+class AddCommandRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief AddCommandRequest class constructor
@@ -71,18 +71,9 @@ class AddCommandRequest : public app_mngr::commands::CommandRequestImpl {
    **/
   void Run() FINAL;
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
   void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
-  /**
-   * @brief Function is called by RequestController when request execution time
-   * has exceed it's limit
-   */
-  void onTimeOut() FINAL;
+  void OnTimeOut() FINAL;
 
   /**
    * @brief Init sets hash update mode for request
@@ -127,13 +118,6 @@ class AddCommandRequest : public app_mngr::commands::CommandRequestImpl {
 
   DISALLOW_COPY_AND_ASSIGN(AddCommandRequest);
 
-  /*
-   * @brief Check if there some not delivered hmi responses exist
-   *
-   * @return true if all responses received
-   */
-  bool IsPendingResponseExist();
-
   /**
    * @brief Checks add command param
    * When type is String there is a check on the contents \t\n \\t \\n
@@ -150,17 +134,14 @@ class AddCommandRequest : public app_mngr::commands::CommandRequestImpl {
    * @return info for mobile response
    */
   const std::string GenerateMobileResponseInfo();
-  bool send_ui_;
-  bool send_vr_;
-
-  bool is_ui_received_;
-  bool is_vr_received_;
 
   std::string ui_info_;
   std::string vr_info_;
 
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType vr_result_;
+  bool ui_is_sent_;
+  bool vr_is_sent_;
 };
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/add_sub_menu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/add_sub_menu_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ADD_SUB_MENU_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ADD_SUB_MENU_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief AddSubMenuRequest command class
  **/
-class AddSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
+class AddSubMenuRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief AddSubMenuRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/alert_maneuver_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/alert_maneuver_request.h
@@ -34,8 +34,8 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ALERT_MANEUVER_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ALERT_MANEUVER_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
 #include "application_manager/commands/pending.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
 
@@ -47,7 +47,7 @@ namespace commands {
 /**
  * @brief AlertManeuverRequest command class
  **/
-class AlertManeuverRequest : public app_mngr::commands::CommandRequestImpl {
+class AlertManeuverRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief AlertManeuverRequest class constructor
@@ -70,12 +70,7 @@ class AlertManeuverRequest : public app_mngr::commands::CommandRequestImpl {
    **/
   virtual void Run();
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/alert_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/alert_request.h
@@ -36,7 +36,7 @@
 
 #include <string>
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
 
@@ -48,7 +48,7 @@ namespace commands {
 /**
  * @brief AlertRequest command class
  **/
-class AlertRequest : public app_mngr::commands::CommandRequestImpl {
+class AlertRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief AlertRequest class constructor
@@ -76,12 +76,9 @@ class AlertRequest : public app_mngr::commands::CommandRequestImpl {
    **/
   virtual void Run();
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
+
+  void OnTimeOut() FINAL;
 
  protected:
  private:
@@ -116,7 +113,7 @@ class AlertRequest : public app_mngr::commands::CommandRequestImpl {
   /*
    * @brief Tells if there are sent requests without responses
    */
-  bool HasHmiResponsesToWait();
+  bool IsPendingResponseExist();
 
   /*
    * @brief Check if all strings have valid syntax in request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/cancel_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/cancel_interaction_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CANCEL_INTERACTION_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CANCEL_INTERACTION_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "sdl_rpc_plugin/sdl_rpc_plugin.h"
 
 namespace sdl_rpc_plugin {
@@ -44,7 +44,8 @@ namespace commands {
 /**
  * @brief CancelInteractionRequest command class
  **/
-class CancelInteractionRequest : public app_mngr::commands::CommandRequestImpl {
+class CancelInteractionRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief CancelInteractionRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/change_registration_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/change_registration_request.h
@@ -36,8 +36,8 @@
 
 #include <strings.h>
 
-#include "application_manager/commands/command_request_impl.h"
 #include "application_manager/commands/pending.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/custom_string.h"
 #include "utils/macro.h"
 
@@ -52,7 +52,7 @@ namespace custom_str = utils::custom_string;
  * @brief ChangeRegistrationRequest command class
  **/
 class ChangeRegistrationRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief ChangeRegistrationRequest class constructor
@@ -75,12 +75,7 @@ class ChangeRegistrationRequest
    **/
   virtual void Run();
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
  private:
   /*
@@ -103,13 +98,6 @@ class ChangeRegistrationRequest
    * @return true if language supported by TTS, otherwise false
    */
   bool IsLanguageSupportedByTTS(const int32_t& hmi_display_lang);
-
-  /*
-   * @brief Check if there some not delivered hmi responses exist
-   *
-   * @return true if all responses received
-   */
-  bool IsPendingResponseExist();
 
   /**
    * @brief Checks change_registration params(ttsName, appname,
@@ -163,8 +151,6 @@ class ChangeRegistrationRequest
 
     const custom_str::CustomString& newItem_;
   };
-
-  app_mngr::commands::Pending pending_requests_;
 
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType vr_result_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "sdl_rpc_plugin/sdl_rpc_plugin.h"
 
 namespace sdl_rpc_plugin {
@@ -44,7 +44,8 @@ namespace commands {
 /**
  * @brief CloseApplicationRequest command class
  **/
-class CloseApplicationRequest : public app_mngr::commands::CommandRequestImpl {
+class CloseApplicationRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief CloseApplicationRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/create_interaction_choice_set_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/create_interaction_choice_set_request.h
@@ -37,7 +37,7 @@
 #include <string>
 
 #include "application_manager/application.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "application_manager/event_engine/event_observer.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
@@ -53,7 +53,7 @@ namespace commands {
  * @brief CreateInteractionChoiceSetRequest command class
  **/
 class CreateInteractionChoiceSetRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief CreateInteractionChoiceSetRequest class constructor
@@ -77,18 +77,9 @@ class CreateInteractionChoiceSetRequest
    **/
   void Run() FINAL;
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
   void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
-  /**
-   * @brief Function is called by RequestController when request execution time
-   * has exceed it's limit
-   */
-  void onTimeOut() FINAL;
+  void OnTimeOut() FINAL;
 
   /**
    * @brief Init sets hash update mode for request
@@ -136,12 +127,6 @@ class CreateInteractionChoiceSetRequest
    */
   volatile bool error_from_hmi_;
   sync_primitives::Lock error_from_hmi_lock_;
-
-  /**
-   * @brief Flag shows if request already was expired by timeout
-   */
-  volatile bool is_timed_out_;
-  sync_primitives::Lock is_timed_out_lock_;
 
   sync_primitives::RecursiveLock vr_commands_lock_;
   /*

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/create_window_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/create_window_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CREATE_WINDOW_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CREATE_WINDOW_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "application_manager/hmi_state.h"
 #include "utils/macro.h"
 
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief CreateWindow request command class
  **/
-class CreateWindowRequest : public app_mngr::commands::CommandRequestImpl {
+class CreateWindowRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   CreateWindowRequest(const app_mngr::commands::MessageSharedPtr& message,
                       app_mngr::ApplicationManager& application_manager,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_command_request.h
@@ -1,3 +1,4 @@
+
 /*
 
  Copyright (c) 2018, Ford Motor Company
@@ -36,7 +37,7 @@
 
 #include <string>
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -47,7 +48,7 @@ namespace commands {
 /**
  * @brief DeleteCommandRequest command class
  **/
-class DeleteCommandRequest : public app_mngr::commands::CommandRequestImpl {
+class DeleteCommandRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief DeleteCommandRequest class constructor
@@ -70,11 +71,6 @@ class DeleteCommandRequest : public app_mngr::commands::CommandRequestImpl {
    **/
   void Run() FINAL;
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
   void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
   /**
@@ -86,13 +82,6 @@ class DeleteCommandRequest : public app_mngr::commands::CommandRequestImpl {
   DISALLOW_COPY_AND_ASSIGN(DeleteCommandRequest);
 
   /*
-   * @brief Check if there some not delivered hmi responses exist
-   *
-   * @return true if all responses received
-   */
-  bool IsPendingResponseExist();
-
-  /*
    * @brief Prepare result code and result for sending to mobile application
    * @param result_code contains result code for sending to mobile application
    * @param info contains info for mobile app.
@@ -100,12 +89,6 @@ class DeleteCommandRequest : public app_mngr::commands::CommandRequestImpl {
    */
   bool PrepareResponseParameters(mobile_apis::Result::eType& result_code,
                                  std::string& info);
-
-  bool is_ui_send_;
-  bool is_vr_send_;
-
-  bool is_ui_received_;
-  bool is_vr_received_;
 
   hmi_apis::Common_Result::eType ui_result_;
   hmi_apis::Common_Result::eType vr_result_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_command_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_command_request.h
@@ -1,4 +1,3 @@
-
 /*
 
  Copyright (c) 2018, Ford Motor Company

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_file_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_file_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DELETE_FILE_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DELETE_FILE_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -47,7 +47,7 @@ namespace commands {
 /**
  * @brief DeleteFileRequest command class
  **/
-class DeleteFileRequest : public app_mngr::commands::CommandRequestImpl {
+class DeleteFileRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief DeleteFileRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_interaction_choice_set_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_interaction_choice_set_request.h
@@ -36,6 +36,7 @@
 
 #include "application_manager/application.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -47,7 +48,7 @@ namespace commands {
  * @brief DeleteInteractionChoiceSetRequest command class
  **/
 class DeleteInteractionChoiceSetRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief DeleteInteractionChoiceSetRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
@@ -36,6 +36,7 @@
 
 #include "application_manager/application.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -46,7 +47,7 @@ namespace commands {
 /**
  * @brief DeleteSubMenuRequest command class
  **/
-class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
+class DeleteSubMenuRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief DeleteSubMenuRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_window_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_window_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DELETE_WINDOW_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DELETE_WINDOW_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "application_manager/hmi_state.h"
 #include "utils/macro.h"
 
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief CreateWindow request command class
  **/
-class DeleteWindowRequest : public app_mngr::commands::CommandRequestImpl {
+class DeleteWindowRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   DeleteWindowRequest(const app_mngr::commands::MessageSharedPtr& message,
                       app_mngr::ApplicationManager& application_manager,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/dial_number_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/dial_number_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DIAL_NUMBER_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DIAL_NUMBER_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -44,7 +44,7 @@ namespace commands {
 /**
  * @brief DialNumber request command class
  **/
-class DialNumberRequest : public app_mngr::commands::CommandRequestImpl {
+class DialNumberRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief DialNumberRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/end_audio_pass_thru_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/end_audio_pass_thru_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_END_AUDIO_PASS_THRU_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_END_AUDIO_PASS_THRU_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,8 @@ namespace commands {
 /**
  * @brief EndAudioPassThruRequest command class
  **/
-class EndAudioPassThruRequest : public app_mngr::commands::CommandRequestImpl {
+class EndAudioPassThruRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief EndAudioPassThruRequest class constructor
@@ -73,7 +74,7 @@ class EndAudioPassThruRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(EndAudioPassThruRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_cloud_app_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_cloud_app_properties_request.h
@@ -1,7 +1,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_CLOUD_APP_PROPERTIES_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_CLOUD_APP_PROPERTIES_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -9,7 +9,7 @@ namespace app_mngr = application_manager;
 namespace commands {
 
 class GetCloudAppPropertiesRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   GetCloudAppPropertiesRequest(
       const app_mngr::commands::MessageSharedPtr& message,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_file_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_file_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_FILE_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_FILE_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "application_manager/event_engine/event.h"
 
 namespace sdl_rpc_plugin {
@@ -44,7 +44,7 @@ namespace commands {
 /**
  * @brief GetFileRequest command class
  **/
-class GetFileRequest : public app_mngr::commands::CommandRequestImpl {
+class GetFileRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief GetFileRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_system_capability_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_system_capability_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_SYSTEM_CAPABILITY_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_SYSTEM_CAPABILITY_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -42,7 +42,7 @@ namespace app_mngr = application_manager;
 namespace commands {
 
 class GetSystemCapabilityRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   GetSystemCapabilityRequest(
       const app_mngr::commands::MessageSharedPtr& message,
@@ -55,7 +55,7 @@ class GetSystemCapabilityRequest
 
   virtual void Run() OVERRIDE;
 
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(GetSystemCapabilityRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/get_way_points_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_WAY_POINTS_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_WAY_POINTS_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -43,7 +43,7 @@ namespace commands {
 /**
  * @brief GetWayPointsRequest command class
  **/
-class GetWayPointsRequest : public app_mngr::commands::CommandRequestImpl {
+class GetWayPointsRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief GetWayPointsRequest class constructor
@@ -63,12 +63,8 @@ class GetWayPointsRequest : public app_mngr::commands::CommandRequestImpl {
    * @brief Execute command
    **/
   virtual void Run() OVERRIDE;
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(GetWayPointsRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/list_files_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/list_files_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_LIST_FILES_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_LIST_FILES_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief ListFilesRequest command class
  **/
-class ListFilesRequest : public app_mngr::commands::CommandRequestImpl {
+class ListFilesRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief ListFilesRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_audio_pass_thru_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_audio_pass_thru_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_PERFORM_AUDIO_PASS_THRU_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_PERFORM_AUDIO_PASS_THRU_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
 
@@ -47,7 +47,7 @@ namespace commands {
  * @brief PerformAudioPassThruRequest command class
  **/
 class PerformAudioPassThruRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief PerformAudioPassThruRequest class constructor
@@ -67,13 +67,6 @@ class PerformAudioPassThruRequest
   virtual ~PerformAudioPassThruRequest();
 
   /**
-   * @brief Function is called by RequestController when request execution time
-   * has exceed it's limit
-   *
-   */
-  virtual void onTimeOut();
-
-  /**
    * @brief Init required by command resources
    **/
   bool Init();
@@ -83,12 +76,14 @@ class PerformAudioPassThruRequest
    **/
   virtual void Run();
 
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
+
   /**
-   * @brief Interface method that is called whenever new event received
+   * @brief Function is called by RequestController when request execution time
+   * has exceed it's limit
    *
-   * @param event The received event
    */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void OnTimeOut() FINAL;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
@@ -38,6 +38,7 @@
 
 #include "application_manager/application.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -51,7 +52,7 @@ namespace commands {
  * @brief PerformInteractionRequest command class
  **/
 class PerformInteractionRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief PerformInteractionRequest class constructor
@@ -79,19 +80,9 @@ class PerformInteractionRequest
    **/
   virtual void Run();
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
-  /*
-   * @brief Function is called by RequestController when request execution time
-   * has exceed it's limit
-   *
-   */
-  virtual void onTimeOut();
+  void OnTimeOut() FINAL;
 
  protected:
   /**
@@ -277,11 +268,10 @@ class PerformInteractionRequest
       smart_objects::SmartObject& msg_param) const;
 
   mobile_apis::InteractionMode::eType interaction_mode_;
+
   std::int32_t ui_choice_id_received_;
   std::int32_t vr_choice_id_received_;
 
-  bool ui_response_received_;
-  bool vr_response_received_;
   bool app_pi_was_active_before_;
   static uint32_t pi_requests_count_;
   hmi_apis::Common_Result::eType vr_result_code_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/put_file_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/put_file_request.h
@@ -36,6 +36,7 @@
 
 #include "application_manager/application_manager.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -46,7 +47,7 @@ namespace commands {
 /**
  * @brief PutFileRequest command class
  **/
-class PutFileRequest : public app_mngr::commands::CommandRequestImpl {
+class PutFileRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief PutFileRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_REGISTER_APP_INTERFACE_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_REGISTER_APP_INTERFACE_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "application_manager/policies/policy_handler_interface.h"
 #include "utils/custom_string.h"
 #include "utils/macro.h"
@@ -56,7 +56,7 @@ namespace custom_str = utils::custom_string;
  * @brief Register app interface request  command class
  **/
 class RegisterAppInterfaceRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief RegisterAppInterfaceRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/reset_global_properties_request.h
@@ -35,7 +35,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_RESET_GLOBAL_PROPERTIES_REQUEST_H_
 
 #include "application_manager/application.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -47,7 +47,7 @@ namespace commands {
  * @brief ResetGlobalPropertiesRequest command class
  **/
 class ResetGlobalPropertiesRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief ResetGlobalPropertiesRequest class constructor
@@ -71,11 +71,6 @@ class ResetGlobalPropertiesRequest
    **/
   void Run() FINAL;
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   *
-   * @param event The received event
-   */
   void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
   /**
@@ -93,13 +88,6 @@ class ResetGlobalPropertiesRequest
    */
   bool PrepareResponseParameters(mobile_apis::Result::eType& out_result_code,
                                  std::string& out_response_info);
-
-  /*
-   * @brief Check if there some not delivered hmi responses exist
-   *
-   * @return true if all responses received
-   */
-  bool IsPendingResponseExist();
 
   DISALLOW_COPY_AND_ASSIGN(ResetGlobalPropertiesRequest);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/scrollable_message_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/scrollable_message_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SCROLLABLE_MESSAGE_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SCROLLABLE_MESSAGE_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
 
@@ -46,7 +46,8 @@ namespace commands {
 /**
  * @brief scrollable message request command class
  **/
-class ScrollableMessageRequest : public app_mngr::commands::CommandRequestImpl {
+class ScrollableMessageRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief ScrollableMessageRequest class constructor
@@ -77,7 +78,7 @@ class ScrollableMessageRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ScrollableMessageRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/send_haptic_data_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/send_haptic_data_request.h
@@ -34,8 +34,9 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SEND_HAPTIC_DATA_REQUEST_H_
 
 #include <string>
+
 #include "application_manager/application_manager.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "application_manager/event_engine/event.h"
 #include "smart_objects/smart_object.h"
 
@@ -47,7 +48,7 @@ namespace commands {
 /**
  * @brief SendHapticDataRequest command class
  **/
-class SendHapticDataRequest : public app_mngr::commands::CommandRequestImpl {
+class SendHapticDataRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SendHapticDataRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/send_location_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/send_location_request.h
@@ -35,7 +35,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SEND_LOCATION_REQUEST_H_
 
 #include <list>
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief send location request command class
  */
-class SendLocationRequest : public app_mngr::commands::CommandRequestImpl {
+class SendLocationRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SendLocationRquest class constructor
@@ -71,7 +71,7 @@ class SendLocationRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_app_icon_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_app_icon_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_APP_ICON_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_APP_ICON_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief SetIconRequest command class
  **/
-class SetAppIconRequest : public app_mngr::commands::CommandRequestImpl {
+class SetAppIconRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief Contains information about the type of image
@@ -73,7 +73,7 @@ class SetAppIconRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_cloud_app_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_cloud_app_properties_request.h
@@ -1,7 +1,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_CLOUD_APP_PROPERTIES_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_CLOUD_APP_PROPERTIES_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -9,7 +9,7 @@ namespace app_mngr = application_manager;
 namespace commands {
 
 class SetCloudAppPropertiesRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   SetCloudAppPropertiesRequest(
       const app_mngr::commands::MessageSharedPtr& message,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_display_layout_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_display_layout_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_DISPLAY_LAYOUT_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_DISPLAY_LAYOUT_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,8 @@ namespace commands {
 /**
  * @brief SetDisplayLayoutRequest command class
  **/
-class SetDisplayLayoutRequest : public app_mngr::commands::CommandRequestImpl {
+class SetDisplayLayoutRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SetDisplayLayoutRequest class constructor
@@ -68,7 +69,7 @@ class SetDisplayLayoutRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    **/
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_global_properties_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_global_properties_request.h
@@ -33,8 +33,9 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_GLOBAL_PROPERTIES_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_GLOBAL_PROPERTIES_REQUEST_H_
 #include <string>
+
 #include "application_manager/application.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -46,7 +47,7 @@ namespace commands {
  * @brief Register app interface request  command class
  **/
 class SetGlobalPropertiesRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SetGlobalPropertiesRequest class constructor
@@ -82,7 +83,7 @@ class SetGlobalPropertiesRequest
    */
   bool Init() FINAL;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
   /**
    * @brief Prepares total result for mobile according to three results:

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_media_clock_timer_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/set_media_clock_timer_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_MEDIA_CLOCK_TIMER_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SET_MEDIA_CLOCK_TIMER_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief SetMediaClockRequest request command class
  **/
-class SetMediaClockRequest : public app_mngr::commands::CommandRequestImpl {
+class SetMediaClockRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief SetMediaClockRequest class constructor
@@ -71,7 +71,7 @@ class SetMediaClockRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   bool isDataValid();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/show_app_menu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/show_app_menu_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SHOW_APP_MENU_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SHOW_APP_MENU_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -43,7 +43,7 @@ namespace commands {
 /**
  * @brief ShowAppMenuRequest command class
  **/
-class ShowAppMenuRequest : public app_mngr::commands::CommandRequestImpl {
+class ShowAppMenuRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief ShowAppMenuRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/show_constant_tbt_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/show_constant_tbt_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SHOW_CONSTANT_TBT_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SHOW_CONSTANT_TBT_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
 
@@ -46,7 +46,8 @@ namespace commands {
 /**
  * @brief ShowConstantTBTRequest command class
  **/
-class ShowConstantTBTRequest : public app_mngr::commands::CommandRequestImpl {
+class ShowConstantTBTRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief ShowConstantTBTRequest class constructor
@@ -74,7 +75,7 @@ class ShowConstantTBTRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/show_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/show_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SHOW_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SHOW_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
 
@@ -46,7 +46,7 @@ namespace commands {
 /**
  * @brief show request command class
  **/
-class ShowRequest : public app_mngr::commands::CommandRequestImpl {
+class ShowRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief ShowRequest class constructor
@@ -72,7 +72,7 @@ class ShowRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /*

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/slider_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/slider_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SLIDER_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SLIDER_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief slider request command class
  **/
-class SliderRequest : public app_mngr::commands::CommandRequestImpl {
+class SliderRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief SliderRequest class constructor
@@ -76,7 +76,7 @@ class SliderRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/speak_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/speak_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SPEAK_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SPEAK_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief speak request command class
  **/
-class SpeakRequest : public app_mngr::commands::CommandRequestImpl {
+class SpeakRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief SpeakRequest class constructor
@@ -71,7 +71,7 @@ class SpeakRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /*

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_button_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_button_request.h
@@ -35,7 +35,7 @@
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBSCRIBE_BUTTON_REQUEST_H_
 
 #include "application_manager/application_impl.h"
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -46,7 +46,8 @@ namespace commands {
 /**
  * @brief SubscribeButtonRequest command class
  **/
-class SubscribeButtonRequest : public app_mngr::commands::CommandRequestImpl {
+class SubscribeButtonRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SubscribeButtonRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBSCRIBE_WAY_POINTS_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBSCRIBE_WAY_POINTS_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -44,7 +44,7 @@ namespace commands {
  * @brief SubsribeWayPointsRequest command class
  **/
 class SubscribeWayPointsRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief SubscribeWayPointsRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h
@@ -76,7 +76,7 @@ class SubscribeWayPointsRequest
    */
   bool Init() FINAL;
 
-  void onTimeOut() FINAL;
+  void OnTimeOut() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(SubscribeWayPointsRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subtle_alert_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/subtle_alert_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBTLE_ALERT_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_SUBTLE_ALERT_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "sdl_rpc_plugin/sdl_rpc_plugin.h"
 
 namespace sdl_rpc_plugin {
@@ -44,7 +44,7 @@ namespace commands {
 /**
  * @brief SubtleAlertRequest command class
  **/
-class SubtleAlertRequest : public app_mngr::commands::CommandRequestImpl {
+class SubtleAlertRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SubtleAlertRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/system_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/system_request.h
@@ -37,6 +37,7 @@
 #include <string>
 #include "application_manager/application_manager.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "application_manager/event_engine/event.h"
 #include "smart_objects/smart_object.h"
 
@@ -48,7 +49,7 @@ namespace commands {
 /**
  * @brief SystemRequest command class
  **/
-class SystemRequest : public app_mngr::commands::CommandRequestImpl {
+class SystemRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SystemRequest class constructor
@@ -76,7 +77,7 @@ class SystemRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unregister_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unregister_app_interface_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UNREGISTER_APP_INTERFACE_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UNREGISTER_APP_INTERFACE_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -46,7 +46,7 @@ namespace commands {
  * @brief Unregister app interface request  command class
  **/
 class UnregisterAppInterfaceRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief UnregisterAppInterfaceRequest class constructor
@@ -57,11 +57,11 @@ class UnregisterAppInterfaceRequest
       app_mngr::rpc_service::RPCService& rpc_service,
       app_mngr::HMICapabilities& hmi_capabilities,
       policy::PolicyHandlerInterface& policy_handler)
-      : CommandRequestImpl(message,
-                           application_manager,
-                           rpc_service,
-                           hmi_capabilities,
-                           policy_handler) {}
+      : RequestFromMobileImpl(message,
+                              application_manager,
+                              rpc_service,
+                              hmi_capabilities,
+                              policy_handler) {}
 
   /**
    * \brief UnregisterAppInterfaceRequest class destructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_button_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_button_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UNSUBSCRIBE_BUTTON_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UNSUBSCRIBE_BUTTON_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 
 namespace sdl_rpc_plugin {
@@ -45,7 +45,8 @@ namespace commands {
 /**
  * @brief UnsubscribeButtonRequest command class
  **/
-class UnsubscribeButtonRequest : public app_mngr::commands::CommandRequestImpl {
+class UnsubscribeButtonRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief UnsubscribeButtonRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
@@ -33,7 +33,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UNSUBSCRIBE_WAY_POINTS_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UNSUBSCRIBE_WAY_POINTS_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 
 namespace sdl_rpc_plugin {
 namespace app_mngr = application_manager;
@@ -41,7 +41,7 @@ namespace app_mngr = application_manager;
 namespace commands {
 
 class UnsubscribeWayPointsRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * \brief UnsubscribeWayPointsRequest class constructor

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h
@@ -75,7 +75,7 @@ class UnsubscribeWayPointsRequest
    */
   bool Init() FINAL;
 
-  void onTimeOut() FINAL;
+  void OnTimeOut() FINAL;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(UnsubscribeWayPointsRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/update_turn_list_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/update_turn_list_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UPDATE_TURN_LIST_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_UPDATE_TURN_LIST_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "interfaces/MOBILE_API.h"
 #include "utils/macro.h"
 
@@ -46,7 +46,7 @@ namespace commands {
 /**
  * @brief UpdateTurnListRequest command class
  **/
-class UpdateTurnListRequest : public app_mngr::commands::CommandRequestImpl {
+class UpdateTurnListRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief UpdateTurnListRequest class constructor
@@ -74,7 +74,7 @@ class UpdateTurnListRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/waypoints_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/waypoints_pending_resumption_handler.h
@@ -47,7 +47,7 @@ class WayPointsPendingResumptionHandler
       app_mngr::ApplicationManager& application_manager);
 
   // EventObserver interface
-  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+  void HandleOnEvent(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   void HandleResumptionSubscriptionRequest(
       app_mngr::AppExtension& extension,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/basic_communication_get_system_time_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/basic_communication_get_system_time_request.cc
@@ -51,7 +51,7 @@ BasicCommunicationGetSystemTimeRequest::BasicCommunicationGetSystemTimeRequest(
                    hmi_capabilities,
                    policy_handler) {}
 
-void BasicCommunicationGetSystemTimeRequest::onTimeOut() {
+void BasicCommunicationGetSystemTimeRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   application_manager_.protocol_handler().NotifyOnGetSystemTimeFailed();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/button_get_capabilities_request.h"
+
 #include "utils/logger.h"
 
 namespace sdl_rpc_plugin {
@@ -60,7 +61,7 @@ void ButtonGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
-void ButtonGetCapabilitiesRequest::onTimeOut() {
+void ButtonGetCapabilitiesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::Buttons_GetCapabilities);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_request.cc
@@ -61,7 +61,7 @@ void GetSystemInfoRequest::Run() {
   SendRequest();
 }
 
-void GetSystemInfoRequest::onTimeOut() {
+void GetSystemInfoRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateCachedCapabilities();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_audio_start_stream_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_audio_start_stream_request.cc
@@ -53,7 +53,6 @@ AudioStartStreamRequest::AudioStartStreamRequest(
                    rpc_service,
                    hmi_capabilities,
                    policy_handle)
-    , EventObserver(application_manager.event_dispatcher())
     , retry_number_(0) {
   SDL_LOG_AUTO_TRACE();
   std::pair<uint32_t, int32_t> stream_retry =
@@ -136,7 +135,7 @@ void AudioStartStreamRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void AudioStartStreamRequest::onTimeOut() {
+void AudioStartStreamRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   RetryStartSession();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_is_ready_request.cc
@@ -49,8 +49,7 @@ NaviIsReadyRequest::NaviIsReadyRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle)
-    , EventObserver(application_manager.event_dispatcher()) {}
+                   policy_handle) {}
 
 NaviIsReadyRequest::~NaviIsReadyRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_set_video_config_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_set_video_config_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/hmi/navi_set_video_config_request.h"
+
 #include <string>
 #include <vector>
 
@@ -51,8 +52,7 @@ NaviSetVideoConfigRequest::NaviSetVideoConfigRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle)
-    , EventObserver(application_manager.event_dispatcher()) {}
+                   policy_handle) {}
 
 NaviSetVideoConfigRequest::~NaviSetVideoConfigRequest() {}
 
@@ -132,7 +132,7 @@ void NaviSetVideoConfigRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void NaviSetVideoConfigRequest::onTimeOut() {
+void NaviSetVideoConfigRequest::OnTimeOut() {
   SDL_LOG_WARN("Timed out while waiting for SetVideoConfig response");
 
   ApplicationSharedPtr app =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_start_stream_request.cc
@@ -53,7 +53,6 @@ NaviStartStreamRequest::NaviStartStreamRequest(
                    rpc_service,
                    hmi_capabilities,
                    policy_handle)
-    , EventObserver(application_manager.event_dispatcher())
     , retry_number_(0) {
   SDL_LOG_AUTO_TRACE();
   std::pair<uint32_t, int32_t> stream_retry =
@@ -138,7 +137,7 @@ void NaviStartStreamRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void NaviStartStreamRequest::onTimeOut() {
+void NaviStartStreamRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   RetryStartSession();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/navi_subscribe_way_points_request.cc
@@ -60,7 +60,7 @@ void NaviSubscribeWayPointsRequest::Run() {
   SendRequest();
 }
 
-void NaviSubscribeWayPointsRequest::onTimeOut() {
+void NaviSubscribeWayPointsRequest::OnTimeOut() {
   auto& resume_ctrl = application_manager_.resume_controller();
 
   resume_ctrl.HandleOnTimeOut(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void RCGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
-void RCGetCapabilitiesRequest::onTimeOut() {
+void RCGetCapabilitiesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::RC_GetCapabilities);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_is_ready_request.cc
@@ -53,8 +53,7 @@ RCIsReadyRequest::RCIsReadyRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle)
-    , EventObserver(application_manager.event_dispatcher()) {}
+                   policy_handle) {}
 
 RCIsReadyRequest::~RCIsReadyRequest() {}
 
@@ -97,7 +96,7 @@ void RCIsReadyRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void RCIsReadyRequest::onTimeOut() {
+void RCIsReadyRequest::OnTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
   RequestInterfaceCapabilities(hmi_interface::rc);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/sdl_activate_app_request.cc
@@ -272,7 +272,7 @@ void SDLActivateAppRequest::Run() {
 }
 
 #endif  // EXTERNAL_PROPRIETARY_MODE
-void SDLActivateAppRequest::onTimeOut() {
+void SDLActivateAppRequest::OnTimeOut() {
   using namespace hmi_apis::FunctionID;
   using namespace hmi_apis::Common_Result;
   using namespace application_manager;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void TTSGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
-void TTSGetCapabilitiesRequest::onTimeOut() {
+void TTSGetCapabilitiesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetCapabilities);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_request.cc
@@ -59,7 +59,7 @@ void TTSGetLanguageRequest::Run() {
   SendRequest();
 }
 
-void TTSGetLanguageRequest::onTimeOut() {
+void TTSGetLanguageRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetLanguage);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_request.cc
@@ -59,7 +59,7 @@ void TTSGetSupportedLanguagesRequest::Run() {
   SendRequest();
 }
 
-void TTSGetSupportedLanguagesRequest::onTimeOut() {
+void TTSGetSupportedLanguagesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::TTS_GetSupportedLanguages);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_is_ready_request.cc
@@ -50,8 +50,7 @@ TTSIsReadyRequest::TTSIsReadyRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handler)
-    , EventObserver(application_manager.event_dispatcher()) {}
+                   policy_handler) {}
 
 TTSIsReadyRequest::~TTSIsReadyRequest() {}
 
@@ -90,7 +89,7 @@ void TTSIsReadyRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void TTSIsReadyRequest::onTimeOut() {
+void TTSIsReadyRequest::OnTimeOut() {
   // Note(dtrunov): According to new requirment  APPLINK-27956
   RequestInterfaceCapabilities(hmi_interface::tts);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_set_global_properties_request.cc
@@ -60,7 +60,7 @@ void TTSSetGlobalPropertiesRequest::Run() {
   SendRequest();
 }
 
-void TTSSetGlobalPropertiesRequest::onTimeOut() {
+void TTSSetGlobalPropertiesRequest::OnTimeOut() {
   auto& resume_ctrl = application_manager_.resume_controller();
   resume_ctrl.HandleOnTimeOut(
       correlation_id(),

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_command_request.cc
@@ -60,7 +60,7 @@ void UIAddCommandRequest::Run() {
   SendRequest();
 }
 
-void UIAddCommandRequest::onTimeOut() {
+void UIAddCommandRequest::OnTimeOut() {
   auto& resume_ctrl = application_manager_.resume_controller();
 
   resume_ctrl.HandleOnTimeOut(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_submenu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_add_submenu_request.cc
@@ -60,7 +60,7 @@ void UIAddSubmenuRequest::Run() {
   SendRequest();
 }
 
-void UIAddSubmenuRequest::onTimeOut() {
+void UIAddSubmenuRequest::OnTimeOut() {
   auto& resume_ctrl = application_manager_.resume_controller();
   resume_ctrl.HandleOnTimeOut(
       correlation_id(),

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_create_window_request.cc
@@ -60,7 +60,7 @@ void UICreateWindowRequest::Run() {
   SendRequest();
 }
 
-void UICreateWindowRequest::onTimeOut() {
+void UICreateWindowRequest::OnTimeOut() {
   auto& resume_ctrl = application_manager_.resume_controller();
 
   resume_ctrl.HandleOnTimeOut(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void UIGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
-void UIGetCapabilitiesRequest::onTimeOut() {
+void UIGetCapabilitiesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetCapabilities);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_request.cc
@@ -59,7 +59,7 @@ void UIGetLanguageRequest::Run() {
   SendRequest();
 }
 
-void UIGetLanguageRequest::onTimeOut() {
+void UIGetLanguageRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetLanguage);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_request.cc
@@ -59,7 +59,7 @@ void UIGetSupportedLanguagesRequest::Run() {
   SendRequest();
 }
 
-void UIGetSupportedLanguagesRequest::onTimeOut() {
+void UIGetSupportedLanguagesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::UI_GetSupportedLanguages);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_is_ready_request.cc
@@ -50,8 +50,7 @@ UIIsReadyRequest::UIIsReadyRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle)
-    , EventObserver(application_manager.event_dispatcher()) {}
+                   policy_handle) {}
 
 UIIsReadyRequest::~UIIsReadyRequest() {}
 
@@ -89,7 +88,7 @@ void UIIsReadyRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void UIIsReadyRequest::onTimeOut() {
+void UIIsReadyRequest::OnTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
   RequestInterfaceCapabilities(hmi_interface::ui);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_set_global_properties_request.cc
@@ -60,7 +60,7 @@ void UISetGlobalPropertiesRequest::Run() {
   SendRequest();
 }
 
-void UISetGlobalPropertiesRequest::onTimeOut() {
+void UISetGlobalPropertiesRequest::OnTimeOut() {
   auto& resume_ctrl = application_manager_.resume_controller();
   resume_ctrl.HandleOnTimeOut(
       correlation_id(),

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/update_device_list_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/update_device_list_request.cc
@@ -53,8 +53,7 @@ UpdateDeviceListRequest::UpdateDeviceListRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle)
-    , EventObserver(application_manager_.event_dispatcher()) {}
+                   policy_handle) {}
 
 UpdateDeviceListRequest::~UpdateDeviceListRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_add_command_request.cc
@@ -60,7 +60,7 @@ void VRAddCommandRequest::Run() {
   SendRequest();
 }
 
-void VRAddCommandRequest::onTimeOut() {
+void VRAddCommandRequest::OnTimeOut() {
   auto& resume_ctrl = application_manager_.resume_controller();
 
   resume_ctrl.HandleOnTimeOut(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_request.cc
@@ -59,7 +59,7 @@ void VRGetCapabilitiesRequest::Run() {
   SendRequest();
 }
 
-void VRGetCapabilitiesRequest::onTimeOut() {
+void VRGetCapabilitiesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetCapabilities);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_request.cc
@@ -59,7 +59,7 @@ void VRGetLanguageRequest::Run() {
   SendRequest();
 }
 
-void VRGetLanguageRequest::onTimeOut() {
+void VRGetLanguageRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetLanguage);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_request.cc
@@ -59,7 +59,7 @@ void VRGetSupportedLanguagesRequest::Run() {
   SendRequest();
 }
 
-void VRGetSupportedLanguagesRequest::onTimeOut() {
+void VRGetSupportedLanguagesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetSupportedLanguages);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_is_ready_request.cc
@@ -50,8 +50,7 @@ VRIsReadyRequest::VRIsReadyRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle)
-    , EventObserver(application_manager.event_dispatcher()) {}
+                   policy_handle) {}
 
 VRIsReadyRequest::~VRIsReadyRequest() {}
 
@@ -90,7 +89,7 @@ void VRIsReadyRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void VRIsReadyRequest::onTimeOut() {
+void VRIsReadyRequest::OnTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
   RequestInterfaceCapabilities(hmi_interface::vr);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_command_request.cc
@@ -32,6 +32,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/mobile/add_command_request.h"
+
 #include <string>
 
 #include "application_manager/application.h"
@@ -56,24 +57,22 @@ AddCommandRequest::AddCommandRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
-    , send_ui_(false)
-    , send_vr_(false)
-    , is_ui_received_(false)
-    , is_vr_received_(false)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , ui_result_(hmi_apis::Common_Result::INVALID_ENUM)
-    , vr_result_(hmi_apis::Common_Result::INVALID_ENUM) {}
+    , vr_result_(hmi_apis::Common_Result::INVALID_ENUM)
+    , ui_is_sent_(false)
+    , vr_is_sent_(false) {}
 
 AddCommandRequest::~AddCommandRequest() {}
 
-void AddCommandRequest::onTimeOut() {
+void AddCommandRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   RemoveCommand();
-  CommandRequestImpl::onTimeOut();
+  RequestFromMobileImpl::OnTimeOut();
 }
 
 bool AddCommandRequest::Init() {
@@ -174,6 +173,7 @@ void AddCommandRequest::Run() {
 
   smart_objects::SmartObject ui_msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
+
   if ((*message_)[strings::msg_params].keyExists(strings::menu_params)) {
     ui_msg_params[strings::cmd_id] =
         (*message_)[strings::msg_params][strings::cmd_id];
@@ -191,7 +191,8 @@ void AddCommandRequest::Run() {
           (*message_)[strings::msg_params][strings::cmd_icon];
     }
 
-    send_ui_ = true;
+    ui_is_sent_ = true;
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
   }
 
   smart_objects::SmartObject vr_msg_params =
@@ -206,16 +207,15 @@ void AddCommandRequest::Run() {
     vr_msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
     vr_msg_params[strings::grammar_id] = app->get_grammar_id();
 
-    send_vr_ = true;
+    vr_is_sent_ = true;
+    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
   }
 
-  if (send_ui_) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI)) {
     SendHMIRequest(hmi_apis::FunctionID::UI_AddCommand, &ui_msg_params, true);
   }
 
-  if (send_vr_) {
-    StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
+  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_VR)) {
     SendHMIRequest(hmi_apis::FunctionID::VR_AddCommand, &vr_msg_params, true);
   }
 }
@@ -342,7 +342,6 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::UI_AddCommand: {
       SDL_LOG_INFO("Received UI_AddCommand event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
-      is_ui_received_ = true;
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       GetInfo(message, ui_info_);
@@ -354,7 +353,6 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::VR_AddCommand: {
       SDL_LOG_INFO("Received VR_AddCommand event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
-      is_vr_received_ = true;
       vr_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       GetInfo(message, vr_info_);
@@ -370,6 +368,7 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
   }
 
   if (IsPendingResponseExist()) {
+    SDL_LOG_DEBUG("Command still wating for HMI response");
     return;
   }
 
@@ -525,10 +524,6 @@ void AddCommandRequest::on_event(const event_engine::Event& event) {
                &(message[strings::msg_params]));
 }
 
-bool AddCommandRequest::IsPendingResponseExist() {
-  return send_ui_ != is_ui_received_ || send_vr_ != is_vr_received_;
-}
-
 bool AddCommandRequest::IsWhiteSpaceExist() {
   SDL_LOG_AUTO_TRACE();
   const char* str = NULL;
@@ -569,7 +564,7 @@ bool AddCommandRequest::IsWhiteSpaceExist() {
 }
 
 bool AddCommandRequest::BothSend() const {
-  return send_vr_ && send_ui_;
+  return ui_is_sent_ && vr_is_sent_;
 }
 
 const std::string AddCommandRequest::GenerateMobileResponseInfo() {
@@ -617,17 +612,18 @@ void AddCommandRequest::RemoveCommand() {
 
   app->RemoveCommand(cmd_id);
 
-  if (BothSend() && !(is_vr_received_ || is_ui_received_)) {
+  if (BothSend() && (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_VR) &&
+                     IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI))) {
     // in case we have send bth UI and VR and no one respond
     // we have nothing to remove from HMI so no DeleteCommand expected
     return;
   }
 
-  if (BothSend() && !is_vr_received_) {
+  if (BothSend() && IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_VR)) {
     SendHMIRequest(hmi_apis::FunctionID::UI_DeleteCommand, &msg_params);
   }
 
-  if (BothSend() && !is_ui_received_) {
+  if (BothSend() && IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI)) {
     msg_params[strings::grammar_id] = app->get_grammar_id();
     msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
     SendHMIRequest(hmi_apis::FunctionID::VR_DeleteCommand, &msg_params);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/add_sub_menu_request.cc
@@ -50,11 +50,11 @@ AddSubMenuRequest::AddSubMenuRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 AddSubMenuRequest::~AddSubMenuRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
@@ -26,8 +26,10 @@
  */
 
 #include "sdl_rpc_plugin/commands/mobile/alert_maneuver_request.h"
+
 #include <cstring>
 #include <string>
+
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/policies/policy_handler.h"
@@ -45,11 +47,11 @@ AlertManeuverRequest::AlertManeuverRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , tts_speak_result_code_(hmi_apis::Common_Result::INVALID_ENUM)
     , navi_alert_maneuver_result_code_(hmi_apis::Common_Result::INVALID_ENUM) {
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
@@ -150,7 +152,9 @@ void AlertManeuverRequest::Run() {
         hmi_apis::Common_MethodName::ALERT_MANEUVER;
 
     StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
-    SendHMIRequest(hmi_apis::FunctionID::TTS_Speak, &msg_params, true);
+    if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS)) {
+      SendHMIRequest(hmi_apis::FunctionID::TTS_Speak, &msg_params, true);
+    }
   }
 }
 
@@ -172,6 +176,7 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::TTS_Speak: {
       SDL_LOG_INFO("Received TTS_Speak event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
+
       pending_requests_.Remove(event_id);
       tts_speak_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
@@ -193,12 +198,11 @@ void AlertManeuverRequest::on_event(const event_engine::Event& event) {
     }
   }
 
-  if (!pending_requests_.IsFinal(event_id)) {
-    SDL_LOG_DEBUG(
-        "There are some pending responses from HMI. "
-        "AlertManeuverRequest still waiting.");
+  if (IsPendingResponseExist()) {
+    SDL_LOG_DEBUG("Command still wating for HMI response");
     return;
   }
+
   std::string return_info;
   mobile_apis::Result::eType result_code;
   const bool result = PrepareResponseParameters(result_code, return_info);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_maneuver_request.cc
@@ -152,9 +152,7 @@ void AlertManeuverRequest::Run() {
         hmi_apis::Common_MethodName::ALERT_MANEUVER;
 
     StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_TTS);
-    if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS)) {
-      SendHMIRequest(hmi_apis::FunctionID::TTS_Speak, &msg_params, true);
-    }
+    SendHMIRequest(hmi_apis::FunctionID::TTS_Speak, &msg_params, true);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
@@ -37,7 +37,6 @@
 
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
-
 #include "application_manager/policies/policy_handler.h"
 #include "smart_objects/smart_object.h"
 #include "utils/helpers.h"
@@ -55,11 +54,11 @@ AlertRequest::AlertRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , awaiting_ui_alert_response_(false)
     , awaiting_tts_speak_response_(false)
     , awaiting_tts_stop_speaking_response_(false)
@@ -122,6 +121,18 @@ void AlertRequest::Run() {
   if (awaiting_tts_speak_response_) {
     SendSpeakRequest(app_id, tts_chunks_exists, length_tts_chunks);
   }
+}
+
+void AlertRequest::OnTimeOut() {
+  SDL_LOG_AUTO_TRACE();
+  if (false ==
+      (*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
+    RequestFromMobileImpl::OnTimeOut();
+    return;
+  }
+  SDL_LOG_INFO(
+      "Default timeout ignored. "
+      "AlertRequest with soft buttons wait timeout on HMI side");
 }
 
 void AlertRequest::on_event(const event_engine::Event& event) {
@@ -190,9 +201,11 @@ void AlertRequest::on_event(const event_engine::Event& event) {
     }
   }
 
-  if (HasHmiResponsesToWait()) {
+  if (IsPendingResponseExist()) {
+    SDL_LOG_DEBUG("Command is still waiting for HMI response");
     return;
   }
+
   mobile_apis::Result::eType result_code = mobile_apis::Result::INVALID_ENUM;
   std::string info;
   const bool result = PrepareResponseParameters(result_code, info);
@@ -464,7 +477,7 @@ bool AlertRequest::CheckStrings() {
   return true;
 }
 
-bool AlertRequest::HasHmiResponsesToWait() {
+bool AlertRequest::IsPendingResponseExist() {
   SDL_LOG_AUTO_TRACE();
   return awaiting_ui_alert_response_ || awaiting_tts_speak_response_ ||
          awaiting_tts_stop_speaking_response_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/alert_request.cc
@@ -125,8 +125,7 @@ void AlertRequest::Run() {
 
 void AlertRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
-  if (false ==
-      (*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
+  if (!(*message_)[strings::msg_params].keyExists(strings::soft_buttons)) {
     RequestFromMobileImpl::OnTimeOut();
     return;
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/cancel_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/cancel_interaction_request.cc
@@ -49,11 +49,11 @@ CancelInteractionRequest::CancelInteractionRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 CancelInteractionRequest::~CancelInteractionRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/change_registration_request.cc
@@ -231,18 +231,21 @@ void ChangeRegistrationRequest::Run() {
     return;
   }
   if (HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE != vr_state) {
-    // VR processing
-    SendVRRequest(app, msg_params);
     StartAwaitForInterface(HmiInterfaces::InterfaceID::HMI_INTERFACE_VR);
   }
   if (HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE != tts_state) {
-    // TTS processing
-    SendTTSRequest(app, msg_params);
     StartAwaitForInterface(HmiInterfaces::InterfaceID::HMI_INTERFACE_TTS);
   }
 
   if (HmiInterfaces::InterfaceState::STATE_NOT_AVAILABLE != ui_state) {
     SendUIRequest(app, msg_params, hmi_language);
+  }
+
+  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS)) {
+    SendTTSRequest(app, msg_params);
+  }
+  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI)) {
+    SendVRRequest(app, msg_params);
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_request.cc
@@ -47,11 +47,11 @@ CloseApplicationRequest::CloseApplicationRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 CloseApplicationRequest::~CloseApplicationRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
@@ -53,11 +53,11 @@ CreateWindowRequest::CreateWindowRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 CreateWindowRequest::~CreateWindowRequest() {}
 
@@ -214,7 +214,7 @@ void CreateWindowRequest::on_event(const event_engine::Event& event) {
   EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
 
   const smart_objects::SmartObject& response_message = event.smart_object();
-  const auto result_code = CommandRequestImpl::GetMobileResultCode(
+  const auto result_code = RequestFromMobileImpl::GetMobileResultCode(
       static_cast<hmi_apis::Common_Result::eType>(
           response_message[strings::params][hmi_response::code].asInt()));
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_command_request.cc
@@ -52,15 +52,11 @@ DeleteCommandRequest::DeleteCommandRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
-    , is_ui_send_(false)
-    , is_vr_send_(false)
-    , is_ui_received_(false)
-    , is_vr_received_(false)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , ui_result_(hmi_apis::Common_Result::INVALID_ENUM)
     , vr_result_(hmi_apis::Common_Result::INVALID_ENUM) {}
 
@@ -99,17 +95,11 @@ void DeleteCommandRequest::Run() {
   /* Need to set all flags before sending request to HMI
    * for correct processing this flags in method on_event */
   if (command.keyExists(strings::menu_params)) {
-    is_ui_send_ = true;
-  }
-  // check vr params
-  if (command.keyExists(strings::vr_commands)) {
-    is_vr_send_ = true;
-  }
-  if (is_ui_send_) {
     StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
     SendHMIRequest(hmi_apis::FunctionID::UI_DeleteCommand, &msg_params, true);
   }
-  if (is_vr_send_) {
+  // check vr params
+  if (command.keyExists(strings::vr_commands)) {
     // VR params
     msg_params[strings::grammar_id] = application->get_grammar_id();
     msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
@@ -151,7 +141,6 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
   switch (event.id()) {
     case hmi_apis::FunctionID::UI_DeleteCommand: {
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
-      is_ui_received_ = true;
       ui_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       SDL_LOG_DEBUG("Received UI_DeleteCommand event with result "
@@ -161,7 +150,6 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
     }
     case hmi_apis::FunctionID::VR_DeleteCommand: {
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
-      is_vr_received_ = true;
       vr_result_ = static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
       SDL_LOG_DEBUG("Received VR_DeleteCommand event with result "
@@ -214,11 +202,6 @@ void DeleteCommandRequest::on_event(const event_engine::Event& event) {
 bool DeleteCommandRequest::Init() {
   hash_update_mode_ = HashUpdateMode::kDoHashUpdate;
   return true;
-}
-
-bool DeleteCommandRequest::IsPendingResponseExist() {
-  SDL_LOG_AUTO_TRACE();
-  return is_ui_send_ != is_ui_received_ || is_vr_send_ != is_vr_received_;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_file_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_file_request.cc
@@ -50,11 +50,11 @@ DeleteFileRequest::DeleteFileRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 DeleteFileRequest::~DeleteFileRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
@@ -51,11 +51,11 @@ DeleteInteractionChoiceSetRequest::DeleteInteractionChoiceSetRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 DeleteInteractionChoiceSetRequest::~DeleteInteractionChoiceSetRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
@@ -52,11 +52,11 @@ DeleteSubMenuRequest::DeleteSubMenuRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 DeleteSubMenuRequest::~DeleteSubMenuRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_window_request.cc
@@ -47,11 +47,11 @@ DeleteWindowRequest::DeleteWindowRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 DeleteWindowRequest::~DeleteWindowRequest() {}
 
@@ -130,7 +130,7 @@ void DeleteWindowRequest::on_event(const event_engine::Event& event) {
   EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
 
   const smart_objects::SmartObject& response_message = event.smart_object();
-  const auto result_code = CommandRequestImpl::GetMobileResultCode(
+  const auto result_code = RequestFromMobileImpl::GetMobileResultCode(
       static_cast<hmi_apis::Common_Result::eType>(
           response_message[strings::params][hmi_response::code].asInt()));
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/dial_number_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/dial_number_request.cc
@@ -49,11 +49,11 @@ DialNumberRequest::DialNumberRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 DialNumberRequest::~DialNumberRequest() {}
 
@@ -118,7 +118,7 @@ void DialNumberRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::BasicCommunication_DialNumber: {
       SDL_LOG_INFO("Received DialNumber event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_BasicCommunication);
-      result_code = CommandRequestImpl::GetMobileResultCode(
+      result_code = RequestFromMobileImpl::GetMobileResultCode(
           static_cast<hmi_apis::Common_Result::eType>(
               message[strings::params][hmi_response::code].asInt()));
       break;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/end_audio_pass_thru_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/end_audio_pass_thru_request.cc
@@ -47,11 +47,11 @@ EndAudioPassThruRequest::EndAudioPassThruRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 EndAudioPassThruRequest::~EndAudioPassThruRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_cloud_app_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_cloud_app_properties_request.cc
@@ -14,11 +14,11 @@ GetCloudAppPropertiesRequest::GetCloudAppPropertiesRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 GetCloudAppPropertiesRequest::~GetCloudAppPropertiesRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_file_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_file_request.cc
@@ -67,11 +67,11 @@ GetFileRequest::GetFileRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , file_name_("")
     , file_type_(mobile_apis::FileType::INVALID_ENUM)
     , length_(0)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_system_capability_request.cc
@@ -50,11 +50,11 @@ GetSystemCapabilityRequest::GetSystemCapabilityRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 GetSystemCapabilityRequest::~GetSystemCapabilityRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/get_way_points_request.cc
@@ -31,6 +31,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/mobile/get_way_points_request.h"
+
 #include "application_manager/application_manager.h"
 #include "application_manager/message_helper.h"
 
@@ -47,11 +48,11 @@ GetWayPointsRequest::GetWayPointsRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {
   subscribe_on_event(hmi_apis::FunctionID::UI_OnResetTimeout);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/list_files_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/list_files_request.cc
@@ -52,11 +52,11 @@ ListFilesRequest::ListFilesRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 ListFilesRequest::~ListFilesRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -32,6 +32,7 @@
  */
 
 #include "sdl_rpc_plugin/commands/mobile/perform_audio_pass_thru_request.h"
+
 #include <cstring>
 
 #include "application_manager/application_impl.h"
@@ -53,11 +54,11 @@ PerformAudioPassThruRequest::PerformAudioPassThruRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , result_tts_speak_(hmi_apis::Common_Result::INVALID_ENUM)
     , result_ui_(hmi_apis::Common_Result::INVALID_ENUM) {
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
@@ -65,11 +66,11 @@ PerformAudioPassThruRequest::PerformAudioPassThruRequest(
 
 PerformAudioPassThruRequest::~PerformAudioPassThruRequest() {}
 
-void PerformAudioPassThruRequest::onTimeOut() {
+void PerformAudioPassThruRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
 
   FinishTTSSpeak();
-  CommandRequestImpl::onTimeOut();
+  RequestFromMobileImpl::OnTimeOut();
 }
 
 bool PerformAudioPassThruRequest::Init() {
@@ -200,7 +201,8 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
       return;
     }
   }
-  if (IsWaitingHMIResponse()) {
+  if (IsPendingResponseExist()) {
+    SDL_LOG_DEBUG("Command still wating for HMI response");
     return;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -68,16 +68,14 @@ PerformInteractionRequest::PerformInteractionRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , interaction_mode_(mobile_apis::InteractionMode::INVALID_ENUM)
     , ui_choice_id_received_(INVALID_CHOICE_ID)
     , vr_choice_id_received_(INVALID_CHOICE_ID)
-    , ui_response_received_(false)
-    , vr_response_received_(false)
     , app_pi_was_active_before_(false)
     , vr_result_code_(hmi_apis::Common_Result::INVALID_ENUM)
     , ui_result_code_(hmi_apis::Common_Result::INVALID_ENUM) {
@@ -229,6 +227,10 @@ void PerformInteractionRequest::Run() {
   app->set_perform_interaction_layout(interaction_layout);
   // increment amount of active requests
   ++pi_requests_count_;
+
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+
   SendVRPerformInteractionRequest(app);
   SendUIPerformInteractionRequest(app);
 }
@@ -247,7 +249,6 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::UI_PerformInteraction: {
       SDL_LOG_DEBUG("Received UI_PerformInteraction event");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
-      ui_response_received_ = true;
 
       unsubscribe_from_event(hmi_apis::FunctionID::UI_PerformInteraction);
       ui_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
@@ -259,7 +260,6 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
     case hmi_apis::FunctionID::VR_PerformInteraction: {
       SDL_LOG_DEBUG("Received VR_PerformInteraction");
       EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VR);
-      vr_response_received_ = true;
 
       unsubscribe_from_event(hmi_apis::FunctionID::VR_PerformInteraction);
       vr_result_code_ = static_cast<hmi_apis::Common_Result::eType>(
@@ -290,19 +290,20 @@ void PerformInteractionRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void PerformInteractionRequest::onTimeOut() {
+void PerformInteractionRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
 
   switch (interaction_mode_) {
     case mobile_apis::InteractionMode::BOTH: {
       SDL_LOG_DEBUG("Interaction Mode: BOTH");
-      if (true == vr_response_received_) {
+      if (!IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_VR)) {
         unsubscribe_from_event(hmi_apis::FunctionID::UI_PerformInteraction);
         DisablePerformInteraction();
-        CommandRequestImpl::onTimeOut();
+        RequestFromMobileImpl::OnTimeOut();
       } else {
         application_manager_.updateRequestTimeout(
             connection_key(), correlation_id(), default_timeout_);
+        set_current_state(RequestState::kAwaitingResponse);
       }
       break;
     }
@@ -310,14 +311,14 @@ void PerformInteractionRequest::onTimeOut() {
       SDL_LOG_DEBUG("Interaction Mode: VR_ONLY");
       unsubscribe_from_event(hmi_apis::FunctionID::UI_PerformInteraction);
       DisablePerformInteraction();
-      CommandRequestImpl::onTimeOut();
+      RequestFromMobileImpl::OnTimeOut();
       break;
     }
     case mobile_apis::InteractionMode::MANUAL_ONLY: {
       SDL_LOG_DEBUG("InteractionMode: MANUAL_ONLY");
       unsubscribe_from_event(hmi_apis::FunctionID::UI_PerformInteraction);
       DisablePerformInteraction();
-      CommandRequestImpl::onTimeOut();
+      RequestFromMobileImpl::OnTimeOut();
       break;
     }
     default: {
@@ -363,7 +364,7 @@ bool PerformInteractionRequest::ProcessVRResponse(
     return false;
   }
 
-  if (!ui_response_received_ &&
+  if (IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI) &&
       InteractionMode::MANUAL_ONLY != interaction_mode_) {
     SendClosePopupRequestToHMI();
   }
@@ -1064,7 +1065,8 @@ bool PerformInteractionRequest::CheckChoiceIDFromRequest(
 
 const bool PerformInteractionRequest::HasHMIResponsesToWait() const {
   SDL_LOG_AUTO_TRACE();
-  return !ui_response_received_ || !vr_response_received_;
+  return IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI) ||
+         IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_VR);
 }
 
 void PerformInteractionRequest::SendBothModeResponse(
@@ -1128,8 +1130,8 @@ PerformInteractionRequest::PrepareResultCodeForResponse(
     return mobile_ui_result_code;
   }
 
-  return CommandRequestImpl::PrepareResultCodeForResponse(ui_response,
-                                                          vr_response);
+  return RequestFromMobileImpl::PrepareResultCodeForResponse(ui_response,
+                                                             vr_response);
 }
 
 bool PerformInteractionRequest::PrepareResultForMobileResponse(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/put_file_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/put_file_request.cc
@@ -69,11 +69,11 @@ PutFileRequest::PutFileRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , offset_(0)
     , sync_file_name_()
     , length_(0)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -134,11 +134,11 @@ RegisterAppInterfaceRequest::RegisterAppInterfaceRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , are_tts_chunks_invalid_(false)
     , are_hmi_types_invalid_(false)
     , is_resumption_failed_(false)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/reset_global_properties_request.cc
@@ -35,7 +35,6 @@
 
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
-
 #include "interfaces/HMI_API.h"
 #include "interfaces/MOBILE_API.h"
 
@@ -52,11 +51,11 @@ ResetGlobalPropertiesRequest::ResetGlobalPropertiesRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , ui_result_(hmi_apis::Common_Result::INVALID_ENUM)
     , tts_result_(hmi_apis::Common_Result::INVALID_ENUM) {}
 
@@ -193,11 +192,6 @@ bool ResetGlobalPropertiesRequest::PrepareResponseParameters(
   }
 
   return result;
-}
-
-bool ResetGlobalPropertiesRequest::IsPendingResponseExist() {
-  return IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_TTS) ||
-         IsInterfaceAwaited(HmiInterfaces::HMI_INTERFACE_UI);
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/scrollable_message_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/scrollable_message_request.cc
@@ -54,11 +54,11 @@ ScrollableMessageRequest::ScrollableMessageRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {
   subscribe_on_event(hmi_apis::FunctionID::UI_OnResetTimeout);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_haptic_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_haptic_data_request.cc
@@ -48,11 +48,11 @@ SendHapticDataRequest::SendHapticDataRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SendHapticDataRequest::~SendHapticDataRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_location_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/send_location_request.cc
@@ -48,11 +48,11 @@ SendLocationRequest::SendLocationRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SendLocationRequest::~SendLocationRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_app_icon_request.cc
@@ -54,11 +54,11 @@ SetAppIconRequest::SetAppIconRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , is_icons_saving_enabled_(false) {
   const std::string path =
       application_manager_.get_settings().app_icons_folder();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_cloud_app_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_cloud_app_properties_request.cc
@@ -15,11 +15,11 @@ SetCloudAppPropertiesRequest::SetCloudAppPropertiesRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SetCloudAppPropertiesRequest::~SetCloudAppPropertiesRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_display_layout_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_display_layout_request.cc
@@ -49,11 +49,11 @@ SetDisplayLayoutRequest::SetDisplayLayoutRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SetDisplayLayoutRequest::~SetDisplayLayoutRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
@@ -73,11 +73,11 @@ SetGlobalPropertiesRequest::SetGlobalPropertiesRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , is_ui_send_(false)
     , is_tts_send_(false)
     , is_rc_send_(false)
@@ -414,10 +414,10 @@ bool SetGlobalPropertiesRequest::Init() {
   return true;
 }
 
-void SetGlobalPropertiesRequest::onTimeOut() {
+void SetGlobalPropertiesRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
 
-  CommandRequestImpl::onTimeOut();
+  RequestFromMobileImpl::HandleTimeOut();
 
   auto& resume_ctrl = application_manager_.resume_controller();
 
@@ -443,7 +443,7 @@ bool SetGlobalPropertiesRequest::PrepareResponseParameters(
   bool result = false;
 
   if (!is_rc_send_) {
-    result = CommandRequestImpl::PrepareResultForMobileResponse(
+    result = RequestFromMobileImpl::PrepareResultForMobileResponse(
         ui_properties_info, tts_properties_info);
   } else {
     result = PrepareResultForMobileResponse(
@@ -464,7 +464,7 @@ bool SetGlobalPropertiesRequest::PrepareResponseParameters(
   }
 
   if (!is_rc_send_) {
-    result_code = CommandRequestImpl::PrepareResultCodeForResponse(
+    result_code = RequestFromMobileImpl::PrepareResultCodeForResponse(
         ui_properties_info, tts_properties_info);
   } else {
     result_code = PrepareResultCodeForResponse(
@@ -505,8 +505,9 @@ bool SetGlobalPropertiesRequest::PrepareResultForMobileResponse(
       (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == first.result_code) ||
       (hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == second.result_code);
 
-  const bool final_result = CommandRequestImpl::CheckResult(both_info, third) ||
-                            CommandRequestImpl::CheckResult(third, both_info);
+  const bool final_result =
+      RequestFromMobileImpl::CheckResultCode(both_info, third) ||
+      RequestFromMobileImpl::CheckResultCode(third, both_info);
 
   return final_result;
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_media_clock_timer_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_media_clock_timer_request.cc
@@ -51,11 +51,11 @@ SetMediaClockRequest::SetMediaClockRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SetMediaClockRequest::~SetMediaClockRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_app_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_app_menu_request.cc
@@ -47,11 +47,11 @@ ShowAppMenuRequest::ShowAppMenuRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 ShowAppMenuRequest::~ShowAppMenuRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_constant_tbt_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_constant_tbt_request.cc
@@ -54,11 +54,11 @@ ShowConstantTBTRequest::ShowConstantTBTRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 ShowConstantTBTRequest::~ShowConstantTBTRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/show_request.cc
@@ -52,11 +52,11 @@ ShowRequest::ShowRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , core_result_code_(mobile_apis::Result::INVALID_ENUM)
     , current_window_id_(mobile_apis::PredefinedWindows::DEFAULT_WINDOW)
     , template_config_(smart_objects::SmartType::SmartType_Null)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/slider_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/slider_request.cc
@@ -51,11 +51,11 @@ SliderRequest::SliderRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {
   subscribe_on_event(hmi_apis::FunctionID::UI_OnResetTimeout);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/speak_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/speak_request.cc
@@ -36,6 +36,7 @@
 
 #include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
+#include "interfaces/HMI_API.h"
 #include "utils/helpers.h"
 
 namespace sdl_rpc_plugin {
@@ -51,11 +52,11 @@ SpeakRequest::SpeakRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {
   subscribe_on_event(hmi_apis::FunctionID::TTS_OnResetTimeout);
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
@@ -49,11 +49,11 @@ SubscribeButtonRequest::SubscribeButtonRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SubscribeButtonRequest::~SubscribeButtonRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
@@ -47,11 +47,11 @@ SubscribeWayPointsRequest::SubscribeWayPointsRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SubscribeWayPointsRequest::~SubscribeWayPointsRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_way_points_request.cc
@@ -121,7 +121,7 @@ void SubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void SubscribeWayPointsRequest::onTimeOut() {
+void SubscribeWayPointsRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   if (application_manager_.GetAppServiceManager().FindWayPointsHandler() !=
       nullptr) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subtle_alert_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subtle_alert_request.cc
@@ -48,11 +48,11 @@ SubtleAlertRequest::SubtleAlertRequest(
     rpc_service::RPCService& rpc_service,
     HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler)
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler)
     , awaiting_ui_subtle_alert_response_(false)
     , awaiting_tts_speak_response_(false)
     , awaiting_tts_stop_speaking_response_(false)

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/system_request.cc
@@ -411,11 +411,11 @@ SystemRequest::SystemRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 SystemRequest::~SystemRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_button_request.cc
@@ -51,11 +51,11 @@ UnsubscribeButtonRequest::UnsubscribeButtonRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 UnsubscribeButtonRequest::~UnsubscribeButtonRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -47,11 +47,11 @@ UnsubscribeWayPointsRequest::UnsubscribeWayPointsRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 UnsubscribeWayPointsRequest::~UnsubscribeWayPointsRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/unsubscribe_way_points_request.cc
@@ -127,7 +127,7 @@ void UnsubscribeWayPointsRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void UnsubscribeWayPointsRequest::onTimeOut() {
+void UnsubscribeWayPointsRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   if (application_manager_.GetAppServiceManager().FindWayPointsHandler() !=
       nullptr) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/update_turn_list_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/update_turn_list_request.cc
@@ -56,11 +56,11 @@ UpdateTurnListRequest::UpdateTurnListRequest(
     app_mngr::rpc_service::RPCService& rpc_service,
     app_mngr::HMICapabilities& hmi_capabilities,
     policy::PolicyHandlerInterface& policy_handler)
-    : CommandRequestImpl(message,
-                         application_manager,
-                         rpc_service,
-                         hmi_capabilities,
-                         policy_handler) {}
+    : RequestFromMobileImpl(message,
+                            application_manager,
+                            rpc_service,
+                            hmi_capabilities,
+                            policy_handler) {}
 
 UpdateTurnListRequest::~UpdateTurnListRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/waypoints_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/waypoints_pending_resumption_handler.cc
@@ -140,7 +140,7 @@ void WayPointsPendingResumptionHandler::RaiseFakeSuccessfulResponse(
   event.raise(application_manager_.event_dispatcher());
 }
 
-void WayPointsPendingResumptionHandler::on_event(
+void WayPointsPendingResumptionHandler::HandleOnEvent(
     const application_manager::event_engine::Event& event) {
   using namespace application_manager;
   SDL_LOG_AUTO_TRACE();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/activate_app_request_test.cc
@@ -97,6 +97,8 @@ TEST_F(ActivateAppRequestTest, Run_SUCCESS) {
   (*msg)[strings::msg_params][strings::activate_app_hmi_level] =
       mobile_apis::HMILevel::HMI_FULL;
 #endif
+  InitEventDispatcher();
+
   ActivateAppRequestPtr command(CreateCommand<ActivateAppRequest>(msg));
 
   EXPECT_CALL(app_mngr_, set_application_id(kCorrelationId, kAppId));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/basic_communication_get_system_time_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/basic_communication_get_system_time_request_test.cc
@@ -62,7 +62,7 @@ TEST_F(BasicCommunicationGetSystemTimeRequestTest, OnTimeout) {
       .WillByDefault(ReturnRef(mock_protocol_handler));
   EXPECT_CALL(mock_protocol_handler, NotifyOnGetSystemTimeFailed());
 
-  command->onTimeOut();
+  command->OnTimeOut();
 }
 
 }  // namespace basic_communication_get_system_time_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/button_get_capabilities_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/button_get_capabilities_request_test.cc
@@ -75,6 +75,9 @@ class ButtonGetCapabilitiesRequestTest
 
 TEST_F(ButtonGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+
+  InitEventDispatcher();
+
   RequestToHMIPtr command(
       CreateCommand<ButtonGetCapabilitiesRequest>(command_msg));
 
@@ -92,6 +95,9 @@ TEST_F(ButtonGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
 TEST_F(ButtonGetCapabilitiesRequestTest,
        onTimeOut_ButtonsGetCapabilitiesUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+
+  InitEventDispatcher();
+
   RequestToHMIPtr command(
       CreateCommand<ButtonGetCapabilitiesRequest>(command_msg));
 
@@ -101,7 +107,7 @@ TEST_F(ButtonGetCapabilitiesRequestTest,
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_system_info_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/get_system_info_request_test.cc
@@ -71,6 +71,8 @@ TEST_F(GetSystemInfoRequestTest, RUN_SendRequest_SUCCESS) {
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*command_msg)[strings::params][strings::correlation_id] = kCorrelationId;
 
+  InitEventDispatcher();
+
   RequestToHMIPtr command(CreateCommand<GetSystemInfoRequest>(command_msg));
 
   const uint32_t kAppId = command->application_id();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/mixing_audio_supported_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/mixing_audio_supported_request_test.cc
@@ -70,6 +70,8 @@ TEST_F(MixingAudioSupportedRequestTest, RUN_SendRequest_SUCCESS) {
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
 
+  InitEventDispatcher();
+
   RequestToHMIPtr command(
       CreateCommand<MixingAudioSupportedRequest>(command_msg));
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/navi_set_video_config_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/navi_set_video_config_request_test.cc
@@ -199,7 +199,7 @@ TEST_F(NaviSetVideoConfigRequestTest, OnTimeout) {
 
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _)).Times(1);
 
-  command->onTimeOut();
+  command->OnTimeOut();
 }
 
 }  // namespace navi_set_video_config_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_request_test.cc
@@ -73,6 +73,8 @@ TEST_F(RCGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
   (*command_msg)[am::strings::params][am::strings::connection_key] =
       kConnectionKey;
 
+  InitEventDispatcher();
+
   RequestToHMIPtr command(CreateCommand<RCGetCapabilitiesRequest>(command_msg));
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
   ASSERT_TRUE(command->Init());
@@ -88,6 +90,7 @@ TEST_F(RCGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
 TEST_F(RCGetCapabilitiesRequestTest,
        onTimeOut_OnCapabilityInitialized_RemoveRCGetCapabilities) {
   MessageSharedPtr command_msg(CreateMessage(smart_objects::SmartType_Map));
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<RCGetCapabilitiesRequest>(command_msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -96,7 +99,7 @@ TEST_F(RCGetCapabilitiesRequestTest,
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 }
 
 }  // namespace rc_get_capabilities_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_is_ready_request_test.cc
@@ -217,7 +217,7 @@ TEST_F(RCIsReadyRequestTest, Run_ErrorMessage_StateNotAvailable) {
 TEST_F(RCIsReadyRequestTest, Run_HMIDoestRespond_SendMessageToHMIByTimeout) {
   HMICapabilitiesExpectations();
   ExpectSendMessagesToHMI();
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 }  // namespace rc_is_ready_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/sdl_activate_app_request_test.cc
@@ -59,6 +59,7 @@ namespace hmi_response = am::hmi_response;
 using am::ApplicationSet;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
+using application_manager::event_engine::EventObserver;
 using connection_handler_test::MockConnectionHandler;
 using policy_test::MockPolicyHandlerInterface;
 using sdl_rpc_plugin::commands::SDLActivateAppRequest;
@@ -503,10 +504,11 @@ TEST_F(SDLActivateAppRequestTest, OnTimeout_SUCCESS) {
 
   std::shared_ptr<SDLActivateAppRequest> command(
       CreateCommand<SDLActivateAppRequest>(msg));
-  ON_CALL(mock_event_dispatcher_, remove_observer(_, _));
+  ON_CALL(mock_event_dispatcher_,
+          remove_observer(_, testing::Matcher<EventObserver&>(_)));
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).WillOnce(Return(true));
 
-  command->onTimeOut();
+  command->OnTimeOut();
 }
 
 TEST_F(SDLActivateAppRequestTest, OnEvent_InvalidEventId_UNSUCCESS) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/simple_requests_to_hmi_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/simple_requests_to_hmi_test.cc
@@ -114,6 +114,7 @@ using event_engine_test::MockEventDispatcher;
 class RequestToHMITest : public CommandsTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(RequestToHMITest, BasicMethodsOverloads_SUCCESS) {
+  InitEventDispatcher();
   std::shared_ptr<am_commands::RequestToHMI> command(
       CreateCommand<am_commands::RequestToHMI>());
 
@@ -124,6 +125,8 @@ TEST_F(RequestToHMITest, BasicMethodsOverloads_SUCCESS) {
 }
 
 TEST_F(RequestToHMITest, SendRequest_SUCCESS) {
+  InitEventDispatcher();
+
   std::shared_ptr<am_commands::RequestToHMI> command(
       CreateCommand<am_commands::RequestToHMI>());
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(NotNull()));
@@ -222,6 +225,8 @@ TYPED_TEST_CASE(RequestToHMICommandsTest3, RequestCommandsList3);
 TYPED_TEST(RequestToHMICommandsTest, Run_SendMessageToHMI_SUCCESS) {
   typedef typename TestFixture::CommandType CommandType;
 
+  this->InitEventDispatcher();
+
   std::shared_ptr<CommandType> command =
       this->template CreateCommand<CommandType>();
 
@@ -233,6 +238,8 @@ TYPED_TEST(RequestToHMICommandsTest, Run_SendMessageToHMI_SUCCESS) {
 TYPED_TEST(RequestToHMICommandsTest2, Run_SendMessageToHMI_SUCCESS) {
   typedef typename TestFixture::CommandType CommandType;
 
+  this->InitEventDispatcher();
+
   std::shared_ptr<CommandType> command =
       this->template CreateCommand<CommandType>();
   EXPECT_CALL(this->mock_rpc_service_, SendMessageToHMI(NotNull()));
@@ -242,6 +249,8 @@ TYPED_TEST(RequestToHMICommandsTest2, Run_SendMessageToHMI_SUCCESS) {
 
 TYPED_TEST(RequestToHMICommandsTest3, Run_SendMessageToHMI_SUCCESS) {
   typedef typename TestFixture::CommandType CommandType;
+
+  EXPECT_CALL(this->event_dispatcher_, remove_observer(_));
 
   std::shared_ptr<CommandType> command =
       this->template CreateCommand<CommandType>();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_capabilities_request_test.cc
@@ -77,6 +77,7 @@ class TTSGetCapabilitiesRequestTest
 
 TEST_F(TTSGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<TTSGetCapabilitiesRequest>(command_msg));
 
@@ -93,6 +94,7 @@ TEST_F(TTSGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
 
 TEST_F(TTSGetCapabilitiesRequestTest, onTimeOut_TTSGetCapabilitiesUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<TTSGetCapabilitiesRequest>(command_msg));
 
@@ -102,7 +104,7 @@ TEST_F(TTSGetCapabilitiesRequestTest, onTimeOut_TTSGetCapabilitiesUpdated) {
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_language_request_test.cc
@@ -77,6 +77,7 @@ class TTSGetLanguageRequestTest
 
 TEST_F(TTSGetLanguageRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<TTSGetLanguageRequest>(command_msg));
 
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
@@ -92,6 +93,7 @@ TEST_F(TTSGetLanguageRequestTest, RUN_SendRequest_SUCCESS) {
 
 TEST_F(TTSGetLanguageRequestTest, onTimeOut_TTSGetLanguageUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<TTSGetLanguageRequest>(command_msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -100,7 +102,7 @@ TEST_F(TTSGetLanguageRequestTest, onTimeOut_TTSGetLanguageUpdated) {
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_supported_languages_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_get_supported_languages_request_test.cc
@@ -77,6 +77,7 @@ class TTSGetSupportedLanguagesRequestTest
 
 TEST_F(TTSGetSupportedLanguagesRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<TTSGetSupportedLanguagesRequest>(command_msg));
 
@@ -94,6 +95,7 @@ TEST_F(TTSGetSupportedLanguagesRequestTest, RUN_SendRequest_SUCCESS) {
 TEST_F(TTSGetSupportedLanguagesRequestTest,
        onTimeOut_TTSGetSupportedLanguagesUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<TTSGetSupportedLanguagesRequest>(command_msg));
 
@@ -103,7 +105,7 @@ TEST_F(TTSGetSupportedLanguagesRequestTest,
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/tts_is_ready_request_test.cc
@@ -242,7 +242,7 @@ TEST_F(TTSIsReadyRequestTest,
   ASSERT_TRUE(command_->Init());
 
   command_->Run();
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 }  // namespace tts_is_ready_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_capabilities_request_test.cc
@@ -77,6 +77,7 @@ class UIGetCapabilitiesRequestTest
 
 TEST_F(UIGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<UIGetCapabilitiesRequest>(command_msg));
 
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
@@ -92,6 +93,7 @@ TEST_F(UIGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
 
 TEST_F(UIGetCapabilitiesRequestTest, onTimeOut_UIGetCapabilitiesUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<UIGetCapabilitiesRequest>(command_msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -100,7 +102,7 @@ TEST_F(UIGetCapabilitiesRequestTest, onTimeOut_UIGetCapabilitiesUpdated) {
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_language_request_test.cc
@@ -77,6 +77,7 @@ class UIGetLanguageRequestTest
 
 TEST_F(UIGetLanguageRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<UIGetLanguageRequest>(command_msg));
 
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
@@ -92,6 +93,7 @@ TEST_F(UIGetLanguageRequestTest, RUN_SendRequest_SUCCESS) {
 
 TEST_F(UIGetLanguageRequestTest, onTimeOut_UIGetLanguageUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<UIGetLanguageRequest>(command_msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -100,7 +102,7 @@ TEST_F(UIGetLanguageRequestTest, onTimeOut_UIGetLanguageUpdated) {
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_supported_languages_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_get_supported_languages_request_test.cc
@@ -77,6 +77,7 @@ class UIGetSupportedLanguagesRequestTest
 
 TEST_F(UIGetSupportedLanguagesRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<UIGetSupportedLanguagesRequest>(command_msg));
 
@@ -94,6 +95,7 @@ TEST_F(UIGetSupportedLanguagesRequestTest, RUN_SendRequest_SUCCESS) {
 TEST_F(UIGetSupportedLanguagesRequestTest,
        onTimeOut_UIGetSupportedLanguagesUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<UIGetSupportedLanguagesRequest>(command_msg));
 
@@ -103,7 +105,7 @@ TEST_F(UIGetSupportedLanguagesRequestTest,
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/ui_is_ready_request_test.cc
@@ -208,7 +208,7 @@ TEST_F(UIIsReadyRequestTest,
 TEST_F(UIIsReadyRequestTest, OnTimeout_SUCCESS_CacheIsAbsent) {
   HMICapabilitiesExpectations();
   ExpectSendMessagesToHMI();
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 }  // namespace ui_is_ready_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/update_device_list_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/update_device_list_request_test.cc
@@ -64,6 +64,7 @@ namespace strings = am::strings;
 namespace hmi_response = am::hmi_response;
 using am::commands::CommandImpl;
 using am::event_engine::Event;
+using application_manager::event_engine::EventObserver;
 using sdl_rpc_plugin::commands::UpdateDeviceListRequest;
 
 typedef std::shared_ptr<UpdateDeviceListRequest> UpdateDeviceListRequestPtr;
@@ -156,7 +157,8 @@ TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
 
   EXPECT_CALL(app_mngr_, event_dispatcher())
       .WillOnce(ReturnRef(mock_event_dispatcher_));
-  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_, _));
+  EXPECT_CALL(mock_event_dispatcher_,
+              remove_observer(_, testing::Matcher<EventObserver&>(_)));
   EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/update_sdl_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/update_sdl_request_test.cc
@@ -69,6 +69,8 @@ TEST_F(UpdateSDLRequestTest, RUN_SUCCESS) {
   (*command_msg)[strings::params][strings::connection_key] = kConnectionKey;
   (*command_msg)[strings::params][strings::correlation_id] = kCorrelationId;
 
+  InitEventDispatcher();
+
   UpdateSDLRequestPtr command(CreateCommand<UpdateSDLRequest>(command_msg));
 
   EXPECT_CALL(mock_policy_handler_, PTExchangeAtUserRequest(kCorrelationId));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_capabilities_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_capabilities_request_test.cc
@@ -77,6 +77,7 @@ class VRGetCapabilitiesRequestTest
 
 TEST_F(VRGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<VRGetCapabilitiesRequest>(command_msg));
 
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
@@ -92,6 +93,7 @@ TEST_F(VRGetCapabilitiesRequestTest, RUN_SendRequest_SUCCESS) {
 
 TEST_F(VRGetCapabilitiesRequestTest, onTimeOut_VRGetCapabilitiesUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<VRGetCapabilitiesRequest>(command_msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -100,7 +102,7 @@ TEST_F(VRGetCapabilitiesRequestTest, onTimeOut_VRGetCapabilitiesUpdated) {
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_language_request_test.cc
@@ -77,6 +77,7 @@ class VRGetLanguageRequestTest
 
 TEST_F(VRGetLanguageRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<VRGetLanguageRequest>(command_msg));
 
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
@@ -92,6 +93,7 @@ TEST_F(VRGetLanguageRequestTest, RUN_SendRequest_SUCCESS) {
 
 TEST_F(VRGetLanguageRequestTest, onTimeOut_VRGetLanguageUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(CreateCommand<VRGetLanguageRequest>(command_msg));
 
   EXPECT_CALL(mock_hmi_capabilities_,
@@ -100,7 +102,7 @@ TEST_F(VRGetLanguageRequestTest, onTimeOut_VRGetLanguageUpdated) {
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_supported_languages_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_get_supported_languages_request_test.cc
@@ -77,7 +77,7 @@ class VRGetSupportedLanguagesRequestTest
 
 TEST_F(VRGetSupportedLanguagesRequestTest, RUN_SendRequest_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
-
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<VRGetSupportedLanguagesRequest>(command_msg));
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
@@ -94,6 +94,7 @@ TEST_F(VRGetSupportedLanguagesRequestTest, RUN_SendRequest_SUCCESS) {
 TEST_F(VRGetSupportedLanguagesRequestTest,
        onTimeOut_VRGetSupportedLanguagesUpdated) {
   MessageSharedPtr command_msg = CreateCommandMsg();
+  InitEventDispatcher();
   RequestToHMIPtr command(
       CreateCommand<VRGetSupportedLanguagesRequest>(command_msg));
 
@@ -103,7 +104,7 @@ TEST_F(VRGetSupportedLanguagesRequestTest,
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 
   EXPECT_EQ(CommandImpl::hmi_protocol_type_,
             (*command_msg)[strings::params][strings::protocol_type].asInt());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/vr_is_ready_request_test.cc
@@ -192,7 +192,7 @@ TEST_F(VRIsReadyRequestTest,
        Run_HMIDoestRespond_SendMessageToHMIByTimeout_CacheIsAbsent) {
   HMICapabilitiesExpectations();
   ExpectSendMessagesToHMI();
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 }  // namespace vr_is_ready_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/add_command_request_test.cc
@@ -74,6 +74,7 @@ using ::testing::_;
 using ::testing::InSequence;
 using ::testing::Return;
 using namespace smart_objects;
+using app_mngr::commands::RequestFromMobileImpl;
 
 namespace custom_str = utils::custom_string;
 namespace strings = ::application_manager::strings;
@@ -222,10 +223,9 @@ class AddCommandRequestTest
         mock_rpc_service_,
         ManageMobileCommand(response,
                             am::commands::Command::CommandSource::SOURCE_SDL));
-
-    std::shared_ptr<CommandRequestImpl> base_class_request =
-        static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
-    base_class_request->onTimeOut();
+    std::shared_ptr<RequestFromMobileImpl> base_class_request =
+        static_cast<std::shared_ptr<RequestFromMobileImpl> >(request_ptr);
+    base_class_request->OnTimeOut();
   }
 
   MessageSharedPtr msg_;
@@ -607,22 +607,41 @@ TEST_F(AddCommandRequestTest, OnTimeOut_EXPECT_UI_DeleteCommand) {
 }
 
 TEST_F(AddCommandRequestTest, OnEvent_BothSend_SUCCESS) {
-  MessageSharedPtr command_msg = CreateMessage(SmartType_Map);
-  (*command_msg)[params][connection_key] = kConnectionKey;
-  MessageSharedPtr event_msg = CreateMessage(SmartType_Map);
-  (*event_msg)[params][hmi_response::code] = hmi_apis::Common_Result::SUCCESS;
-  (*event_msg)[msg_params][cmd_id] = kCmdId;
+  CreateBasicParamsVRRequest();
+  CreateBasicParamsUIRequest();
+  SmartObject& params = (*msg_)[strings::params];
+  params[hmi_response::code] = hmi_apis::Common_Result::WARNINGS;
+  SmartObject& image = (*msg_)[msg_params][cmd_icon];
+  EXPECT_CALL(mock_message_helper_, VerifyImage(image, _, _))
+      .WillOnce(Return(mobile_apis::Result::SUCCESS));
 
   Event event_ui(hmi_apis::FunctionID::UI_AddCommand);
-  event_ui.set_smart_object(*event_msg);
-
+  event_ui.set_smart_object(*msg_);
   Event event_vr(hmi_apis::FunctionID::VR_AddCommand);
-  event_vr.set_smart_object(*event_msg);
+  event_vr.set_smart_object(*msg_);
+
+  am::CommandsMap commands_map;
+  EXPECT_CALL(*mock_app_, commands_map())
+      .WillRepeatedly(Return(DataAccessor<application_manager::CommandsMap>(
+          commands_map, lock_ptr_)));
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::UI_AddCommand), _))
+      .WillOnce(Return(true));
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageHMICommand(HMIResultCodeIs(hmi_apis::FunctionID::VR_AddCommand), _))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(*mock_app_, help_prompt_manager())
+      .WillOnce(ReturnRef(*mock_help_prompt_manager_));
+  EXPECT_CALL(*mock_help_prompt_manager_, OnVrCommandAdded(kCmdId, _, false));
 
   EXPECT_CALL(*mock_app_, RemoveCommand(kCmdId)).Times(0);
 
   std::shared_ptr<AddCommandRequest> request_ptr =
-      CreateCommand<AddCommandRequest>(command_msg);
+      CreateCommand<AddCommandRequest>(msg_);
   request_ptr->Run();
   request_ptr->on_event(event_ui);
   request_ptr->on_event(event_vr);
@@ -1096,11 +1115,10 @@ TEST_F(AddCommandRequestTest,
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
-
-  std::shared_ptr<CommandRequestImpl> base_class_request =
-      static_cast<std::shared_ptr<CommandRequestImpl> >(
+  std::shared_ptr<RequestFromMobileImpl> base_class_request =
+      static_cast<std::shared_ptr<RequestFromMobileImpl> >(
           CreateCommand<AddCommandRequest>(msg_));
-  base_class_request->onTimeOut();
+  base_class_request->OnTimeOut();
 }
 
 TEST_F(AddCommandRequestTest, OnTimeOut_AppRemoveCommandCalled) {
@@ -1147,10 +1165,9 @@ TEST_F(AddCommandRequestTest, OnTimeOut_AppRemoveCommandCalled) {
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   response, am::commands::Command::CommandSource::SOURCE_SDL));
-
-  std::shared_ptr<CommandRequestImpl> base_class_request =
-      static_cast<std::shared_ptr<CommandRequestImpl> >(request_ptr);
-  base_class_request->onTimeOut();
+  std::shared_ptr<RequestFromMobileImpl> base_class_request =
+      static_cast<std::shared_ptr<RequestFromMobileImpl> >(request_ptr);
+  base_class_request->OnTimeOut();
 }
 
 }  // namespace add_command_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/alert_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/alert_request_test.cc
@@ -56,6 +56,7 @@ using am::MockMessageHelper;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
 using am::event_engine::Event;
+using app_mngr::commands::RequestFromMobileImpl;
 using policy_test::MockPolicyHandlerInterface;
 using sdl_rpc_plugin::commands::AlertRequest;
 using ::testing::_;
@@ -207,7 +208,7 @@ TEST_F(AlertRequestTest, OnTimeout_GENERIC_ERROR) {
       ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
       .WillOnce(DoAll(SaveArg<0>(&ui_command_result), Return(true)));
 
-  command->onTimeOut();
+  command->OnTimeOut();
   EXPECT_EQ((*ui_command_result)[am::strings::msg_params][am::strings::success]
                 .asBool(),
             false);
@@ -259,13 +260,13 @@ TEST_F(AlertRequestTest, OnEvent_UI_HmiSendSuccess_UNSUPPORTED_RESOURCE) {
 
 class CallOnTimeOut {
  public:
-  CallOnTimeOut(CommandRequestImpl& command) : command_(command) {}
+  CallOnTimeOut(RequestFromMobileImpl& command) : command_(command) {}
 
   void operator()() {
-    command_.onTimeOut();
+    command_.OnTimeOut();
   }
 
-  CommandRequestImpl& command_;
+  RequestFromMobileImpl& command_;
 };
 
 TEST_F(AlertRequestTest, Init_DurationExists_SUCCESS) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/create_interaction_choice_set_test.cc
@@ -165,11 +165,6 @@ class CreateInteractionChoiceSetResponseTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {};
 
 TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeout_GENERIC_ERROR) {
-  MessageSharedPtr msg_vr = CreateMessage(smart_objects::SmartType_Map);
-  (*msg_vr)[strings::msg_params][strings::result_code] =
-      am::mobile_api::Result::GENERIC_ERROR;
-  (*msg_vr)[strings::msg_params][strings::success] = false;
-
   std::shared_ptr<CreateInteractionChoiceSetRequest> req_vr =
       CreateCommand<CreateInteractionChoiceSetRequest>();
 
@@ -178,6 +173,8 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeout_GENERIC_ERROR) {
   ON_CALL(*mock_app, app_id()).WillByDefault(Return(kConnectionKey));
   ON_CALL(*mock_app, get_grammar_id()).WillByDefault(Return(kConnectionKey));
   ON_CALL(*mock_app, RemoveCommand(_)).WillByDefault(Return());
+
+  InitNegativeResponse();
 
   MessageSharedPtr vr_command_result;
 
@@ -191,7 +188,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeout_GENERIC_ERROR) {
       .WillOnce(ReturnRef(mock_resume_ctrl));
   EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
 
-  req_vr->onTimeOut();
+  req_vr->OnTimeOut();
   EXPECT_EQ(
       (*vr_command_result)[strings::msg_params][strings::success].asBool(),
       false);
@@ -706,6 +703,8 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
        OnTimeOut_InvalidErrorFromHMI_UNSUCCESS) {
   EXPECT_CALL(app_mngr_, application(_)).WillOnce(Return(mock_app_));
 
+  InitNegativeResponse();
+
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   MobileResultCodeIs(mobile_apis::Result::GENERIC_ERROR),
@@ -716,8 +715,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       .WillOnce(ReturnRef(mock_resume_ctrl));
   EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
-
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 TEST_F(CreateInteractionChoiceSetRequestTest,
@@ -766,7 +764,7 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
   EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
   EXPECT_CALL(app_mngr_, TerminateRequest(_, _, _));
 
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
@@ -811,12 +809,13 @@ TEST_F(CreateInteractionChoiceSetRequestTest, OnTimeOut_InvalidApp_UNSUCCESS) {
   EXPECT_CALL(app_mngr_, application(kConnectionKey))
       .WillOnce(Return(invalid_app));
   EXPECT_CALL(*mock_app_, RemoveChoiceSet(_)).Times(0);
+
   resumption_test::MockResumeCtrl mock_resume_ctrl;
   EXPECT_CALL(app_mngr_, resume_controller())
       .WillOnce(ReturnRef(mock_resume_ctrl));
   EXPECT_CALL(mock_resume_ctrl, HandleOnTimeOut(_, _));
 
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 TEST_F(CreateInteractionChoiceSetRequestTest,
@@ -871,7 +870,9 @@ TEST_F(CreateInteractionChoiceSetRequestTest,
       .WillOnce(Return(mock_app_));
   EXPECT_CALL(*mock_app_, RemoveChoiceSet(_));
 
-  command_->onTimeOut();
+  InitNegativeResponse();
+
+  command_->OnTimeOut();
 }
 
 TEST_F(CreateInteractionChoiceSetResponseTest, Run_SuccessFalse_UNSUCCESS) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -184,7 +184,7 @@ TEST_F(PerformAudioPassThruRequestTest, OnTimeout_GENERIC_ERROR) {
       ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
       .WillOnce(DoAll(SaveArg<0>(&vr_command_result), Return(true)));
 
-  command->onTimeOut();
+  command->OnTimeOut();
   EXPECT_EQ((*vr_command_result)[am::strings::msg_params][am::strings::success]
                 .asBool(),
             false);
@@ -756,10 +756,20 @@ TEST_F(PerformAudioPassThruRequestTest,
   // For setting current_state_ -> kCompleted
 
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _));
-  command_sptr_->SendResponse(true, am::mobile_api::Result::SUCCESS);
   EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_, _)).Times(0);
 
-  command_sptr_->onTimeOut();
+  MessageSharedPtr timeout_response =
+      CreateMessage(smart_objects::SmartType_Map);
+  (*timeout_response)[am::strings::msg_params][am::strings::result_code] =
+      am::mobile_api::Result::GENERIC_ERROR;
+  (*timeout_response)[am::strings::msg_params][am::strings::success] = false;
+
+  EXPECT_CALL(
+      mock_message_helper_,
+      CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))
+      .WillOnce(Return(timeout_response));
+
+  command_sptr_->OnTimeOut();
 }
 
 TEST_F(PerformAudioPassThruRequestTest,
@@ -830,7 +840,7 @@ TEST_F(PerformAudioPassThruRequestTest,
                   HMIResultCodeIs(hmi_apis::FunctionID::TTS_StopSpeaking), _))
       .WillOnce(Return(false));
 
-  command_sptr_->onTimeOut();
+  command_sptr_->OnTimeOut();
 }
 
 }  // namespace perform_audio_pass_thru_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_interaction_test.cc
@@ -422,7 +422,6 @@ TEST_F(
   ASSERT_TRUE(command->Init());
 
   command->StartAwaitForInterfaces();
-  command->StartAwaitForInterfaces();
 
   MockAppPtr mock_app;
   EXPECT_CALL(app_mngr_, application(_)).WillRepeatedly(Return(mock_app));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/reset_global_properties_test.cc
@@ -404,7 +404,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       ManageMobileCommand(
           MobileResponseIs(mobile_apis::Result::GENERIC_ERROR, info, false),
           am::commands::Command::SOURCE_SDL));
-  command->onTimeOut();
+  command->OnTimeOut();
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest,
@@ -471,7 +471,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       ManageMobileCommand(
           MobileResponseIs(mobile_apis::Result::GENERIC_ERROR, info, false),
           am::commands::Command::SOURCE_SDL));
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 TEST_F(ResetGlobalPropertiesRequestTest,
@@ -528,7 +528,7 @@ TEST_F(ResetGlobalPropertiesRequestTest,
       ManageMobileCommand(
           MobileResponseIs(mobile_apis::Result::GENERIC_ERROR, info, false),
           am::commands::Command::SOURCE_SDL));
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 }  // namespace reset_global_properties

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/slider_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/slider_test.cc
@@ -55,6 +55,7 @@ namespace am = application_manager;
 using am::MockMessageHelper;
 using am::commands::CommandImpl;
 using am::commands::MessageSharedPtr;
+using app_mngr::commands::RequestFromMobileImpl;
 using policy_test::MockPolicyHandlerInterface;
 using sdl_rpc_plugin::commands::SliderRequest;
 using ::testing::_;
@@ -182,13 +183,13 @@ TEST_F(SliderRequestTest, OnEvent_UI_UNSUPPORTED_RESOURCE) {
 
 class CallOnTimeOut {
  public:
-  CallOnTimeOut(CommandRequestImpl& command) : command_(command) {}
+  CallOnTimeOut(RequestFromMobileImpl& command) : command_(command) {}
 
   void operator()() {
-    command_.onTimeOut();
+    command_.OnTimeOut();
   }
 
-  CommandRequestImpl& command_;
+  RequestFromMobileImpl& command_;
 };
 
 TEST_F(SliderRequestTest, Init_SUCCESS) {

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_get_vehicle_type_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_get_vehicle_type_request.h
@@ -61,7 +61,7 @@ class VIGetVehicleTypeRequest : public app_mngr::commands::RequestToHMI {
 
   void Run() OVERRIDE;
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VIGetVehicleTypeRequest);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_is_ready_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_is_ready_request.h
@@ -44,8 +44,7 @@ namespace commands {
 /**
  * @brief VIIsReadyRequest command class
  **/
-class VIIsReadyRequest : public app_mngr::commands::RequestToHMI,
-                         public app_mngr::event_engine::EventObserver {
+class VIIsReadyRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief VIIsReadyRequest class constructor
@@ -73,7 +72,7 @@ class VIIsReadyRequest : public app_mngr::commands::RequestToHMI,
   /**
    * @brief onTimeOut from requrst Controller
    */
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(VIIsReadyRequest);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/hmi/vi_subscribe_vehicle_data_request.h
@@ -66,7 +66,7 @@ class VISubscribeVehicleDataRequest : public app_mngr::commands::RequestToHMI {
    **/
   virtual void Run();
 
-  void onTimeOut() OVERRIDE;
+  void OnTimeOut() OVERRIDE;
 
  private:
   CustomVehicleDataManager& custom_vehicle_data_manager_;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/diagnostic_message_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/diagnostic_message_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DIAGNOSTIC_MESSAGE_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_DIAGNOSTIC_MESSAGE_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 #include "vehicle_info_plugin/vehicle_info_command_params.h"
 
@@ -46,7 +46,8 @@ namespace commands {
 /**
  * @brief DiagnosticMessageRequest command class
  **/
-class DiagnosticMessageRequest : public app_mngr::commands::CommandRequestImpl {
+class DiagnosticMessageRequest
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief DiagnosticMessageRequest class constructor

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/get_dtcs_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/get_dtcs_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_DTCS_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_DTCS_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 #include "vehicle_info_plugin/vehicle_info_command_params.h"
 
@@ -46,7 +46,7 @@ namespace commands {
 /**
  * @brief GetDTCsRequest command class
  **/
-class GetDTCsRequest : public app_mngr::commands::CommandRequestImpl {
+class GetDTCsRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief GetDTCsRequest class constructor
@@ -71,7 +71,7 @@ class GetDTCsRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(GetDTCsRequest);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/get_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/get_vehicle_data_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_VEHICLE_DATA_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_GET_VEHICLE_DATA_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 #include "vehicle_info_plugin/vehicle_info_command_params.h"
 
@@ -46,7 +46,7 @@ namespace commands {
 /**
  * @brief GetVehicleDataRequest command class
  **/
-class GetVehicleDataRequest : public app_mngr::commands::CommandRequestImpl {
+class GetVehicleDataRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief GetVehicleDataRequest class constructor
@@ -67,7 +67,7 @@ class GetVehicleDataRequest : public app_mngr::commands::CommandRequestImpl {
   virtual void Run();
 
  protected:
-  virtual void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
  private:
   /**

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/read_did_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/read_did_request.h
@@ -34,7 +34,7 @@
 #ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_READ_DID_REQUEST_H_
 #define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_READ_DID_REQUEST_H_
 
-#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 #include "vehicle_info_plugin/vehicle_info_command_params.h"
 namespace vehicle_info_plugin {
@@ -45,7 +45,7 @@ namespace commands {
 /**
  * @brief ReadDIDRequest command class
  **/
-class ReadDIDRequest : public app_mngr::commands::CommandRequestImpl {
+class ReadDIDRequest : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief ReadDIDRequest class constructor
@@ -65,7 +65,7 @@ class ReadDIDRequest : public app_mngr::commands::CommandRequestImpl {
    *
    * @param event The received event
    */
-  void on_event(const app_mngr::event_engine::Event& event);
+  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   /**
    * @brief Execute command

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/subscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/subscribe_vehicle_data_request.h
@@ -39,6 +39,7 @@
 
 #include "application_manager/application.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 #include "vehicle_info_plugin/custom_vehicle_data_manager.h"
 #include "vehicle_info_plugin/vehicle_info_app_extension.h"
@@ -53,7 +54,7 @@ namespace commands {
  * @brief SubscribeVehicleDataRequest command class
  **/
 class SubscribeVehicleDataRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief SubscribeVehicleDataRequest class constructor

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/unsubscribe_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/commands/mobile/unsubscribe_vehicle_data_request.h
@@ -36,6 +36,7 @@
 
 #include "application_manager/application.h"
 #include "application_manager/commands/command_request_impl.h"
+#include "application_manager/commands/request_from_mobile_impl.h"
 #include "utils/macro.h"
 #include "vehicle_info_plugin/custom_vehicle_data_manager.h"
 #include "vehicle_info_plugin/vehicle_info_app_extension.h"
@@ -50,7 +51,7 @@ namespace commands {
  * @brief UnsubscribeVehicleDataRequest command class
  **/
 class UnsubscribeVehicleDataRequest
-    : public app_mngr::commands::CommandRequestImpl {
+    : public app_mngr::commands::RequestFromMobileImpl {
  public:
   /**
    * @brief UnsubscribeVehicleDataRequest class constructor

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/include/vehicle_info_plugin/vehicle_info_pending_resumption_handler.h
@@ -52,7 +52,7 @@ class VehicleInfoPendingResumptionHandler
       app_mngr::ApplicationManager& application_manager,
       CustomVehicleDataManager& custom_vehicle_data_manager);
 
-  void on_event(const app_mngr::event_engine::Event& event) OVERRIDE;
+  void HandleOnEvent(const app_mngr::event_engine::Event& event) OVERRIDE;
 
   void HandleResumptionSubscriptionRequest(app_mngr::AppExtension& extension,
                                            app_mngr::Application& app) OVERRIDE;

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_request.cc
@@ -56,7 +56,7 @@ void VIGetVehicleTypeRequest::Run() {
   SendRequest();
 }
 
-void VIGetVehicleTypeRequest::onTimeOut() {
+void VIGetVehicleTypeRequest::OnTimeOut() {
   SDL_LOG_AUTO_TRACE();
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VehicleInfo_GetVehicleType);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_is_ready_request.cc
@@ -51,8 +51,7 @@ VIIsReadyRequest::VIIsReadyRequest(
                    params.application_manager_,
                    params.rpc_service_,
                    params.hmi_capabilities_,
-                   params.policy_handler_)
-    , EventObserver(application_manager_.event_dispatcher()) {}
+                   params.policy_handler_) {}
 
 VIIsReadyRequest::~VIIsReadyRequest() {}
 
@@ -97,7 +96,7 @@ void VIIsReadyRequest::on_event(const event_engine::Event& event) {
   }
 }
 
-void VIIsReadyRequest::onTimeOut() {
+void VIIsReadyRequest::OnTimeOut() {
   // Note(dtrunov): According to new requirment APPLINK-27956
   RequestInterfaceCapabilities(hmi_interface ::vehicle_info);
 }

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_subscribe_vehicle_data_request.cc
@@ -77,7 +77,7 @@ void VISubscribeVehicleDataRequest::Run() {
   SendRequest();
 }
 
-void VISubscribeVehicleDataRequest::onTimeOut() {
+void VISubscribeVehicleDataRequest::OnTimeOut() {
   event_engine::Event timeout_event(
       hmi_apis::FunctionID::VehicleInfo_SubscribeVehicleData);
   SDL_LOG_AUTO_TRACE();

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/diagnostic_message_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/diagnostic_message_request.cc
@@ -49,11 +49,11 @@ SDL_CREATE_LOG_VARIABLE("Commands")
 DiagnosticMessageRequest::DiagnosticMessageRequest(
     const application_manager::commands::MessageSharedPtr& message,
     const VehicleInfoCommandParams& params)
-    : CommandRequestImpl(message,
-                         params.application_manager_,
-                         params.rpc_service_,
-                         params.hmi_capabilities_,
-                         params.policy_handler_) {}
+    : RequestFromMobileImpl(message,
+                            params.application_manager_,
+                            params.rpc_service_,
+                            params.hmi_capabilities_,
+                            params.policy_handler_) {}
 
 DiagnosticMessageRequest::~DiagnosticMessageRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_dtcs_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_dtcs_request.cc
@@ -47,11 +47,11 @@ SDL_CREATE_LOG_VARIABLE("Commands")
 GetDTCsRequest::GetDTCsRequest(
     const application_manager::commands::MessageSharedPtr& message,
     const VehicleInfoCommandParams& params)
-    : CommandRequestImpl(message,
-                         params.application_manager_,
-                         params.rpc_service_,
-                         params.hmi_capabilities_,
-                         params.policy_handler_) {}
+    : RequestFromMobileImpl(message,
+                            params.application_manager_,
+                            params.rpc_service_,
+                            params.hmi_capabilities_,
+                            params.policy_handler_) {}
 
 GetDTCsRequest::~GetDTCsRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/get_vehicle_data_request.cc
@@ -54,11 +54,11 @@ namespace str = strings;
 GetVehicleDataRequest::GetVehicleDataRequest(
     const application_manager::commands::MessageSharedPtr& message,
     const VehicleInfoCommandParams& params)
-    : CommandRequestImpl(message,
-                         params.application_manager_,
-                         params.rpc_service_,
-                         params.hmi_capabilities_,
-                         params.policy_handler_)
+    : RequestFromMobileImpl(message,
+                            params.application_manager_,
+                            params.rpc_service_,
+                            params.hmi_capabilities_,
+                            params.policy_handler_)
     , custom_vehicle_data_manager_(params.custom_vehicle_data_manager_) {}
 
 GetVehicleDataRequest::~GetVehicleDataRequest() {}

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/read_did_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/read_did_request.cc
@@ -48,11 +48,11 @@ SDL_CREATE_LOG_VARIABLE("Commands")
 ReadDIDRequest::ReadDIDRequest(
     const application_manager::commands::MessageSharedPtr& message,
     const VehicleInfoCommandParams& params)
-    : CommandRequestImpl(message,
-                         params.application_manager_,
-                         params.rpc_service_,
-                         params.hmi_capabilities_,
-                         params.policy_handler_) {}
+    : RequestFromMobileImpl(message,
+                            params.application_manager_,
+                            params.rpc_service_,
+                            params.hmi_capabilities_,
+                            params.policy_handler_) {}
 
 ReadDIDRequest::~ReadDIDRequest() {}
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -47,11 +47,11 @@ SDL_CREATE_LOG_VARIABLE("Commands")
 SubscribeVehicleDataRequest::SubscribeVehicleDataRequest(
     const application_manager::commands::MessageSharedPtr& message,
     VehicleInfoCommandParams params)
-    : CommandRequestImpl(message,
-                         params.application_manager_,
-                         params.rpc_service_,
-                         params.hmi_capabilities_,
-                         params.policy_handler_)
+    : RequestFromMobileImpl(message,
+                            params.application_manager_,
+                            params.rpc_service_,
+                            params.hmi_capabilities_,
+                            params.policy_handler_)
     , custom_vehicle_data_manager_(params.custom_vehicle_data_manager_) {}
 
 SubscribeVehicleDataRequest::~SubscribeVehicleDataRequest() {}
@@ -103,7 +103,7 @@ void SubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
   }
   EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
   ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(RequestFromMobileImpl::connection_key());
 
   if (!app) {
     SDL_LOG_ERROR("NULL pointer.");

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/mobile/unsubscribe_vehicle_data_request.cc
@@ -52,11 +52,11 @@ SDL_CREATE_LOG_VARIABLE("Commands")
 UnsubscribeVehicleDataRequest::UnsubscribeVehicleDataRequest(
     const application_manager::commands::MessageSharedPtr& message,
     const VehicleInfoCommandParams& params)
-    : CommandRequestImpl(message,
-                         params.application_manager_,
-                         params.rpc_service_,
-                         params.hmi_capabilities_,
-                         params.policy_handler_)
+    : RequestFromMobileImpl(message,
+                            params.application_manager_,
+                            params.rpc_service_,
+                            params.hmi_capabilities_,
+                            params.policy_handler_)
     , custom_vehicle_data_manager_(params.custom_vehicle_data_manager_) {}
 
 UnsubscribeVehicleDataRequest::~UnsubscribeVehicleDataRequest() {}
@@ -189,7 +189,7 @@ void UnsubscribeVehicleDataRequest::on_event(const event_engine::Event& event) {
   EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_VehicleInfo);
 
   ApplicationSharedPtr app =
-      application_manager_.application(CommandRequestImpl::connection_key());
+      application_manager_.application(RequestFromMobileImpl::connection_key());
 
   if (!app) {
     SDL_LOG_ERROR("NULL pointer.");

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/vehicle_info_pending_resumption_handler.cc
@@ -205,7 +205,7 @@ void VehicleInfoPendingResumptionHandler::TriggerPendingResumption() {
   }
 }
 
-void VehicleInfoPendingResumptionHandler::on_event(
+void VehicleInfoPendingResumptionHandler::HandleOnEvent(
     const application_manager::event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
   sync_primitives::AutoLock lock(pending_resumption_lock_);

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_get_vehicle_type_request_test.cc
@@ -99,7 +99,7 @@ TEST_F(
   ASSERT_TRUE(command->Init());
 
   command->Run();
-  command->onTimeOut();
+  command->OnTimeOut();
 }
 
 }  // namespace vi_get_vehicle_type_request

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_is_ready_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/commands/hmi/vi_is_ready_request_test.cc
@@ -210,7 +210,7 @@ TEST_F(VIIsReadyRequestTest, Run_HMIDoestRespond_SendMessageToHMIByTimeout) {
   ASSERT_TRUE(command_->Init());
 
   command_->Run();
-  command_->onTimeOut();
+  command_->OnTimeOut();
 }
 
 }  // namespace vi_is_ready_request

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/test/vehicle_info_pending_resumption_test.cc
@@ -380,7 +380,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
               raise_event(EventCheck(subscribed_correlation_id,
                                      expected_data_in_event)));
 
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
   EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
@@ -427,7 +427,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
                                      expected_data_in_event)));
 
   // TODO check that raized the same fid and cid as subscribed
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
   EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
@@ -469,7 +469,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext, *mock_app);
 
   // TODO check that raized the same fid and cid as subscribed
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
   EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
@@ -506,7 +506,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext, *mock_app);
 
   // TODO check that raized the same fid and cid as subscribed
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("speed"));
   EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
@@ -550,7 +550,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest, TwoAppsOneSharedDataSuccess) {
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext, *mock_app);
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext2, *mock_app2);
   // TODO check that raized the same fid and cid as subscribed
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
   EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);
@@ -599,7 +599,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext, *mock_app);
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext2, *mock_app2);
   // TODO check that raized the same fid and cid as subscribed
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext->isSubscribedToVehicleInfo("speed"));
   EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
@@ -648,7 +648,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext, *mock_app);
   resumption_handler_->HandleResumptionSubscriptionRequest(*ext2, *mock_app2);
   // TODO check that raized the same fid and cid as subscribed
-  resumption_handler_->on_event(event);
+  resumption_handler_->HandleOnEvent(event);
 
   const std::map<std::string, hmi_apis::Common_VehicleDataResultCode::eType>
       second_subscriptions_result = {
@@ -661,7 +661,7 @@ TEST_F(VehicleInfoPendingResumptionHandlerTest,
       VehicleInfo_SubscribeVehicleData);
   second_event.set_smart_object(second_response);
 
-  resumption_handler_->on_event(second_event);
+  resumption_handler_->HandleOnEvent(second_event);
   EXPECT_FALSE(ext->isSubscribedToVehicleInfo("gps"));
   EXPECT_TRUE(ext2->isSubscribedToVehicleInfo("gps"));
   EXPECT_EQ(ext->PendingSubscriptions().GetData().size(), 0u);

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -173,7 +173,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
     , connection_handler_(NULL)
     , policy_handler_(new policy::PolicyHandler(policy_settings, *this))
     , protocol_handler_(NULL)
-    , request_ctrl_(am_settings)
+    , request_ctrl_(am_settings, event_dispatcher_)
     , hmi_so_factory_(NULL)
     , mobile_so_factory_(NULL)
     , hmi_capabilities_(new HMICapabilitiesImpl(*this))
@@ -4975,6 +4975,22 @@ void ApplicationManagerImpl::ChangeAppsHMILevel(
   } else {
     SDL_LOG_WARN("Redundant changing HMI level: " << level);
   }
+}
+
+bool ApplicationManagerImpl::RetainRequestInstance(
+    const uint32_t connection_key, const uint32_t correlation_id) {
+  return request_ctrl_.RetainRequestInstance(connection_key, correlation_id);
+}
+
+void ApplicationManagerImpl::RemoveRetainedRequest(
+    const uint32_t connection_key, const uint32_t correlation_id) {
+  request_ctrl_.RemoveRetainedRequest(connection_key, correlation_id);
+}
+
+bool ApplicationManagerImpl::IsStillWaitingForResponse(
+    const uint32_t connection_key, const uint32_t correlation_id) const {
+  return request_ctrl_.IsStillWaitingForResponse(connection_key,
+                                                 correlation_id);
 }
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -37,16 +37,6 @@
 #include "application_manager/message_helper.h"
 
 namespace application_manager {
-
-namespace {
-struct AppExtensionPredicate {
-  AppExtensionUID uid;
-  bool operator()(const ApplicationSharedPtr app) {
-    return app ? (app->QueryInterface(uid).use_count() != 0) : false;
-  }
-};
-}  // namespace
-
 namespace commands {
 
 SDL_CREATE_LOG_VARIABLE("Commands")
@@ -86,6 +76,8 @@ bool CommandImpl::CleanUp() {
 
 void CommandImpl::Run() {}
 
+void CommandImpl::OnUpdateTimeOut() {}
+
 uint32_t CommandImpl::default_timeout() const {
   return default_timeout_;
 }
@@ -111,6 +103,8 @@ uint32_t CommandImpl::connection_key() const {
   return (*message_)[strings::params][strings::connection_key].asUInt();
 }
 
+void CommandImpl::HandleTimeOut() {}
+
 void CommandImpl::set_warning_info(const std::string info) {
   warning_info_ = info;
 }
@@ -118,8 +112,6 @@ void CommandImpl::set_warning_info(const std::string info) {
 std::string CommandImpl::warning_info() const {
   return warning_info_;
 }
-
-void CommandImpl::onTimeOut() {}
 
 bool CommandImpl::AllowedToTerminate() {
   return allowed_to_terminate_;

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -1,22 +1,17 @@
 /*
  Copyright (c) 2016, Ford Motor Company
  All rights reserved.
-
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
-
  Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
-
  Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following
  disclaimer in the documentation and/or other materials provided with the
  distribution.
-
  Neither the name of the Ford Motor Company nor the names of its contributors
  may be used to endorse or promote products derived from this software
  without specific prior written permission.
-
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -30,171 +25,18 @@
  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <algorithm>
-#include <numeric>
-#include <string>
-#include "utils/macro.h"
-
 #include "application_manager/commands/command_request_impl.h"
 
-#include "application_manager/app_service_manager.h"
-#include "application_manager/application_manager.h"
+#include "application_manager/application_impl.h"
 #include "application_manager/message_helper.h"
 #include "application_manager/rpc_service.h"
+#include "smart_objects/enum_schema_item.h"
 #include "smart_objects/smart_object.h"
 
-#include "smart_objects/enum_schema_item.h"
-
 namespace application_manager {
-
 namespace commands {
 
-SDL_CREATE_LOG_VARIABLE("Commands");
-
-std::string MergeInfos(const ResponseInfo& first_info,
-                       const std::string& first_str,
-                       const ResponseInfo& second_info,
-                       const std::string& second_str) {
-  if ((first_info.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) &&
-      (second_info.interface_state != HmiInterfaces::STATE_NOT_AVAILABLE) &&
-      !second_str.empty()) {
-    return second_str;
-  }
-
-  if ((second_info.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) &&
-      (first_info.interface_state != HmiInterfaces::STATE_NOT_AVAILABLE) &&
-      !first_str.empty()) {
-    return first_str;
-  }
-
-  return MergeInfos(first_str, second_str);
-}
-
-std::string MergeInfos(const std::string& first, const std::string& second) {
-  return first + ((!first.empty() && !second.empty()) ? ", " : "") + second;
-}
-
-std::string MergeInfos(const std::string& first,
-                       const std::string& second,
-                       const std::string& third) {
-  std::string result = MergeInfos(first, second);
-  return MergeInfos(result, third);
-}
-
-const std::string CreateInfoForUnsupportedResult(
-    HmiInterfaces::InterfaceID interface) {
-  switch (interface) {
-    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_VR): {
-      return "VR is not supported by system";
-    }
-    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_TTS): {
-      return "TTS is not supported by system";
-    }
-    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_UI): {
-      return "UI is not supported by system";
-    }
-    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_Navigation): {
-      return "Navigation is not supported by system";
-    }
-    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_VehicleInfo): {
-      return "VehicleInfo is not supported by system";
-    }
-    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_RC): {
-      return "RC is not supported by system";
-    }
-    default:
-      SDL_LOG_WARN(
-          "Could not create info because"
-          " interface isn't valid. Interface is:"
-          << static_cast<int32_t>(interface));
-      return "";
-  }
-}
-
-bool CommandRequestImpl::CheckResult(const ResponseInfo& first,
-                                     const ResponseInfo& second) const {
-  if (first.is_ok && second.is_unsupported_resource) {
-    return true;
-  }
-  if (first.is_ok && second.is_not_used) {
-    return true;
-  }
-  if (first.is_ok && second.is_ok) {
-    return true;
-  }
-  return false;
-}
-
-bool IsResultCodeWarning(const ResponseInfo& first,
-                         const ResponseInfo& second) {
-  const bool first_is_ok_second_is_warn =
-      (first.is_ok || first.is_not_used) &&
-      hmi_apis::Common_Result::WARNINGS == second.result_code;
-
-  const bool both_warnings =
-      hmi_apis::Common_Result::WARNINGS == first.result_code &&
-      hmi_apis::Common_Result::WARNINGS == second.result_code;
-
-  return first_is_ok_second_is_warn || both_warnings;
-}
-
-struct DisallowedParamsInserter {
-  DisallowedParamsInserter(smart_objects::SmartObject& response,
-                           mobile_apis::VehicleDataResultCode::eType code)
-      : response_(response), code_(code) {}
-
-  bool operator()(const std::string& param) {
-    smart_objects::SmartObjectSPtr disallowed_param =
-        std::make_shared<smart_objects::SmartObject>(
-            smart_objects::SmartType_Map);
-
-    auto rpc_spec_vehicle_data = MessageHelper::vehicle_data();
-    auto vehicle_data = rpc_spec_vehicle_data.find(param);
-    auto vehicle_data_type =
-        vehicle_data == rpc_spec_vehicle_data.end()
-            ? mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA
-            : vehicle_data->second;
-
-    (*disallowed_param)[strings::data_type] = vehicle_data_type;
-    (*disallowed_param)[strings::result_code] = code_;
-    response_[strings::msg_params][param.c_str()] = *disallowed_param;
-    return true;
-  }
-
- private:
-  smart_objects::SmartObject& response_;
-  mobile_apis::VehicleDataResultCode::eType code_;
-};
-
-ResponseInfo::ResponseInfo()
-    : result_code(hmi_apis::Common_Result::INVALID_ENUM)
-    , interface(HmiInterfaces::HMI_INTERFACE_INVALID_ENUM)
-    , interface_state(HmiInterfaces::STATE_NOT_RESPONSE)
-    , is_ok(false)
-    , is_unsupported_resource(false)
-    , is_not_used(false) {}
-
-ResponseInfo::ResponseInfo(const hmi_apis::Common_Result::eType result,
-                           const HmiInterfaces::InterfaceID hmi_interface,
-                           ApplicationManager& application_manager)
-    : result_code(result)
-    , interface(hmi_interface)
-    , interface_state(HmiInterfaces::STATE_NOT_RESPONSE)
-    , is_ok(false)
-    , is_unsupported_resource(false)
-    , is_not_used(false) {
-  using namespace helpers;
-
-  interface_state =
-      application_manager.hmi_interfaces().GetInterfaceState(hmi_interface);
-
-  is_ok = CommandRequestImpl::IsHMIResultSuccess(result_code);
-
-  is_not_used = hmi_apis::Common_Result::INVALID_ENUM == result_code;
-
-  is_unsupported_resource =
-      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code;
-}
+SDL_CREATE_LOG_VARIABLE("Commands")
 
 CommandRequestImpl::CommandRequestImpl(
     const MessageSharedPtr& message,
@@ -208,269 +50,25 @@ CommandRequestImpl::CommandRequestImpl(
                   hmi_capabilities,
                   policy_handler)
     , EventObserver(application_manager.event_dispatcher())
-    , current_state_(kAwaitingHMIResponse)
-    , hash_update_mode_(kSkipHashUpdate)
-    , is_success_result_(false) {}
+    , current_state_(RequestState::kAwaitingResponse) {}
 
 CommandRequestImpl::~CommandRequestImpl() {
-  UpdateHash();
-}
-
-bool CommandRequestImpl::Init() {
-  return true;
-}
-
-bool CommandRequestImpl::CheckPermissions() {
-  return CheckAllowedParameters(Command::CommandSource::SOURCE_MOBILE);
-}
-
-bool CommandRequestImpl::CleanUp() {
-  return true;
+  CleanUp();
 }
 
 void CommandRequestImpl::Run() {}
 
-void CommandRequestImpl::onTimeOut() {
+bool CommandRequestImpl::CheckAllowedParameters(
+    const Command::CommandSource source) {
   SDL_LOG_AUTO_TRACE();
 
-  unsubscribe_from_all_hmi_events();
-  unsubscribe_from_all_mobile_events();
-  {
-    // FIXME (dchmerev@luxoft.com): atomic_xchg fits better
-    sync_primitives::AutoLock auto_lock(state_lock_);
-    if (kCompleted == current_state_) {
-      SDL_LOG_DEBUG("current_state_ = kCompleted");
-      // don't send timeout if request completed
-      return;
-    }
-
-    current_state_ = kTimedOut;
+  // RegisterAppInterface should always be allowed
+  if (mobile_apis::FunctionID::RegisterAppInterfaceID ==
+      static_cast<mobile_apis::FunctionID::eType>(function_id())) {
+    return true;
   }
 
-  smart_objects::SmartObjectSPtr response =
-      MessageHelper::CreateNegativeResponse(connection_key(),
-                                            function_id(),
-                                            correlation_id(),
-                                            mobile_api::Result::GENERIC_ERROR);
-  AddTimeOutComponentInfoToMessage(*response);
-  rpc_service_.ManageMobileCommand(response, SOURCE_SDL);
-}
-
-void CommandRequestImpl::on_event(const event_engine::Event& event) {}
-
-void CommandRequestImpl::on_event(const event_engine::MobileEvent& event) {}
-
-void CommandRequestImpl::SendResponse(
-    const bool success,
-    const mobile_apis::Result::eType& result_code,
-    const char* info,
-    const smart_objects::SmartObject* response_params,
-    const std::vector<uint8_t> binary_data) {
-  SDL_LOG_AUTO_TRACE();
-  {
-    sync_primitives::AutoLock auto_lock(state_lock_);
-    if (kTimedOut == current_state_) {
-      // don't send response if request timeout expired
-      return;
-    }
-
-    current_state_ = kCompleted;
-  }
-
-  smart_objects::SmartObjectSPtr result =
-      std::make_shared<smart_objects::SmartObject>();
-
-  smart_objects::SmartObject& response = *result;
-
-  response[strings::params][strings::message_type] = MessageType::kResponse;
-  response[strings::params][strings::correlation_id] = correlation_id();
-  response[strings::params][strings::protocol_type] =
-      CommandImpl::mobile_protocol_type_;
-  response[strings::params][strings::protocol_version] =
-      CommandImpl::protocol_version_;
-  response[strings::params][strings::connection_key] = connection_key();
-  response[strings::params][strings::function_id] = function_id();
-  if (!binary_data.empty()) {
-    response[strings::params][strings::binary_data] = binary_data;
-  }
-  if (response_params) {
-    response[strings::msg_params] = *response_params;
-  }
-
-  if (info && *info != '\0') {
-    response[strings::msg_params][strings::info] = std::string(info);
-  }
-
-  // Add disallowed parameters and info from request back to response with
-  // appropriate reasons (VehicleData result codes)
-  if (result_code != mobile_apis::Result::APPLICATION_NOT_REGISTERED &&
-      result_code != mobile_apis::Result::INVALID_DATA) {
-    const mobile_apis::FunctionID::eType& id =
-        static_cast<mobile_apis::FunctionID::eType>(function_id());
-    if ((id == mobile_apis::FunctionID::SubscribeVehicleDataID) ||
-        (id == mobile_apis::FunctionID::UnsubscribeVehicleDataID)) {
-      AddDisallowedParameters(response);
-      AddDisallowedParametersToInfo(response);
-    } else if (id == mobile_apis::FunctionID::GetVehicleDataID) {
-      AddDisallowedParametersToInfo(response);
-    }
-  }
-
-  response[strings::msg_params][strings::success] = success;
-  if ((result_code == mobile_apis::Result::SUCCESS ||
-       result_code == mobile_apis::Result::WARNINGS) &&
-      !warning_info().empty()) {
-    response[strings::msg_params][strings::info] =
-        (info && *info != '\0') ? std::string(info) + "\n" + warning_info()
-                                : warning_info();
-    response[strings::msg_params][strings::result_code] =
-        mobile_apis::Result::WARNINGS;
-  } else {
-    response[strings::msg_params][strings::result_code] = result_code;
-  }
-
-  is_success_result_ = success;
-
-  rpc_service_.ManageMobileCommand(result, SOURCE_SDL);
-}
-
-smart_objects::SmartObject CreateUnsupportedResourceResponse(
-    const hmi_apis::FunctionID::eType function_id,
-    const uint32_t hmi_correlation_id,
-    HmiInterfaces::InterfaceID interface) {
-  smart_objects::SmartObject response(smart_objects::SmartType_Map);
-  smart_objects::SmartObject& params = response[strings::params];
-  params[strings::message_type] = MessageType::kResponse;
-  params[strings::correlation_id] = hmi_correlation_id;
-  params[strings::protocol_type] = CommandImpl::hmi_protocol_type_;
-  params[strings::protocol_version] = CommandImpl::protocol_version_;
-  params[strings::function_id] = function_id;
-  params[hmi_response::code] = hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
-  smart_objects::SmartObject& msg_params = response[strings::msg_params];
-  msg_params[strings::info] = CreateInfoForUnsupportedResult(interface);
-  return response;
-}
-
-bool CommandRequestImpl::ProcessHMIInterfacesAvailability(
-    const uint32_t hmi_correlation_id,
-    const hmi_apis::FunctionID::eType& function_id) {
-  SDL_LOG_AUTO_TRACE();
-  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
-  HmiInterfaces::InterfaceID interface =
-      hmi_interfaces.GetInterfaceFromFunction(function_id);
-  DCHECK(interface != HmiInterfaces::HMI_INTERFACE_INVALID_ENUM);
-  const HmiInterfaces::InterfaceState state =
-      hmi_interfaces.GetInterfaceState(interface);
-  if (HmiInterfaces::STATE_NOT_AVAILABLE == state) {
-    event_engine::Event event(function_id);
-    event.set_smart_object(CreateUnsupportedResourceResponse(
-        function_id, hmi_correlation_id, interface));
-    event.raise(application_manager_.event_dispatcher());
-    return false;
-  }
-  return true;
-}
-
-void CommandRequestImpl::UpdateHash() {
-  SDL_LOG_AUTO_TRACE();
-  if (hash_update_mode_ == kSkipHashUpdate) {
-    SDL_LOG_DEBUG("Hash update is disabled for " << function_id());
-    return;
-  }
-
-  if (HmiInterfaces::InterfaceState::STATE_NOT_RESPONSE ==
-      application_manager_.hmi_interfaces().GetInterfaceState(
-          HmiInterfaces::InterfaceID::HMI_INTERFACE_UI)) {
-    SDL_LOG_ERROR("UI interface has not responded. Hash won't be updated.");
-    return;
-  }
-
-  if (!is_success_result_) {
-    SDL_LOG_WARN("Command is not succeeded. Hash won't be updated.");
-    return;
-  }
-
-  ApplicationSharedPtr application =
-      application_manager_.application(connection_key());
-  if (!application) {
-    SDL_LOG_ERROR("Application with connection key "
-                  << connection_key()
-                  << " not found. Not able to update hash.");
-    return;
-  }
-
-  SDL_LOG_DEBUG(
-      "Updating hash for application with connection key "
-      << connection_key() << " while processing function id "
-      << MessageHelper::StringifiedFunctionID(
-             static_cast<mobile_api::FunctionID::eType>(function_id())));
-
-  application->UpdateHash();
-}
-
-void CommandRequestImpl::SendProviderRequest(
-    const mobile_apis::FunctionID::eType& mobile_function_id,
-    const hmi_apis::FunctionID::eType& hmi_function_id,
-    const smart_objects::SmartObject* msg,
-    bool use_events) {
-  SDL_LOG_AUTO_TRACE();
-  bool hmi_destination = false;
-  ApplicationSharedPtr app;
-  // Default error code and error message
-  std::string error_msg = "No app service provider available";
-  mobile_apis::Result::eType error_code =
-      mobile_apis::Result::DATA_NOT_AVAILABLE;
-
-  if ((*msg)[strings::msg_params].keyExists(strings::service_type)) {
-    std::string service_type =
-        (*msg)[strings::msg_params][strings::service_type].asString();
-    application_manager_.GetAppServiceManager().GetProviderByType(
-        service_type, true, app, hmi_destination);
-    error_msg = "No app service provider with serviceType: " + service_type +
-                " is available";
-    error_code = mobile_apis::Result::DATA_NOT_AVAILABLE;
-  } else if ((*msg)[strings::msg_params].keyExists(strings::service_id)) {
-    std::string service_id =
-        (*msg)[strings::msg_params][strings::service_id].asString();
-    application_manager_.GetAppServiceManager().GetProviderByID(
-        service_id, true, app, hmi_destination);
-    error_msg = "No app service provider with serviceId: " + service_id +
-                " is available";
-    error_code = mobile_apis::Result::INVALID_ID;
-  }
-
-  if (hmi_destination) {
-    SDL_LOG_DEBUG("Sending Request to HMI Provider");
-    application_manager_.IncreaseForwardedRequestTimeout(connection_key(),
-                                                         correlation_id());
-    SendHMIRequest(hmi_function_id, &(*msg)[strings::msg_params], use_events);
-    return;
-  }
-
-  if (!app) {
-    SDL_LOG_DEBUG("Invalid App Provider pointer");
-    SendResponse(false, error_code, error_msg.c_str());
-    return;
-  }
-
-  if (connection_key() == app->app_id()) {
-    SendResponse(false,
-                 mobile_apis::Result::IGNORED,
-                 "Consumer app is same as producer app");
-    return;
-  }
-
-  smart_objects::SmartObjectSPtr new_msg =
-      std::make_shared<smart_objects::SmartObject>();
-  smart_objects::SmartObject& request = *new_msg;
-
-  request[strings::params] = (*msg)[strings::params];
-  request[strings::msg_params] = (*msg)[strings::msg_params];
-  request[strings::params][strings::connection_key] = app->app_id();
-
-  application_manager_.IncreaseForwardedRequestTimeout(connection_key(),
-                                                       correlation_id());
-  SendMobileRequest(mobile_function_id, new_msg, use_events);
+  return CommandImpl::CheckAllowedParameters(source);
 }
 
 void CommandRequestImpl::SendMobileRequest(
@@ -495,288 +93,24 @@ void CommandRequestImpl::SendMobileRequest(
   }
 }
 
-uint32_t CommandRequestImpl::SendHMIRequest(
-    const hmi_apis::FunctionID::eType& function_id,
-    const smart_objects::SmartObject* msg_params,
-    bool use_events) {
-  smart_objects::SmartObjectSPtr result =
-      std::make_shared<smart_objects::SmartObject>();
+void CommandRequestImpl::OnTimeOut() {}
 
-  const uint32_t hmi_correlation_id =
-      application_manager_.GetNextHMICorrelationID();
+void CommandRequestImpl::on_event(const event_engine::Event&) {}
+void CommandRequestImpl::on_event(const event_engine::MobileEvent&) {}
 
-  smart_objects::SmartObject& request = *result;
-  request[strings::params][strings::message_type] = MessageType::kRequest;
-  request[strings::params][strings::function_id] = function_id;
-  request[strings::params][strings::correlation_id] = hmi_correlation_id;
-  request[strings::params][strings::protocol_version] =
-      CommandImpl::protocol_version_;
-  request[strings::params][strings::protocol_type] =
-      CommandImpl::hmi_protocol_type_;
-
-  if (msg_params) {
-    request[strings::msg_params] = *msg_params;
-  }
-
-  if (use_events) {
-    SDL_LOG_DEBUG("SendHMIRequest subscribe_on_event " << function_id << " "
-                                                       << hmi_correlation_id);
-    subscribe_on_event(function_id, hmi_correlation_id);
-  }
-  if (ProcessHMIInterfacesAvailability(hmi_correlation_id, function_id)) {
-    if (!rpc_service_.ManageHMICommand(result, SOURCE_SDL_TO_HMI)) {
-      SDL_LOG_ERROR("Unable to send request");
-      SendResponse(false, mobile_apis::Result::OUT_OF_MEMORY);
-    }
-  } else {
-    SDL_LOG_DEBUG("Interface is not available");
-  }
-  return hmi_correlation_id;
-}
-
-void CommandRequestImpl::CreateHMINotification(
-    const hmi_apis::FunctionID::eType& function_id,
-    const ns_smart::SmartObject& msg_params) const {
-  smart_objects::SmartObjectSPtr result =
-      std::make_shared<smart_objects::SmartObject>();
-  if (!result) {
-    SDL_LOG_ERROR("Memory allocation failed.");
-    return;
-  }
-  smart_objects::SmartObject& notify = *result;
-
-  notify[strings::params][strings::message_type] =
-      static_cast<int32_t>(application_manager::MessageType::kNotification);
-  notify[strings::params][strings::protocol_version] =
-      CommandImpl::protocol_version_;
-  notify[strings::params][strings::protocol_type] =
-      CommandImpl::hmi_protocol_type_;
-  notify[strings::params][strings::function_id] = function_id;
-  notify[strings::msg_params] = msg_params;
-
-  if (!rpc_service_.ManageHMICommand(result, SOURCE_SDL_TO_HMI)) {
-    SDL_LOG_ERROR("Unable to send HMI notification");
-  }
-}
-
-mobile_apis::Result::eType CommandRequestImpl::GetMobileResultCode(
-    const hmi_apis::Common_Result::eType& hmi_code) const {
-  mobile_apis::Result::eType mobile_result = mobile_apis::Result::GENERIC_ERROR;
-  switch (hmi_code) {
-    case hmi_apis::Common_Result::SUCCESS: {
-      mobile_result = mobile_apis::Result::SUCCESS;
-      break;
-    }
-    case hmi_apis::Common_Result::UNSUPPORTED_REQUEST: {
-      mobile_result = mobile_apis::Result::UNSUPPORTED_REQUEST;
-      break;
-    }
-    case hmi_apis::Common_Result::UNSUPPORTED_RESOURCE: {
-      mobile_result = mobile_apis::Result::UNSUPPORTED_RESOURCE;
-      break;
-    }
-    case hmi_apis::Common_Result::DISALLOWED: {
-      mobile_result = mobile_apis::Result::DISALLOWED;
-      break;
-    }
-    case hmi_apis::Common_Result::REJECTED: {
-      mobile_result = mobile_apis::Result::REJECTED;
-      break;
-    }
-    case hmi_apis::Common_Result::ABORTED: {
-      mobile_result = mobile_apis::Result::ABORTED;
-      break;
-    }
-    case hmi_apis::Common_Result::IGNORED: {
-      mobile_result = mobile_apis::Result::IGNORED;
-      break;
-    }
-    case hmi_apis::Common_Result::RETRY: {
-      mobile_result = mobile_apis::Result::RETRY;
-      break;
-    }
-    case hmi_apis::Common_Result::IN_USE: {
-      mobile_result = mobile_apis::Result::IN_USE;
-      break;
-    }
-    case hmi_apis::Common_Result::DATA_NOT_AVAILABLE: {
-      mobile_result = mobile_apis::Result::VEHICLE_DATA_NOT_AVAILABLE;
-      break;
-    }
-    case hmi_apis::Common_Result::TIMED_OUT: {
-      mobile_result = mobile_apis::Result::TIMED_OUT;
-      break;
-    }
-    case hmi_apis::Common_Result::INVALID_DATA: {
-      mobile_result = mobile_apis::Result::INVALID_DATA;
-      break;
-    }
-    case hmi_apis::Common_Result::CHAR_LIMIT_EXCEEDED: {
-      mobile_result = mobile_apis::Result::CHAR_LIMIT_EXCEEDED;
-      break;
-    }
-    case hmi_apis::Common_Result::INVALID_ID: {
-      mobile_result = mobile_apis::Result::INVALID_ID;
-      break;
-    }
-    case hmi_apis::Common_Result::DUPLICATE_NAME: {
-      mobile_result = mobile_apis::Result::DUPLICATE_NAME;
-      break;
-    }
-    case hmi_apis::Common_Result::APPLICATION_NOT_REGISTERED: {
-      mobile_result = mobile_apis::Result::APPLICATION_NOT_REGISTERED;
-      break;
-    }
-    case hmi_apis::Common_Result::WRONG_LANGUAGE: {
-      mobile_result = mobile_apis::Result::WRONG_LANGUAGE;
-      break;
-    }
-    case hmi_apis::Common_Result::OUT_OF_MEMORY: {
-      mobile_result = mobile_apis::Result::OUT_OF_MEMORY;
-      break;
-    }
-    case hmi_apis::Common_Result::TOO_MANY_PENDING_REQUESTS: {
-      mobile_result = mobile_apis::Result::TOO_MANY_PENDING_REQUESTS;
-      break;
-    }
-    case hmi_apis::Common_Result::NO_APPS_REGISTERED: {
-      mobile_result = mobile_apis::Result::APPLICATION_NOT_REGISTERED;
-      break;
-    }
-    case hmi_apis::Common_Result::NO_DEVICES_CONNECTED: {
-      mobile_result = mobile_apis::Result::APPLICATION_NOT_REGISTERED;
-      break;
-    }
-    case hmi_apis::Common_Result::WARNINGS: {
-      mobile_result = mobile_apis::Result::WARNINGS;
-      break;
-    }
-    case hmi_apis::Common_Result::GENERIC_ERROR: {
-      mobile_result = mobile_apis::Result::GENERIC_ERROR;
-      break;
-    }
-    case hmi_apis::Common_Result::USER_DISALLOWED: {
-      mobile_result = mobile_apis::Result::USER_DISALLOWED;
-      break;
-    }
-    case hmi_apis::Common_Result::SAVED: {
-      mobile_result = mobile_apis::Result::SAVED;
-      break;
-    }
-    case hmi_apis::Common_Result::READ_ONLY: {
-      mobile_result = mobile_apis::Result::READ_ONLY;
-      break;
-    }
-    default: {
-      SDL_LOG_ERROR("Unknown HMI result code " << hmi_code);
-      break;
-    }
-  }
-
-  return mobile_result;
-}
-
-bool CommandRequestImpl::CheckAllowedParameters(
-    const Command::CommandSource source) {
+void CommandRequestImpl::HandleTimeOut() {
   SDL_LOG_AUTO_TRACE();
-
-  // RegisterAppInterface should always be allowed
-  if (mobile_apis::FunctionID::RegisterAppInterfaceID ==
-      static_cast<mobile_apis::FunctionID::eType>(function_id())) {
-    return true;
-  }
-
-  return CommandImpl::CheckAllowedParameters(source);
-}
-
-bool CommandRequestImpl::CheckHMICapabilities(
-    const mobile_apis::ButtonName::eType button) const {
-  SDL_LOG_AUTO_TRACE();
-
-  using namespace smart_objects;
-  using namespace mobile_apis;
-
-  if (!hmi_capabilities_.is_ui_cooperating()) {
-    SDL_LOG_ERROR("UI is not supported by HMI");
-    return false;
-  }
-
-  auto button_capabilities = hmi_capabilities_.button_capabilities();
-  if (!button_capabilities) {
-    SDL_LOG_ERROR("Invalid button capabilities object");
-    return false;
-  }
-
-  for (size_t i = 0; i < button_capabilities->length(); ++i) {
-    const SmartObject& capabilities = (*button_capabilities)[i];
-    const ButtonName::eType current_button = static_cast<ButtonName::eType>(
-        capabilities.getElement(hmi_response::button_name).asInt());
-    if (current_button == button) {
-      SDL_LOG_DEBUG("Button capabilities for " << button << " was found");
-      return true;
+  {
+    sync_primitives::AutoLock auto_lock(state_lock_);
+    if (RequestState::kProcessEvent == current_state()) {
+      SDL_LOG_DEBUG("Current request state is: "
+                    << current_state() << ". Timeout request ignored");
+      return;
     }
+    set_current_state(RequestState::kTimedOut);
   }
 
-  SDL_LOG_DEBUG("Button capabilities for " << button << " was not found");
-  return false;
-}
-
-void CommandRequestImpl::AddDisallowedParameterToInfoString(
-    std::string& info, const std::string& param) const {
-  // prepare disallowed params enumeration for response info string
-  if (info.empty()) {
-    info = "\'" + param + "\'";
-  } else {
-    info = info + "," + " " + "\'" + param + "\'";
-  }
-}
-
-void CommandRequestImpl::AddDisallowedParametersToInfo(
-    smart_objects::SmartObject& response) const {
-  std::string info;
-
-  RPCParams::const_iterator it =
-      removed_parameters_permissions_.disallowed_params.begin();
-  for (; it != removed_parameters_permissions_.disallowed_params.end(); ++it) {
-    AddDisallowedParameterToInfoString(info, (*it));
-  }
-
-  it = removed_parameters_permissions_.undefined_params.begin();
-  for (; it != removed_parameters_permissions_.undefined_params.end(); ++it) {
-    AddDisallowedParameterToInfoString(info, (*it));
-  }
-
-  if (!info.empty()) {
-    info += " disallowed by policies.";
-
-    if (!response[strings::msg_params][strings::info].asString().empty()) {
-      // If we already have info add info about disallowed params to it
-      response[strings::msg_params][strings::info] =
-          response[strings::msg_params][strings::info].asString() + " " + info;
-    } else {
-      response[strings::msg_params][strings::info] = info;
-    }
-  }
-}
-
-void CommandRequestImpl::AddDisallowedParameters(
-    smart_objects::SmartObject& response) {
-  DisallowedParamsInserter disallowed_inserter(
-      response, mobile_apis::VehicleDataResultCode::VDRC_USER_DISALLOWED);
-  std::for_each(removed_parameters_permissions_.disallowed_params.begin(),
-                removed_parameters_permissions_.disallowed_params.end(),
-                disallowed_inserter);
-
-  DisallowedParamsInserter undefined_inserter(
-      response, mobile_apis::VehicleDataResultCode::VDRC_DISALLOWED);
-  std::for_each(removed_parameters_permissions_.undefined_params.begin(),
-                removed_parameters_permissions_.undefined_params.end(),
-                undefined_inserter);
-}
-
-bool CommandRequestImpl::HasDisallowedParams() const {
-  return ((!removed_parameters_permissions_.disallowed_params.empty()) ||
-          (!removed_parameters_permissions_.undefined_params.empty()));
+  OnTimeOut();
 }
 
 bool CommandRequestImpl::IsMobileResultSuccess(
@@ -807,77 +141,68 @@ bool CommandRequestImpl::IsHMIResultSuccess(
       hmi_apis::Common_Result::TRUNCATED_DATA);
 }
 
-bool CommandRequestImpl::PrepareResultForMobileResponse(
-    hmi_apis::Common_Result::eType result_code,
-    HmiInterfaces::InterfaceID interface) const {
+bool CommandRequestImpl::StartOnEventHandling() {
   SDL_LOG_AUTO_TRACE();
-  if (IsHMIResultSuccess(result_code)) {
-    return true;
+
+  const auto conn_key = connection_key();
+  const auto corr_id = correlation_id();
+
+  // Retain request instance to avoid object suicide after on_event()
+  if (!application_manager_.RetainRequestInstance(conn_key, corr_id)) {
+    return false;
   }
 
-  const HmiInterfaces::InterfaceState state =
-      application_manager_.hmi_interfaces().GetInterfaceState(interface);
-  if ((hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code) &&
-      (HmiInterfaces::STATE_NOT_AVAILABLE != state)) {
-    return true;
-  }
-  return false;
-}
-
-bool CommandRequestImpl::PrepareResultForMobileResponse(
-    ResponseInfo& out_first, ResponseInfo& out_second) const {
-  SDL_LOG_AUTO_TRACE();
-  bool result =
-      CheckResult(out_first, out_second) || CheckResult(out_second, out_first);
-  return result;
-}
-
-void CommandRequestImpl::GetInfo(
-    const smart_objects::SmartObject& response_from_hmi,
-    std::string& out_info) {
-  if (response_from_hmi[strings::msg_params].keyExists(strings::info)) {
-    if (!response_from_hmi[strings::msg_params][strings::info].empty()) {
-      out_info =
-          response_from_hmi[strings::msg_params][strings::info].asString();
+  {
+    sync_primitives::AutoLock auto_lock(state_lock_);
+    if (RequestState::kTimedOut == current_state()) {
+      SDL_LOG_DEBUG("current_state_ = kTimedOut");
+      return false;
     }
+    set_current_state(RequestState::kProcessEvent);
   }
+
+  return true;
 }
 
-mobile_apis::Result::eType CommandRequestImpl::PrepareResultCodeForResponse(
-    const ResponseInfo& first, const ResponseInfo& second) {
+void CommandRequestImpl::FinalizeOnEventHandling() {
+  const auto conn_key = connection_key();
+  const auto corr_id = correlation_id();
+
+  if (application_manager_.IsStillWaitingForResponse(conn_key, corr_id)) {
+    SDL_LOG_DEBUG("Request (" << conn_key << ", " << corr_id
+                              << ") is still waiting for repsonse");
+    set_current_state(RequestState::kAwaitingResponse);
+  }
+
+  // Remove request instance from retained to destroy it safely if required
+  application_manager_.RemoveRetainedRequest(conn_key, corr_id);
+}
+
+void CommandRequestImpl::HandleOnEvent(const event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
-  if (IsResultCodeUnsupported(first, second) ||
-      IsResultCodeUnsupported(second, first)) {
-    return mobile_apis::Result::UNSUPPORTED_RESOURCE;
+
+  if (!StartOnEventHandling()) {
+    return;
   }
-  if (IsResultCodeWarning(first, second) ||
-      IsResultCodeWarning(second, first)) {
-    return mobile_apis::Result::WARNINGS;
-  }
-  // If response contains erroneous result code SDL need return erroneus
-  // result code.
-  hmi_apis::Common_Result::eType first_result =
-      hmi_apis::Common_Result::INVALID_ENUM;
-  hmi_apis::Common_Result::eType second_result =
-      hmi_apis::Common_Result::INVALID_ENUM;
-  if (!first.is_unsupported_resource) {
-    first_result = first.result_code;
-  }
-  if (!second.is_unsupported_resource) {
-    second_result = second.result_code;
-  }
-  mobile_apis::Result::eType result_code =
-      MessageHelper::HMIToMobileResult(std::max(first_result, second_result));
-  return result_code;
+  on_event(event);
+  FinalizeOnEventHandling();
 }
 
-const CommandParametersPermissions& CommandRequestImpl::parameters_permissions()
-    const {
-  return parameters_permissions_;
+void CommandRequestImpl::HandleOnEvent(const event_engine::MobileEvent& event) {
+  if (!StartOnEventHandling()) {
+    return;
+  }
+  on_event(event);
+  FinalizeOnEventHandling();
+}
+
+void CommandRequestImpl::OnUpdateTimeOut() {
+  SDL_LOG_AUTO_TRACE();
+  set_current_state(RequestState::kAwaitingResponse);
 }
 
 void CommandRequestImpl::StartAwaitForInterface(
-    const HmiInterfaces::InterfaceID interface_id) {
+    const HmiInterfaces::InterfaceID& interface_id) {
   sync_primitives::AutoLock lock(awaiting_response_interfaces_lock_);
   awaiting_response_interfaces_.insert(interface_id);
 }
@@ -885,94 +210,31 @@ void CommandRequestImpl::StartAwaitForInterface(
 bool CommandRequestImpl::IsInterfaceAwaited(
     const HmiInterfaces::InterfaceID& interface_id) const {
   sync_primitives::AutoLock lock(awaiting_response_interfaces_lock_);
-  std::set<HmiInterfaces::InterfaceID>::const_iterator it =
-      awaiting_response_interfaces_.find(interface_id);
-  return (it != awaiting_response_interfaces_.end());
+
+  return helpers::in_range(awaiting_response_interfaces_, interface_id);
 }
 
 void CommandRequestImpl::EndAwaitForInterface(
     const HmiInterfaces::InterfaceID& interface_id) {
   sync_primitives::AutoLock lock(awaiting_response_interfaces_lock_);
-  std::set<HmiInterfaces::InterfaceID>::const_iterator it =
-      awaiting_response_interfaces_.find(interface_id);
-  if (it != awaiting_response_interfaces_.end()) {
-    awaiting_response_interfaces_.erase(it);
-  } else {
-    SDL_LOG_WARN(
-        "EndAwaitForInterface called on interface \
-                    which was not put into await state: "
-        << interface_id);
-  }
+  awaiting_response_interfaces_.erase(interface_id);
 }
 
-bool CommandRequestImpl::IsResultCodeUnsupported(
-    const ResponseInfo& first, const ResponseInfo& second) const {
-  const bool first_ok_second_unsupported =
-      (first.is_ok || first.is_not_used) && second.is_unsupported_resource;
-  const bool both_unsupported =
-      first.is_unsupported_resource && second.is_unsupported_resource;
-  return first_ok_second_unsupported || both_unsupported;
-}
-
-std::string GetComponentNameFromInterface(
-    const HmiInterfaces::InterfaceID& interface) {
-  switch (interface) {
-    case HmiInterfaces::HMI_INTERFACE_Buttons:
-      return hmi_interface::buttons;
-    case HmiInterfaces::HMI_INTERFACE_BasicCommunication:
-      return hmi_interface::basic_communication;
-    case HmiInterfaces::HMI_INTERFACE_VR:
-      return hmi_interface::vr;
-    case HmiInterfaces::HMI_INTERFACE_TTS:
-      return hmi_interface::tts;
-    case HmiInterfaces::HMI_INTERFACE_UI:
-      return hmi_interface::ui;
-    case HmiInterfaces::HMI_INTERFACE_Navigation:
-      return hmi_interface::navigation;
-    case HmiInterfaces::HMI_INTERFACE_VehicleInfo:
-      return hmi_interface::vehicle_info;
-    case HmiInterfaces::HMI_INTERFACE_SDL:
-      return hmi_interface::sdl;
-    case HmiInterfaces::HMI_INTERFACE_RC:
-      return hmi_interface::rc;
-    case HmiInterfaces::HMI_INTERFACE_AppService:
-      return hmi_interface::app_service;
-    default:
-      return "Unknown type";
-  }
-}
-
-const std::string InfoInterfaceSeparator(
-    const std::string& sum, const HmiInterfaces::InterfaceID container_value) {
-  return sum.empty()
-             ? GetComponentNameFromInterface(container_value)
-             : sum + ", " + GetComponentNameFromInterface(container_value);
-}
-
-void CommandRequestImpl::AddTimeOutComponentInfoToMessage(
-    smart_objects::SmartObject& response) const {
-  using ns_smart_device_link::ns_smart_objects::SmartObject;
-  SDL_LOG_AUTO_TRACE();
+bool CommandRequestImpl::IsPendingResponseExist() const {
   sync_primitives::AutoLock lock(awaiting_response_interfaces_lock_);
-  if (awaiting_response_interfaces_.empty()) {
-    SDL_LOG_ERROR("No interfaces awaiting, info param is empty");
-    return;
-  }
+  return !awaiting_response_interfaces_.empty();
+}
 
-  const std::string not_responding_interfaces_string =
-      std::accumulate(awaiting_response_interfaces_.begin(),
-                      awaiting_response_interfaces_.end(),
-                      std::string(""),
-                      InfoInterfaceSeparator);
-  SDL_LOG_DEBUG(
-      "Not responding interfaces string: " << not_responding_interfaces_string);
-  if (!not_responding_interfaces_string.empty()) {
-    const std::string component_info =
-        not_responding_interfaces_string + " component does not respond";
-    response[strings::msg_params][strings::info] = component_info;
-  }
+CommandRequestImpl::RequestState CommandRequestImpl::current_state() const {
+  sync_primitives::AutoLock auto_lock(state_lock_);
+  return current_state_;
+}
+
+void CommandRequestImpl::set_current_state(
+    const CommandRequestImpl::RequestState state) {
+  sync_primitives::AutoLock auto_lock(state_lock_);
+  current_state_ = state;
 }
 
 }  // namespace commands
-
 }  // namespace application_manager

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -1,17 +1,22 @@
 /*
  Copyright (c) 2016, Ford Motor Company
  All rights reserved.
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
+
  Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
+
  Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following
  disclaimer in the documentation and/or other materials provided with the
  distribution.
+
  Neither the name of the Ford Motor Company nor the names of its contributors
  may be used to endorse or promote products derived from this software
  without specific prior written permission.
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -181,19 +186,19 @@ void CommandRequestImpl::FinalizeOnEventHandling() {
 void CommandRequestImpl::HandleOnEvent(const event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
 
-  if (!StartOnEventHandling()) {
-    return;
+  if (StartOnEventHandling()) {
+    on_event(event);
+    FinalizeOnEventHandling();
   }
-  on_event(event);
-  FinalizeOnEventHandling();
 }
 
 void CommandRequestImpl::HandleOnEvent(const event_engine::MobileEvent& event) {
-  if (!StartOnEventHandling()) {
-    return;
+  SDL_LOG_AUTO_TRACE();
+
+  if (StartOnEventHandling()) {
+    on_event(event);
+    FinalizeOnEventHandling();
   }
-  on_event(event);
-  FinalizeOnEventHandling();
 }
 
 void CommandRequestImpl::OnUpdateTimeOut() {

--- a/src/components/application_manager/src/commands/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/request_from_hmi.cc
@@ -53,12 +53,11 @@ RequestFromHMI::RequestFromHMI(const MessageSharedPtr& message,
                                rpc_service::RPCService& rpc_service,
                                HMICapabilities& hmi_capabilities,
                                policy::PolicyHandlerInterface& policy_handler)
-    : CommandImpl(message,
-                  application_manager,
-                  rpc_service,
-                  hmi_capabilities,
-                  policy_handler)
-    , EventObserver(application_manager.event_dispatcher()) {
+    : CommandRequestImpl(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler) {
   // Replace HMI app id with Mobile connection id
   ReplaceHMIWithMobileAppId(*message);
 }
@@ -78,6 +77,8 @@ void RequestFromHMI::Run() {}
 void RequestFromHMI::on_event(const event_engine::Event& event) {}
 
 void RequestFromHMI::on_event(const event_engine::MobileEvent& event) {}
+
+void RequestFromHMI::OnTimeOut() {}
 
 void RequestFromHMI::SendResponse(
     const bool success,

--- a/src/components/application_manager/src/commands/request_from_mobile_impl.cc
+++ b/src/components/application_manager/src/commands/request_from_mobile_impl.cc
@@ -1,0 +1,934 @@
+/*
+ Copyright (c) 2020, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "application_manager/commands/request_from_mobile_impl.h"
+
+#include <algorithm>
+#include <numeric>
+#include <string>
+
+#include "application_manager/app_service_manager.h"
+#include "application_manager/application_manager.h"
+#include "application_manager/message_helper.h"
+#include "application_manager/rpc_service.h"
+#include "smart_objects/smart_object.h"
+#include "utils/macro.h"
+
+namespace application_manager {
+
+namespace commands {
+
+SDL_CREATE_LOG_VARIABLE("Commands")
+
+namespace smart_objects = ns_smart_device_link::ns_smart_objects;
+
+std::string MergeInfos(const ResponseInfo& first_info,
+                       const std::string& first_str,
+                       const ResponseInfo& second_info,
+                       const std::string& second_str) {
+  if ((first_info.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      (second_info.interface_state != HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      !second_str.empty()) {
+    return second_str;
+  }
+
+  if ((second_info.interface_state == HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      (first_info.interface_state != HmiInterfaces::STATE_NOT_AVAILABLE) &&
+      !first_str.empty()) {
+    return first_str;
+  }
+
+  return MergeInfos(first_str, second_str);
+}
+
+std::string MergeInfos(const std::string& first, const std::string& second) {
+  return first + ((!first.empty() && !second.empty()) ? ", " : "") + second;
+}
+
+std::string MergeInfos(const std::string& first,
+                       const std::string& second,
+                       const std::string& third) {
+  std::string result = MergeInfos(first, second);
+  return MergeInfos(result, third);
+}
+
+const std::string CreateInfoForUnsupportedResult(
+    HmiInterfaces::InterfaceID interface) {
+  switch (interface) {
+    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_VR): {
+      return "VR is not supported by system";
+    }
+    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_TTS): {
+      return "TTS is not supported by system";
+    }
+    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_UI): {
+      return "UI is not supported by system";
+    }
+    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_Navigation): {
+      return "Navigation is not supported by system";
+    }
+    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_VehicleInfo): {
+      return "VehicleInfo is not supported by system";
+    }
+    case (HmiInterfaces::InterfaceID::HMI_INTERFACE_RC): {
+      return "Remote control is not supported by system";
+    }
+    default:
+      SDL_LOG_WARN(
+          "Could not create info because"
+          " interface isn't valid. Interface is:"
+          << static_cast<int32_t>(interface));
+      return "";
+  }
+}
+
+bool RequestFromMobileImpl::CheckResultCode(const ResponseInfo& first,
+                                            const ResponseInfo& second) const {
+  if (first.is_ok && second.is_unsupported_resource) {
+    return true;
+  }
+  if (first.is_ok && second.is_not_used) {
+    return true;
+  }
+  if (first.is_ok && second.is_ok) {
+    return true;
+  }
+  return false;
+}
+
+bool IsResultCodeWarning(const ResponseInfo& first,
+                         const ResponseInfo& second) {
+  const bool first_is_ok_second_is_warn =
+      (first.is_ok || first.is_not_used) &&
+      hmi_apis::Common_Result::WARNINGS == second.result_code;
+
+  const bool both_warnings =
+      hmi_apis::Common_Result::WARNINGS == first.result_code &&
+      hmi_apis::Common_Result::WARNINGS == second.result_code;
+
+  return first_is_ok_second_is_warn || both_warnings;
+}
+
+struct DisallowedParamsInserter {
+  DisallowedParamsInserter(smart_objects::SmartObject& response,
+                           mobile_apis::VehicleDataResultCode::eType code)
+      : response_(response), code_(code) {}
+
+  bool operator()(const std::string& param) {
+    smart_objects::SmartObjectSPtr disallowed_param =
+        std::make_shared<smart_objects::SmartObject>(
+            smart_objects::SmartType_Map);
+
+    auto rpc_spec_vehicle_data = MessageHelper::vehicle_data();
+    auto vehicle_data = rpc_spec_vehicle_data.find(param);
+    auto vehicle_data_type =
+        vehicle_data == rpc_spec_vehicle_data.end()
+            ? mobile_apis::VehicleDataType::VEHICLEDATA_OEM_CUSTOM_DATA
+            : vehicle_data->second;
+
+    (*disallowed_param)[strings::data_type] = vehicle_data_type;
+    (*disallowed_param)[strings::result_code] = code_;
+    response_[strings::msg_params][param.c_str()] = *disallowed_param;
+    return true;
+  }
+
+ private:
+  smart_objects::SmartObject& response_;
+  mobile_apis::VehicleDataResultCode::eType code_;
+};
+
+ResponseInfo::ResponseInfo()
+    : result_code(hmi_apis::Common_Result::INVALID_ENUM)
+    , interface(HmiInterfaces::HMI_INTERFACE_INVALID_ENUM)
+    , interface_state(HmiInterfaces::STATE_NOT_RESPONSE)
+    , is_ok(false)
+    , is_unsupported_resource(false)
+    , is_not_used(false) {}
+
+ResponseInfo::ResponseInfo(const hmi_apis::Common_Result::eType result,
+                           const HmiInterfaces::InterfaceID hmi_interface,
+                           ApplicationManager& application_manager)
+    : result_code(result)
+    , interface(hmi_interface)
+    , interface_state(HmiInterfaces::STATE_NOT_RESPONSE)
+    , is_ok(false)
+    , is_unsupported_resource(false)
+    , is_not_used(false) {
+  using namespace helpers;
+
+  interface_state =
+      application_manager.hmi_interfaces().GetInterfaceState(hmi_interface);
+
+  is_ok = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+      result_code,
+      hmi_apis::Common_Result::SUCCESS,
+      hmi_apis::Common_Result::WARNINGS,
+      hmi_apis::Common_Result::WRONG_LANGUAGE,
+      hmi_apis::Common_Result::RETRY,
+      hmi_apis::Common_Result::SAVED,
+      hmi_apis::Common_Result::TRUNCATED_DATA);
+
+  is_not_used = hmi_apis::Common_Result::INVALID_ENUM == result_code;
+
+  is_unsupported_resource =
+      hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code;
+}
+
+RequestFromMobileImpl::RequestFromMobileImpl(
+    const MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    rpc_service::RPCService& rpc_service,
+    HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : CommandRequestImpl(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler)
+    , hash_update_mode_(kSkipHashUpdate)
+    , is_success_result_(false) {}
+
+RequestFromMobileImpl::~RequestFromMobileImpl() {
+  UpdateHash();
+}
+
+bool RequestFromMobileImpl::Init() {
+  return true;
+}
+
+bool RequestFromMobileImpl::CheckPermissions() {
+  return CheckAllowedParameters(Command::CommandSource::SOURCE_MOBILE);
+}
+
+bool RequestFromMobileImpl::CleanUp() {
+  unsubscribe_from_all_mobile_events();
+  unsubscribe_from_all_hmi_events();  // To prevent on_event calls
+
+  // Cleanup for mobile requests can be done only if OnEvent/OnTimeout events
+  // are not processed at that moment
+  return kAwaitingResponse == current_state();
+}
+
+void RequestFromMobileImpl::Run() {}
+
+void RequestFromMobileImpl::OnTimeOut() {
+  SDL_LOG_AUTO_TRACE();
+
+  unsubscribe_from_all_mobile_events();
+  unsubscribe_from_all_hmi_events();
+
+  smart_objects::SmartObjectSPtr response =
+      MessageHelper::CreateNegativeResponse(connection_key(),
+                                            function_id(),
+                                            correlation_id(),
+                                            mobile_api::Result::GENERIC_ERROR);
+
+  AddTimeOutComponentInfoToMessage(*response);
+
+  rpc_service_.ManageMobileCommand(response, SOURCE_SDL);
+}
+
+void RequestFromMobileImpl::on_event(const event_engine::Event& event) {}
+
+void RequestFromMobileImpl::on_event(const event_engine::MobileEvent& event) {}
+
+void RequestFromMobileImpl::SendResponse(
+    const bool success,
+    const mobile_apis::Result::eType& result_code,
+    const char* info,
+    const smart_objects::SmartObject* response_params,
+    const std::vector<uint8_t> binary_data) {
+  SDL_LOG_AUTO_TRACE();
+
+  smart_objects::SmartObjectSPtr result =
+      std::make_shared<smart_objects::SmartObject>();
+
+  smart_objects::SmartObject& response = *result;
+
+  response[strings::params][strings::message_type] = MessageType::kResponse;
+  response[strings::params][strings::correlation_id] = correlation_id();
+  response[strings::params][strings::protocol_type] =
+      CommandImpl::mobile_protocol_type_;
+  response[strings::params][strings::protocol_version] =
+      CommandImpl::protocol_version_;
+  response[strings::params][strings::connection_key] = connection_key();
+  response[strings::params][strings::function_id] = function_id();
+  if (!binary_data.empty()) {
+    response[strings::params][strings::binary_data] = binary_data;
+  }
+  if (response_params) {
+    response[strings::msg_params] = *response_params;
+  }
+
+  if (info && *info != '\0') {
+    response[strings::msg_params][strings::info] = std::string(info);
+  }
+
+  // Add disallowed parameters and info from request back to response with
+  // appropriate reasons (VehicleData result codes)
+  if (result_code != mobile_apis::Result::APPLICATION_NOT_REGISTERED &&
+      result_code != mobile_apis::Result::INVALID_DATA) {
+    const mobile_apis::FunctionID::eType& id =
+        static_cast<mobile_apis::FunctionID::eType>(function_id());
+    if ((id == mobile_apis::FunctionID::SubscribeVehicleDataID) ||
+        (id == mobile_apis::FunctionID::UnsubscribeVehicleDataID)) {
+      AddDisallowedParameters(response);
+      AddDisallowedParametersToInfo(response);
+    } else if (id == mobile_apis::FunctionID::GetVehicleDataID) {
+      AddDisallowedParametersToInfo(response);
+    }
+  }
+
+  response[strings::msg_params][strings::success] = success;
+  if ((result_code == mobile_apis::Result::SUCCESS ||
+       result_code == mobile_apis::Result::WARNINGS) &&
+      !warning_info().empty()) {
+    response[strings::msg_params][strings::info] =
+        (info && *info != '\0') ? std::string(info) + "\n" + warning_info()
+                                : warning_info();
+    response[strings::msg_params][strings::result_code] =
+        mobile_apis::Result::WARNINGS;
+  } else {
+    response[strings::msg_params][strings::result_code] = result_code;
+  }
+
+  is_success_result_ = success;
+
+  rpc_service_.ManageMobileCommand(result, SOURCE_SDL);
+}
+
+smart_objects::SmartObject CreateUnsupportedResourceResponse(
+    const hmi_apis::FunctionID::eType function_id,
+    const uint32_t hmi_correlation_id,
+    HmiInterfaces::InterfaceID interface) {
+  smart_objects::SmartObject response(smart_objects::SmartType_Map);
+  smart_objects::SmartObject& params = response[strings::params];
+  params[strings::message_type] = MessageType::kResponse;
+  params[strings::correlation_id] = hmi_correlation_id;
+  params[strings::protocol_type] = CommandImpl::hmi_protocol_type_;
+  params[strings::protocol_version] = CommandImpl::protocol_version_;
+  params[strings::function_id] = function_id;
+  params[hmi_response::code] = hmi_apis::Common_Result::UNSUPPORTED_RESOURCE;
+  smart_objects::SmartObject& msg_params = response[strings::msg_params];
+  msg_params[strings::info] = CreateInfoForUnsupportedResult(interface);
+  return response;
+}
+
+bool RequestFromMobileImpl::ProcessHMIInterfacesAvailability(
+    const uint32_t hmi_correlation_id,
+    const hmi_apis::FunctionID::eType& function_id) {
+  SDL_LOG_AUTO_TRACE();
+  HmiInterfaces& hmi_interfaces = application_manager_.hmi_interfaces();
+  HmiInterfaces::InterfaceID interface =
+      hmi_interfaces.GetInterfaceFromFunction(function_id);
+  DCHECK(interface != HmiInterfaces::HMI_INTERFACE_INVALID_ENUM);
+  const HmiInterfaces::InterfaceState state =
+      hmi_interfaces.GetInterfaceState(interface);
+  if (HmiInterfaces::STATE_NOT_AVAILABLE == state) {
+    event_engine::Event event(function_id);
+    event.set_smart_object(CreateUnsupportedResourceResponse(
+        function_id, hmi_correlation_id, interface));
+    event.raise(application_manager_.event_dispatcher());
+    return false;
+  }
+  return true;
+}
+
+void RequestFromMobileImpl::UpdateHash() {
+  SDL_LOG_AUTO_TRACE();
+  if (hash_update_mode_ == kSkipHashUpdate) {
+    SDL_LOG_DEBUG("Hash update is disabled for " << function_id());
+    return;
+  }
+
+  if (HmiInterfaces::InterfaceState::STATE_NOT_RESPONSE ==
+      application_manager_.hmi_interfaces().GetInterfaceState(
+          HmiInterfaces::InterfaceID::HMI_INTERFACE_UI)) {
+    SDL_LOG_ERROR("UI interface has not responded. Hash won't be updated.");
+    return;
+  }
+
+  if (!is_success_result_) {
+    SDL_LOG_WARN("Command is not succeeded. Hash won't be updated.");
+    return;
+  }
+
+  ApplicationSharedPtr application =
+      application_manager_.application(connection_key());
+  if (!application) {
+    SDL_LOG_ERROR("Application with connection key "
+                  << connection_key()
+                  << " not found. Not able to update hash.");
+    return;
+  }
+
+  SDL_LOG_DEBUG(
+      "Updating hash for application with connection key "
+      << connection_key() << " while processing function id "
+      << MessageHelper::StringifiedFunctionID(
+             static_cast<mobile_api::FunctionID::eType>(function_id())));
+
+  application->UpdateHash();
+}
+
+uint32_t RequestFromMobileImpl::SendHMIRequest(
+    const hmi_apis::FunctionID::eType& function_id,
+    const smart_objects::SmartObject* msg_params,
+    bool use_events) {
+  smart_objects::SmartObjectSPtr result =
+      std::make_shared<smart_objects::SmartObject>();
+
+  const uint32_t hmi_correlation_id =
+      application_manager_.GetNextHMICorrelationID();
+
+  smart_objects::SmartObject& request = *result;
+  request[strings::params][strings::message_type] = MessageType::kRequest;
+  request[strings::params][strings::function_id] = function_id;
+  request[strings::params][strings::correlation_id] = hmi_correlation_id;
+  request[strings::params][strings::protocol_version] =
+      CommandImpl::protocol_version_;
+  request[strings::params][strings::protocol_type] =
+      CommandImpl::hmi_protocol_type_;
+
+  if (msg_params) {
+    request[strings::msg_params] = *msg_params;
+  }
+
+  if (use_events) {
+    SDL_LOG_DEBUG("SendHMIRequest subscribe_on_event " << function_id << " "
+                                                       << hmi_correlation_id);
+    subscribe_on_event(function_id, hmi_correlation_id);
+  }
+  if (ProcessHMIInterfacesAvailability(hmi_correlation_id, function_id)) {
+    if (!rpc_service_.ManageHMICommand(result, SOURCE_SDL_TO_HMI)) {
+      SDL_LOG_ERROR("Unable to send request");
+      SendResponse(false, mobile_apis::Result::OUT_OF_MEMORY);
+    }
+  } else {
+    SDL_LOG_DEBUG("Interface is not available");
+  }
+  return hmi_correlation_id;
+}
+
+void RequestFromMobileImpl::CreateHMINotification(
+    const hmi_apis::FunctionID::eType& function_id,
+    const ns_smart_device_link::ns_smart_objects::SmartObject& msg_params)
+    const {
+  smart_objects::SmartObjectSPtr result =
+      std::make_shared<smart_objects::SmartObject>();
+  if (!result) {
+    SDL_LOG_ERROR("Memory allocation failed.");
+    return;
+  }
+  smart_objects::SmartObject& notify = *result;
+
+  notify[strings::params][strings::message_type] =
+      static_cast<int32_t>(application_manager::MessageType::kNotification);
+  notify[strings::params][strings::protocol_version] =
+      CommandImpl::protocol_version_;
+  notify[strings::params][strings::protocol_type] =
+      CommandImpl::hmi_protocol_type_;
+  notify[strings::params][strings::function_id] = function_id;
+  notify[strings::msg_params] = msg_params;
+
+  if (!rpc_service_.ManageHMICommand(result, SOURCE_SDL_TO_HMI)) {
+    SDL_LOG_ERROR("Unable to send HMI notification");
+  }
+}
+
+mobile_apis::Result::eType RequestFromMobileImpl::GetMobileResultCode(
+    const hmi_apis::Common_Result::eType& hmi_code) const {
+  mobile_apis::Result::eType mobile_result = mobile_apis::Result::GENERIC_ERROR;
+  switch (hmi_code) {
+    case hmi_apis::Common_Result::SUCCESS: {
+      mobile_result = mobile_apis::Result::SUCCESS;
+      break;
+    }
+    case hmi_apis::Common_Result::UNSUPPORTED_REQUEST: {
+      mobile_result = mobile_apis::Result::UNSUPPORTED_REQUEST;
+      break;
+    }
+    case hmi_apis::Common_Result::UNSUPPORTED_RESOURCE: {
+      mobile_result = mobile_apis::Result::UNSUPPORTED_RESOURCE;
+      break;
+    }
+    case hmi_apis::Common_Result::DISALLOWED: {
+      mobile_result = mobile_apis::Result::DISALLOWED;
+      break;
+    }
+    case hmi_apis::Common_Result::REJECTED: {
+      mobile_result = mobile_apis::Result::REJECTED;
+      break;
+    }
+    case hmi_apis::Common_Result::ABORTED: {
+      mobile_result = mobile_apis::Result::ABORTED;
+      break;
+    }
+    case hmi_apis::Common_Result::IGNORED: {
+      mobile_result = mobile_apis::Result::IGNORED;
+      break;
+    }
+    case hmi_apis::Common_Result::RETRY: {
+      mobile_result = mobile_apis::Result::RETRY;
+      break;
+    }
+    case hmi_apis::Common_Result::IN_USE: {
+      mobile_result = mobile_apis::Result::IN_USE;
+      break;
+    }
+    case hmi_apis::Common_Result::DATA_NOT_AVAILABLE: {
+      mobile_result = mobile_apis::Result::VEHICLE_DATA_NOT_AVAILABLE;
+      break;
+    }
+    case hmi_apis::Common_Result::TIMED_OUT: {
+      mobile_result = mobile_apis::Result::TIMED_OUT;
+      break;
+    }
+    case hmi_apis::Common_Result::INVALID_DATA: {
+      mobile_result = mobile_apis::Result::INVALID_DATA;
+      break;
+    }
+    case hmi_apis::Common_Result::CHAR_LIMIT_EXCEEDED: {
+      mobile_result = mobile_apis::Result::CHAR_LIMIT_EXCEEDED;
+      break;
+    }
+    case hmi_apis::Common_Result::INVALID_ID: {
+      mobile_result = mobile_apis::Result::INVALID_ID;
+      break;
+    }
+    case hmi_apis::Common_Result::DUPLICATE_NAME: {
+      mobile_result = mobile_apis::Result::DUPLICATE_NAME;
+      break;
+    }
+    case hmi_apis::Common_Result::APPLICATION_NOT_REGISTERED: {
+      mobile_result = mobile_apis::Result::APPLICATION_NOT_REGISTERED;
+      break;
+    }
+    case hmi_apis::Common_Result::WRONG_LANGUAGE: {
+      mobile_result = mobile_apis::Result::WRONG_LANGUAGE;
+      break;
+    }
+    case hmi_apis::Common_Result::OUT_OF_MEMORY: {
+      mobile_result = mobile_apis::Result::OUT_OF_MEMORY;
+      break;
+    }
+    case hmi_apis::Common_Result::TOO_MANY_PENDING_REQUESTS: {
+      mobile_result = mobile_apis::Result::TOO_MANY_PENDING_REQUESTS;
+      break;
+    }
+    case hmi_apis::Common_Result::NO_APPS_REGISTERED: {
+      mobile_result = mobile_apis::Result::APPLICATION_NOT_REGISTERED;
+      break;
+    }
+    case hmi_apis::Common_Result::NO_DEVICES_CONNECTED: {
+      mobile_result = mobile_apis::Result::APPLICATION_NOT_REGISTERED;
+      break;
+    }
+    case hmi_apis::Common_Result::WARNINGS: {
+      mobile_result = mobile_apis::Result::WARNINGS;
+      break;
+    }
+    case hmi_apis::Common_Result::GENERIC_ERROR: {
+      mobile_result = mobile_apis::Result::GENERIC_ERROR;
+      break;
+    }
+    case hmi_apis::Common_Result::USER_DISALLOWED: {
+      mobile_result = mobile_apis::Result::USER_DISALLOWED;
+      break;
+    }
+    case hmi_apis::Common_Result::SAVED: {
+      mobile_result = mobile_apis::Result::SAVED;
+      break;
+    }
+    case hmi_apis::Common_Result::READ_ONLY: {
+      mobile_result = mobile_apis::Result::READ_ONLY;
+      break;
+    }
+    default: {
+      SDL_LOG_ERROR("Unknown HMI result code " << hmi_code);
+      break;
+    }
+  }
+
+  return mobile_result;
+}
+
+bool RequestFromMobileImpl::CheckHMICapabilities(
+    const mobile_apis::ButtonName::eType button) const {
+  SDL_LOG_AUTO_TRACE();
+
+  using namespace smart_objects;
+  using namespace mobile_apis;
+
+  if (!hmi_capabilities_.is_ui_cooperating()) {
+    SDL_LOG_ERROR("UI is not supported by HMI");
+    return false;
+  }
+
+  const auto button_capabilities_so = hmi_capabilities_.button_capabilities();
+  if (!button_capabilities_so) {
+    SDL_LOG_ERROR("Invalid button capabilities object");
+    return false;
+  }
+
+  const SmartObject& button_capabilities = *button_capabilities_so;
+  for (size_t i = 0; i < button_capabilities.length(); ++i) {
+    const SmartObject& capabilities = button_capabilities[i];
+    const ButtonName::eType current_button = static_cast<ButtonName::eType>(
+        capabilities.getElement(hmi_response::button_name).asInt());
+    if (current_button == button) {
+      SDL_LOG_DEBUG("Button capabilities for " << button << " was found");
+      return true;
+    }
+  }
+
+  SDL_LOG_DEBUG("Button capabilities for " << button << " was not found");
+  return false;
+}
+
+void RequestFromMobileImpl::RemoveDisallowedParameters() {
+  SDL_LOG_AUTO_TRACE();
+
+  smart_objects::SmartObject& params = (*message_)[strings::msg_params];
+
+  // Remove from request all disallowed parameters
+  RPCParams::const_iterator it_disallowed =
+      parameters_permissions_.disallowed_params.begin();
+  RPCParams::const_iterator it_disallowed_end =
+      parameters_permissions_.disallowed_params.end();
+  for (; it_disallowed != it_disallowed_end; ++it_disallowed) {
+    if (params.keyExists(*it_disallowed)) {
+      const std::string key = *it_disallowed;
+      params.erase(key);
+      removed_parameters_permissions_.disallowed_params.insert(key);
+      SDL_LOG_INFO("Following parameter is disallowed by user: " << key);
+    }
+  }
+
+  // Remove from request all undefined yet parameters
+  RPCParams::const_iterator it_undefined =
+      parameters_permissions_.undefined_params.begin();
+  RPCParams::const_iterator it_undefined_end =
+      parameters_permissions_.undefined_params.end();
+  for (; it_undefined != it_undefined_end; ++it_undefined) {
+    if (params.keyExists(*it_undefined)) {
+      const std::string key = *it_undefined;
+      params.erase(key);
+      removed_parameters_permissions_.undefined_params.insert(key);
+      SDL_LOG_INFO("Following parameter is disallowed by policy: " << key);
+    }
+  }
+
+  // Remove from request all parameters missed in allowed
+  const VehicleData& vehicle_data =
+      application_manager::MessageHelper::vehicle_data();
+
+  VehicleData::const_iterator it_vehicle_data = vehicle_data.begin();
+  VehicleData::const_iterator it_vehicle_data_end = vehicle_data.end();
+  for (; it_vehicle_data != it_vehicle_data_end; ++it_vehicle_data) {
+    const std::string key = it_vehicle_data->first;
+    if (params.keyExists(key) &&
+        parameters_permissions_.allowed_params.end() ==
+            std::find(parameters_permissions_.allowed_params.begin(),
+                      parameters_permissions_.allowed_params.end(),
+                      key)) {
+      params.erase(key);
+      removed_parameters_permissions_.undefined_params.insert(key);
+      SDL_LOG_INFO("Following parameter is not found among allowed parameters '"
+                   << key << "' and will be treated as disallowed.");
+    }
+  }
+}
+
+void RequestFromMobileImpl::AddDissalowedParameterToInfoString(
+    std::string& info, const std::string& param) const {
+  // prepare disallowed params enumeration for response info string
+  if (info.empty()) {
+    info = "\'" + param + "\'";
+  } else {
+    info = info + "," + " " + "\'" + param + "\'";
+  }
+}
+
+void RequestFromMobileImpl::AddDisallowedParametersToInfo(
+    smart_objects::SmartObject& response) const {
+  std::string info;
+
+  RPCParams::const_iterator it =
+      removed_parameters_permissions_.disallowed_params.begin();
+  for (; it != removed_parameters_permissions_.disallowed_params.end(); ++it) {
+    AddDissalowedParameterToInfoString(info, (*it));
+  }
+
+  it = removed_parameters_permissions_.undefined_params.begin();
+  for (; it != removed_parameters_permissions_.undefined_params.end(); ++it) {
+    AddDissalowedParameterToInfoString(info, (*it));
+  }
+
+  if (!info.empty()) {
+    info += " disallowed by policies.";
+
+    if (!response[strings::msg_params][strings::info].asString().empty()) {
+      // If we already have info add info about disallowed params to it
+      response[strings::msg_params][strings::info] =
+          response[strings::msg_params][strings::info].asString() + " " + info;
+    } else {
+      response[strings::msg_params][strings::info] = info;
+    }
+  }
+}
+
+void RequestFromMobileImpl::AddDisallowedParameters(
+    smart_objects::SmartObject& response) {
+  DisallowedParamsInserter disallowed_inserter(
+      response, mobile_apis::VehicleDataResultCode::VDRC_USER_DISALLOWED);
+  std::for_each(removed_parameters_permissions_.disallowed_params.begin(),
+                removed_parameters_permissions_.disallowed_params.end(),
+                disallowed_inserter);
+
+  DisallowedParamsInserter undefined_inserter(
+      response, mobile_apis::VehicleDataResultCode::VDRC_DISALLOWED);
+  std::for_each(removed_parameters_permissions_.undefined_params.begin(),
+                removed_parameters_permissions_.undefined_params.end(),
+                undefined_inserter);
+}
+
+bool RequestFromMobileImpl::HasDisallowedParams() const {
+  return ((!removed_parameters_permissions_.disallowed_params.empty()) ||
+          (!removed_parameters_permissions_.undefined_params.empty()));
+}
+
+bool RequestFromMobileImpl::PrepareResultForMobileResponse(
+    hmi_apis::Common_Result::eType result_code,
+    HmiInterfaces::InterfaceID interface) const {
+  SDL_LOG_AUTO_TRACE();
+  if (IsHMIResultSuccess(result_code)) {
+    return true;
+  }
+
+  const HmiInterfaces::InterfaceState state =
+      application_manager_.hmi_interfaces().GetInterfaceState(interface);
+  if ((hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code) &&
+      (HmiInterfaces::STATE_NOT_AVAILABLE != state)) {
+    return true;
+  }
+  return false;
+}
+
+bool RequestFromMobileImpl::PrepareResultForMobileResponse(
+    ResponseInfo& out_first, ResponseInfo& out_second) const {
+  SDL_LOG_AUTO_TRACE();
+  bool result = CheckResultCode(out_first, out_second) ||
+                CheckResultCode(out_second, out_first);
+  return result;
+}
+
+void RequestFromMobileImpl::GetInfo(
+    const smart_objects::SmartObject& response_from_hmi,
+    std::string& out_info) {
+  if (response_from_hmi[strings::msg_params].keyExists(strings::info)) {
+    if (!response_from_hmi[strings::msg_params][strings::info].empty()) {
+      out_info =
+          response_from_hmi[strings::msg_params][strings::info].asString();
+    }
+  }
+}
+
+mobile_apis::Result::eType RequestFromMobileImpl::PrepareResultCodeForResponse(
+    const ResponseInfo& first, const ResponseInfo& second) {
+  SDL_LOG_AUTO_TRACE();
+  if (IsResultCodeUnsupported(first, second) ||
+      IsResultCodeUnsupported(second, first)) {
+    return mobile_apis::Result::UNSUPPORTED_RESOURCE;
+  }
+  if (IsResultCodeWarning(first, second) ||
+      IsResultCodeWarning(second, first)) {
+    return mobile_apis::Result::WARNINGS;
+  }
+  // If response contains erroneous result code SDL need return erroneus
+  // result code.
+  hmi_apis::Common_Result::eType first_result =
+      hmi_apis::Common_Result::INVALID_ENUM;
+  hmi_apis::Common_Result::eType second_result =
+      hmi_apis::Common_Result::INVALID_ENUM;
+  if (!first.is_unsupported_resource) {
+    first_result = first.result_code;
+  }
+  if (!second.is_unsupported_resource) {
+    second_result = second.result_code;
+  }
+  mobile_apis::Result::eType result_code =
+      MessageHelper::HMIToMobileResult(std::max(first_result, second_result));
+  return result_code;
+}
+
+const CommandParametersPermissions&
+RequestFromMobileImpl::parameters_permissions() const {
+  return parameters_permissions_;
+}
+
+void RequestFromMobileImpl::SendProviderRequest(
+    const mobile_apis::FunctionID::eType& mobile_function_id,
+    const hmi_apis::FunctionID::eType& hmi_function_id,
+    const smart_objects::SmartObject* msg,
+    bool use_events) {
+  SDL_LOG_AUTO_TRACE();
+  bool hmi_destination = false;
+  ApplicationSharedPtr app;
+  // Default error code and error message
+  std::string error_msg = "No app service provider available";
+  mobile_apis::Result::eType error_code =
+      mobile_apis::Result::DATA_NOT_AVAILABLE;
+
+  if ((*msg)[strings::msg_params].keyExists(strings::service_type)) {
+    std::string service_type =
+        (*msg)[strings::msg_params][strings::service_type].asString();
+    application_manager_.GetAppServiceManager().GetProviderByType(
+        service_type, true, app, hmi_destination);
+    error_msg = "No app service provider with serviceType: " + service_type +
+                " is available";
+    error_code = mobile_apis::Result::DATA_NOT_AVAILABLE;
+  } else if ((*msg)[strings::msg_params].keyExists(strings::service_id)) {
+    std::string service_id =
+        (*msg)[strings::msg_params][strings::service_id].asString();
+    application_manager_.GetAppServiceManager().GetProviderByID(
+        service_id, true, app, hmi_destination);
+    error_msg = "No app service provider with serviceId: " + service_id +
+                " is available";
+    error_code = mobile_apis::Result::INVALID_ID;
+  }
+
+  if (hmi_destination) {
+    SDL_LOG_DEBUG("Sending Request to HMI Provider");
+    application_manager_.IncreaseForwardedRequestTimeout(connection_key(),
+                                                         correlation_id());
+    SendHMIRequest(hmi_function_id, &(*msg)[strings::msg_params], use_events);
+    return;
+  }
+
+  if (!app) {
+    SDL_LOG_DEBUG("Invalid App Provider pointer");
+    SendResponse(false, error_code, error_msg.c_str());
+    return;
+  }
+
+  if (connection_key() == app->app_id()) {
+    SendResponse(false,
+                 mobile_apis::Result::IGNORED,
+                 "Consumer app is same as producer app");
+    return;
+  }
+
+  smart_objects::SmartObjectSPtr new_msg =
+      std::make_shared<smart_objects::SmartObject>();
+  smart_objects::SmartObject& request = *new_msg;
+
+  request[strings::params] = (*msg)[strings::params];
+  request[strings::msg_params] = (*msg)[strings::msg_params];
+  request[strings::params][strings::connection_key] = app->app_id();
+
+  application_manager_.IncreaseForwardedRequestTimeout(connection_key(),
+                                                       correlation_id());
+  SendMobileRequest(mobile_function_id, new_msg, use_events);
+}
+
+bool RequestFromMobileImpl::IsResultCodeUnsupported(
+    const ResponseInfo& first, const ResponseInfo& second) const {
+  const bool first_ok_second_unsupported =
+      (first.is_ok || first.is_not_used) && second.is_unsupported_resource;
+  const bool both_unsupported =
+      first.is_unsupported_resource && second.is_unsupported_resource;
+  return first_ok_second_unsupported || both_unsupported;
+}
+
+std::string GetComponentNameFromInterface(
+    const HmiInterfaces::InterfaceID& interface) {
+  switch (interface) {
+    case HmiInterfaces::HMI_INTERFACE_Buttons:
+      return hmi_interface::buttons;
+    case HmiInterfaces::HMI_INTERFACE_BasicCommunication:
+      return hmi_interface::basic_communication;
+    case HmiInterfaces::HMI_INTERFACE_VR:
+      return hmi_interface::vr;
+    case HmiInterfaces::HMI_INTERFACE_TTS:
+      return hmi_interface::tts;
+    case HmiInterfaces::HMI_INTERFACE_UI:
+      return hmi_interface::ui;
+    case HmiInterfaces::HMI_INTERFACE_Navigation:
+      return hmi_interface::navigation;
+    case HmiInterfaces::HMI_INTERFACE_VehicleInfo:
+      return hmi_interface::vehicle_info;
+    case HmiInterfaces::HMI_INTERFACE_SDL:
+      return hmi_interface::sdl;
+    case HmiInterfaces::HMI_INTERFACE_RC:
+      return hmi_interface::rc;
+    case HmiInterfaces::HMI_INTERFACE_AppService:
+      return hmi_interface::app_service;
+    default:
+      return "Unknown type";
+  }
+}
+
+const std::string InfoInterfaceSeparator(
+    const std::string& sum, const HmiInterfaces::InterfaceID container_value) {
+  return sum.empty()
+             ? GetComponentNameFromInterface(container_value)
+             : sum + ", " + GetComponentNameFromInterface(container_value);
+}
+
+void RequestFromMobileImpl::AddTimeOutComponentInfoToMessage(
+    smart_objects::SmartObject& response) const {
+  using ns_smart_device_link::ns_smart_objects::SmartObject;
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(awaiting_response_interfaces_lock_);
+  if (awaiting_response_interfaces_.empty()) {
+    SDL_LOG_ERROR("No interfaces awaiting, info param is empty");
+    return;
+  }
+
+  const std::string not_responding_interfaces_string =
+      std::accumulate(awaiting_response_interfaces_.begin(),
+                      awaiting_response_interfaces_.end(),
+                      std::string(""),
+                      InfoInterfaceSeparator);
+  SDL_LOG_DEBUG(
+      "Not responding interfaces string: " << not_responding_interfaces_string);
+  if (!not_responding_interfaces_string.empty()) {
+    const std::string component_info =
+        not_responding_interfaces_string + " component does not respond";
+    response[strings::msg_params][strings::info] = component_info;
+  }
+}
+
+}  // namespace commands
+
+}  // namespace application_manager

--- a/src/components/application_manager/src/commands/request_from_mobile_impl.cc
+++ b/src/components/application_manager/src/commands/request_from_mobile_impl.cc
@@ -754,7 +754,7 @@ bool RequestFromMobileImpl::PrepareResultForMobileResponse(
 
 void RequestFromMobileImpl::GetInfo(
     const smart_objects::SmartObject& response_from_hmi,
-    std::string& out_info) {
+    std::string& out_info) const {
   if (response_from_hmi[strings::msg_params].keyExists(strings::info)) {
     if (!response_from_hmi[strings::msg_params][strings::info].empty()) {
       out_info =

--- a/src/components/application_manager/src/commands/request_to_hmi.cc
+++ b/src/components/application_manager/src/commands/request_to_hmi.cc
@@ -141,11 +141,11 @@ RequestToHMI::RequestToHMI(const MessageSharedPtr& message,
                            rpc_service::RPCService& rpc_service,
                            HMICapabilities& hmi_capabilities,
                            policy::PolicyHandlerInterface& policy_handler)
-    : CommandImpl(message,
-                  application_manager,
-                  rpc_service,
-                  hmi_capabilities,
-                  policy_handler) {}
+    : CommandRequestImpl(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler) {}
 
 RequestToHMI::~RequestToHMI() {}
 

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -66,7 +66,7 @@ void EventDispatcherImpl::raise_event(const Event& event) {
     EventObserver* temp = *observers.begin();
     observers.erase(observers.begin());
     AutoUnlock unlock_observer(observer_lock);
-    temp->on_event(event);
+    temp->HandleOnEvent(event);
   }
 }
 
@@ -87,6 +87,14 @@ struct IdCheckFunctor {
  private:
   const unsigned long target_id;
 };
+
+void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
+                                          const int32_t hmi_correlation_id) {
+  auto& observers = observers_event_[event_id][hmi_correlation_id];
+  for (auto observer : observers) {
+    remove_observer_from_vector(*observer);
+  }
+}
 
 void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
                                           EventObserver& observer) {
@@ -148,7 +156,7 @@ void EventDispatcherImpl::raise_mobile_event(const MobileEvent& event) {
     EventObserver* temp = *mobile_observers_.begin();
     mobile_observers_.erase(mobile_observers_.begin());
     AutoUnlock unlock_observer(observer_lock);
-    temp->on_event(event);
+    temp->HandleOnEvent(event);
   }
 }
 

--- a/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
+++ b/src/components/application_manager/src/event_engine/event_dispatcher_impl.cc
@@ -90,6 +90,7 @@ struct IdCheckFunctor {
 
 void EventDispatcherImpl::remove_observer(const Event::EventID& event_id,
                                           const int32_t hmi_correlation_id) {
+  AutoLock auto_lock(state_lock_);
   auto& observers = observers_event_[event_id][hmi_correlation_id];
   for (auto observer : observers) {
     remove_observer_from_vector(*observer);

--- a/src/components/application_manager/src/event_engine/event_observer.cc
+++ b/src/components/application_manager/src/event_engine/event_observer.cc
@@ -75,7 +75,7 @@ void EventObserver::unsubscribe_from_all_mobile_events() {
   event_dispatcher_.remove_mobile_observer(*this);
 }
 
-void EventObserver::on_event(const event_engine::MobileEvent& event) {}
+void EventObserver::HandleOnEvent(const event_engine::MobileEvent& event) {}
 
 }  // namespace event_engine
 }  // namespace application_manager

--- a/src/components/application_manager/src/hmi_language_handler.cc
+++ b/src/components/application_manager/src/hmi_language_handler.cc
@@ -31,6 +31,7 @@
  */
 
 #include "application_manager/hmi_language_handler.h"
+
 #include "application_manager/application_manager.h"
 #include "application_manager/hmi_capabilities.h"
 #include "application_manager/message_helper.h"
@@ -119,7 +120,7 @@ hmi_apis::Common_Language::eType HMILanguageHandler::get_language_for(
   return Common_Language::INVALID_ENUM;
 }
 
-void HMILanguageHandler::on_event(const event_engine::Event& event) {
+void HMILanguageHandler::HandleOnEvent(const event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
   smart_objects::SmartObject msg = event.smart_object();
   switch (event.id()) {

--- a/src/components/application_manager/src/policies/policy_event_observer.cc
+++ b/src/components/application_manager/src/policies/policy_event_observer.cc
@@ -55,9 +55,10 @@ void PolicyEventObserver::set_policy_handler(
   policy_handler_ = policy_handler;
 }
 
-void PolicyEventObserver::on_event(const event_engine::MobileEvent& event) {}
+void PolicyEventObserver::HandleOnEvent(
+    const event_engine::MobileEvent& event) {}
 
-void PolicyEventObserver::on_event(const event_engine::Event& event) {
+void PolicyEventObserver::HandleOnEvent(const event_engine::Event& event) {
   sync_primitives::AutoLock auto_lock(policy_handler_lock_);
   if (!policy_handler_) {
     return;

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -496,10 +496,6 @@ void RequestController::TimeoutThread() {
     probably_expired->request()->HandleTimeOut();
 
     if (RequestInfo::HmiConnectionKey == probably_expired->app_id()) {
-      const uint32_t function_id = probably_expired->request()->function_id();
-      event_dispatcher_.remove_observer(
-          static_cast<hmi_apis::FunctionID::eType>(function_id),
-          expired_request_id);
       SDL_LOG_DEBUG("Erase HMI request: " << probably_expired->requestId());
       waiting_for_response_.RemoveRequest(probably_expired);
     }

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -331,7 +331,8 @@ void ResumptionDataProcessorImpl::HandleOnTimeOut(
   ProcessResponseFromHMI(*error_response, function_id, corr_id);
 }
 
-void ResumptionDataProcessorImpl::on_event(const event_engine::Event& event) {
+void ResumptionDataProcessorImpl::HandleOnEvent(
+    const event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
   SDL_LOG_DEBUG(
       "Handling response message from HMI "

--- a/src/components/application_manager/src/state_controller_impl.cc
+++ b/src/components/application_manager/src/state_controller_impl.cc
@@ -31,12 +31,13 @@
  */
 
 #include "application_manager/state_controller_impl.h"
+
 #include <tuple>
+
 #include "application_manager/rpc_service.h"
 #include "application_manager/usage_statistics.h"
-#include "utils/helpers.h"
-
 #include "connection_handler/connection_handler.h"
+#include "utils/helpers.h"
 
 namespace application_manager {
 
@@ -720,7 +721,8 @@ void StateControllerImpl::UpdateAppWindowsStreamingState(
   }
 }
 
-void StateControllerImpl::on_event(const event_engine::MobileEvent& event) {
+void StateControllerImpl::HandleOnEvent(
+    const event_engine::MobileEvent& event) {
   using namespace mobile_apis;
 
   SDL_LOG_AUTO_TRACE();
@@ -765,9 +767,9 @@ void StateControllerImpl::on_event(const event_engine::MobileEvent& event) {
     default:
       break;
   }
-}
+}  // namespace application_manager
 
-void StateControllerImpl::on_event(const event_engine::Event& event) {
+void StateControllerImpl::HandleOnEvent(const event_engine::Event& event) {
   using event_engine::Event;
   using smart_objects::SmartObject;
   using namespace hmi_apis;

--- a/src/components/application_manager/src/system_time/system_time_handler_impl.cc
+++ b/src/components/application_manager/src/system_time/system_time_handler_impl.cc
@@ -121,7 +121,7 @@ void SystemTimeHandlerImpl::SendTimeRequest() {
   awaiting_get_system_time_ = true;
 }
 
-void SystemTimeHandlerImpl::on_event(
+void SystemTimeHandlerImpl::HandleOnEvent(
     const application_manager::event_engine::Event& event) {
   SDL_LOG_AUTO_TRACE();
   using namespace application_manager;

--- a/src/components/application_manager/test/commands/command_impl_test.cc
+++ b/src/components/application_manager/test/commands/command_impl_test.cc
@@ -155,7 +155,7 @@ TEST_F(CommandImplTest, GetMethods_SUCCESS) {
   EXPECT_EQ(kConnectionKey, command->connection_key());
   EXPECT_EQ(kFunctionId, command->function_id());
   EXPECT_NO_THROW(command->Run());
-  EXPECT_NO_THROW(command->onTimeOut());
+  EXPECT_NO_THROW(command->HandleTimeOut());
 }
 
 TEST_F(CommandImplTest, ReplaceMobileWithHMIAppId_NoAppIdInMessage_UNSUCCESS) {

--- a/src/components/application_manager/test/event_engine_test.cc
+++ b/src/components/application_manager/test/event_engine_test.cc
@@ -125,7 +125,7 @@ class EventEngineTest : public testing::Test {
         event_id, correlation_id, event_observer_mock_);
     event_->set_smart_object(so);
 
-    EXPECT_CALL(event_observer_mock_, on_event(An<const Event&>()))
+    EXPECT_CALL(event_observer_mock_, HandleOnEvent(An<const Event&>()))
         .Times(calls_number);
     event_dispatcher_instance_->raise_event(*event_);
   }

--- a/src/components/application_manager/test/hmi_language_handler_test.cc
+++ b/src/components/application_manager/test/hmi_language_handler_test.cc
@@ -143,10 +143,10 @@ TEST_F(HmiLanguageHandlerTest, OnEvent_AllLanguageIsReceivedAndSame_SUCCESS) {
   // Repeatedly add events to set `is_*_language_received_` flags up
 
   Event ui_event(hmi_apis::FunctionID::UI_GetLanguage);
-  hmi_language_handler_->on_event(ui_event);
+  hmi_language_handler_->HandleOnEvent(ui_event);
 
   Event vr_event(hmi_apis::FunctionID::VR_GetLanguage);
-  hmi_language_handler_->on_event(vr_event);
+  hmi_language_handler_->HandleOnEvent(vr_event);
 
   // After last flag gets up, `VerifyWithPersistedLanguages`
   // method been called to and then will call `hmi_capabilities`
@@ -173,14 +173,14 @@ TEST_F(HmiLanguageHandlerTest, OnEvent_AllLanguageIsReceivedAndSame_SUCCESS) {
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(app_manager_, UnregisterApplication(_, _, _, _)).Times(0);
   Event tts_event(hmi_apis::FunctionID::TTS_GetLanguage);
-  hmi_language_handler_->on_event(tts_event);
+  hmi_language_handler_->HandleOnEvent(tts_event);
 }
 
 TEST_F(HmiLanguageHandlerTest, OnEvent_AllReceivedLanguagesMismatch_SUCCESS) {
   Event ui_event(hmi_apis::FunctionID::UI_GetLanguage);
-  hmi_language_handler_->on_event(ui_event);
+  hmi_language_handler_->HandleOnEvent(ui_event);
   Event vr_event(hmi_apis::FunctionID::VR_GetLanguage);
-  hmi_language_handler_->on_event(vr_event);
+  hmi_language_handler_->HandleOnEvent(vr_event);
 
   ON_CALL(app_manager_, hmi_capabilities())
       .WillByDefault(ReturnRef(hmi_capabilities_));
@@ -212,14 +212,14 @@ TEST_F(HmiLanguageHandlerTest, OnEvent_AllReceivedLanguagesMismatch_SUCCESS) {
   EXPECT_CALL(app_manager_, UnregisterApplication(_, _, _, _)).Times(0);
 
   Event tts_event(hmi_apis::FunctionID::TTS_GetLanguage);
-  hmi_language_handler_->on_event(tts_event);
+  hmi_language_handler_->HandleOnEvent(tts_event);
 }
 
 TEST_F(HmiLanguageHandlerTest, OnEvent_AllReceivedLanguagesMismatch_UNSUCCESS) {
   Event ui_event(hmi_apis::FunctionID::UI_GetLanguage);
-  hmi_language_handler_->on_event(ui_event);
+  hmi_language_handler_->HandleOnEvent(ui_event);
   Event vr_event(hmi_apis::FunctionID::VR_GetLanguage);
-  hmi_language_handler_->on_event(vr_event);
+  hmi_language_handler_->HandleOnEvent(vr_event);
 
   ON_CALL(app_manager_, hmi_capabilities())
       .WillByDefault(ReturnRef(hmi_capabilities_));
@@ -242,7 +242,7 @@ TEST_F(HmiLanguageHandlerTest, OnEvent_AllReceivedLanguagesMismatch_UNSUCCESS) {
   ON_CALL(app_manager_, applications()).WillByDefault(Return(data_accessor));
 
   Event tts_event(hmi_apis::FunctionID::TTS_GetLanguage);
-  hmi_language_handler_->on_event(tts_event);
+  hmi_language_handler_->HandleOnEvent(tts_event);
 }
 
 TEST_F(HmiLanguageHandlerTest,
@@ -299,7 +299,7 @@ TEST_F(HmiLanguageHandlerTest,
   event.set_smart_object(msg);
 
   EXPECT_CALL(app_manager_, hmi_capabilities()).Times(0);
-  hmi_language_handler_->on_event(event);
+  hmi_language_handler_->HandleOnEvent(event);
 
   EXPECT_CALL(app_manager_, hmi_capabilities())
       .WillOnce(ReturnRef(hmi_capabilities_));
@@ -327,7 +327,7 @@ TEST_F(HmiLanguageHandlerTest,
       .WillRepeatedly(ReturnRef(mock_rpc_service_));
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(2);
   EXPECT_CALL(app_manager_, UnregisterApplication(_, _, _, _)).Times(1);
-  hmi_language_handler_->on_event(event);
+  hmi_language_handler_->HandleOnEvent(event);
 }
 
 TEST_F(HmiLanguageHandlerTest, OnUnregisterApp_SUCCESS) {
@@ -339,7 +339,7 @@ TEST_F(HmiLanguageHandlerTest, OnUnregisterApp_SUCCESS) {
   event.set_smart_object(msg);
 
   EXPECT_CALL(app_manager_, hmi_capabilities()).Times(0);
-  hmi_language_handler_->on_event(event);
+  hmi_language_handler_->HandleOnEvent(event);
 
   hmi_language_handler_->OnUnregisterApplication(app_id);
 
@@ -356,7 +356,7 @@ TEST_F(HmiLanguageHandlerTest, OnUnregisterApp_SUCCESS) {
   EXPECT_CALL(app_manager_, GetRPCService()).Times(0);
   EXPECT_CALL(mock_rpc_service_, ManageMobileCommand(_, _)).Times(0);
   EXPECT_CALL(app_manager_, UnregisterApplication(_, _, _, _)).Times(0);
-  hmi_language_handler_->on_event(event);
+  hmi_language_handler_->HandleOnEvent(event);
 }
 }  // namespace hmi_language_handler
 }  // namespace components

--- a/src/components/application_manager/test/include/application_manager/commands/commands_test.h
+++ b/src/components/application_manager/test/include/application_manager/commands/commands_test.h
@@ -41,6 +41,7 @@
 
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_application_manager_settings.h"
+#include "application_manager/mock_event_dispatcher.h"
 #include "application_manager/mock_hmi_capabilities.h"
 #include "application_manager/mock_rpc_service.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
@@ -68,6 +69,7 @@ using ::test::components::application_manager_test::MockApplication;
 using ::test::components::application_manager_test::MockApplicationManager;
 using ::test::components::application_manager_test::
     MockApplicationManagerSettings;
+using ::test::components::event_engine_test::MockEventDispatcher;
 
 // Depending on the value type will be selected
 template <const bool kIf, class ThenT, class ElseT>
@@ -145,6 +147,23 @@ class CommandsTest : public ::testing::Test {
                                      mock_policy_handler_);
   }
 
+  void InitEventDispatcher() {
+    ON_CALL(app_mngr_, event_dispatcher())
+        .WillByDefault(ReturnRef(event_dispatcher_));
+  }
+
+  void InitNegativeResponse() {
+    MessageSharedPtr timeout_response =
+        CommandsTest<kIsNice>::CreateMessage(smart_objects::SmartType_Map);
+    (*timeout_response)[am::strings::msg_params][am::strings::result_code] =
+        am::mobile_api::Result::GENERIC_ERROR;
+    (*timeout_response)[am::strings::msg_params][am::strings::success] = false;
+
+    ON_CALL(mock_message_helper_,
+            CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))
+        .WillByDefault(Return(timeout_response));
+  }
+
   enum { kDefaultTimeout_ = 100 };
 
   MockAppManager app_mngr_;
@@ -154,6 +173,7 @@ class CommandsTest : public ::testing::Test {
   testing::NiceMock<policy_test::MockPolicyHandlerInterface>
       mock_policy_handler_;
   MockAppManagerSettings app_mngr_settings_;
+  MockEventDispatcher event_dispatcher_;
   MOCK(am::MockHmiInterfaces) mock_hmi_interfaces_;
   am::MockMessageHelper& mock_message_helper_;
 

--- a/src/components/application_manager/test/include/application_manager/mock_event_dispatcher.h
+++ b/src/components/application_manager/test/include/application_manager/mock_event_dispatcher.h
@@ -57,6 +57,10 @@ class MockEventDispatcher
       remove_observer,
       void(const ::application_manager::event_engine::Event::EventID& event_id,
            ::application_manager::event_engine::EventObserver& observer));
+  MOCK_METHOD2(
+      remove_observer,
+      void(const ::application_manager::event_engine::Event::EventID& event_id,
+           int32_t hmi_correlation_id));
   MOCK_METHOD1(
       remove_observer,
       void(::application_manager::event_engine::EventObserver& observer));

--- a/src/components/application_manager/test/include/application_manager/mock_event_observer.h
+++ b/src/components/application_manager/test/include/application_manager/mock_event_observer.h
@@ -50,8 +50,10 @@ class MockEventObserver
   MOCK_METHOD1(on_event,
                void(const application_manager::event_engine::Event& event));
   MOCK_METHOD1(
-      on_event,
+      HandleOnEvent,
       void(const application_manager::event_engine::MobileEvent& event));
+  MOCK_METHOD1(HandleOnEvent,
+               void(const application_manager::event_engine::Event& event));
 };
 
 }  // namespace event_engine_test

--- a/src/components/application_manager/test/include/application_manager/mock_request.h
+++ b/src/components/application_manager/test/include/application_manager/mock_request.h
@@ -56,9 +56,10 @@ class MockRequest : public application_manager::commands::Command {
   MOCK_CONST_METHOD0(default_timeout, uint32_t());
   MOCK_CONST_METHOD0(function_id, int32_t());
   MOCK_CONST_METHOD0(window_id, application_manager::WindowID());
+  MOCK_METHOD0(HandleTimeOut, void());
+  MOCK_METHOD0(OnUpdateTimeOut, void());
   MOCK_METHOD1(set_warning_info, void(const std::string info));
   MOCK_CONST_METHOD0(warning_info, std::string());
-  MOCK_METHOD0(onTimeOut, void());
   MOCK_METHOD0(AllowedToTerminate, bool());
   MOCK_METHOD1(SetAllowedToTerminate, void(bool is_allowed));
 

--- a/src/components/application_manager/test/mobile_event_engine_test.cc
+++ b/src/components/application_manager/test/mobile_event_engine_test.cc
@@ -116,7 +116,7 @@ class MobileEventEngineTest : public testing::Test {
     event_dispatcher_instance_->add_mobile_observer(
         event_id, correlation_id, event_observer_mock_);
     event_->set_smart_object(so);
-    EXPECT_CALL(event_observer_mock_, on_event(An<const MobileEvent&>()))
+    EXPECT_CALL(event_observer_mock_, HandleOnEvent(An<const MobileEvent&>()))
         .Times(calls_number);
     event_dispatcher_instance_->raise_mobile_event(*event_);
   }

--- a/src/components/application_manager/test/policy_event_observer_test.cc
+++ b/src/components/application_manager/test/policy_event_observer_test.cc
@@ -89,7 +89,7 @@ class PolicyEventObserverTest : public ::testing::Test {
     EXPECT_CALL(policy_handler_mock_,
                 PTUpdatedAt(Counters::KILOMETERS, field_value))
         .Times(pt_updated_calls_number);
-    policy_event_observer_->on_event(*event_);
+    policy_event_observer_->HandleOnEvent(*event_);
   }
 
   void DeleteEvent() {

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -198,7 +198,9 @@ class PolicyHandlerTest : public ::testing::Test {
 
   virtual void TearDown() OVERRIDE {
     Mock::VerifyAndClearExpectations(&mock_message_helper_);
-    ON_CALL(mock_event_dispatcher_, remove_observer(_, _));
+    ON_CALL(
+        mock_event_dispatcher_,
+        remove_observer(_, testing::Matcher<event_engine::EventObserver&>(_)));
   }
 
   void ChangePolicyManagerToMock() {

--- a/src/components/application_manager/test/request_controller/request_controller_test.cc
+++ b/src/components/application_manager/test/request_controller/request_controller_test.cc
@@ -48,6 +48,7 @@
 #include "application_manager/policies/policy_handler.h"
 #include "application_manager/resumption/resume_ctrl.h"
 #include "application_manager/state_controller.h"
+#include "application_manager/test/include/application_manager/mock_event_dispatcher.h"
 #include "resumption/last_state.h"
 #include "utils/test_async_waiter.h"
 
@@ -58,6 +59,7 @@ namespace request_controller_test {
 using ::application_manager::request_controller::RequestController;
 using ::application_manager::request_controller::RequestInfo;
 
+using ::test::components::event_engine_test::MockEventDispatcher;
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -103,8 +105,8 @@ class RequestControllerTestClass : public ::testing::Test {
   RequestControllerTestClass() {
     ON_CALL(mock_request_controller_settings_, thread_pool_size())
         .WillByDefault(Return(kThreadPoolSize));
-    request_ctrl_ =
-        std::make_shared<RequestController>(mock_request_controller_settings_);
+    request_ctrl_ = std::make_shared<RequestController>(
+        mock_request_controller_settings_, mock_event_dispatcher_);
   }
 
   RequestPtr GetMockRequest(
@@ -154,6 +156,7 @@ class RequestControllerTestClass : public ::testing::Test {
 
   NiceMock<application_manager_test::MockRequestControlerSettings>
       mock_request_controller_settings_;
+  NiceMock<MockEventDispatcher> mock_event_dispatcher_;
   RequestControllerSPtr request_ctrl_;
   RequestPtr empty_mock_request_;
   const TestSettings default_settings_;
@@ -288,7 +291,7 @@ TEST_F(RequestControllerTestClass, OnTimer_SUCCESS) {
                        mock_request,
                        RequestInfo::RequestType::MobileRequest));
 
-  EXPECT_CALL(*mock_request, onTimeOut())
+  EXPECT_CALL(*mock_request, HandleTimeOut())
       .WillOnce(NotifyTestAsyncWaiter(&waiter));
 
   // Waiting for call of `onTimeOut` for `kTimeScale` seconds

--- a/src/components/application_manager/test/rpc_service_impl_test.cc
+++ b/src/components/application_manager/test/rpc_service_impl_test.cc
@@ -43,6 +43,7 @@
 #include "application_manager/mock_application_manager.h"
 #include "application_manager/mock_command_factory.h"
 #include "application_manager/mock_command_holder.h"
+#include "application_manager/mock_event_dispatcher.h"
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/mock_request.h"
 #include "application_manager/mock_request_controller_settings.h"
@@ -66,6 +67,7 @@ using test::components::protocol_handler_test::MockProtocolHandler;
 typedef smart_objects::SmartObjectSPtr MessageSharedPtr;
 typedef utils::Optional<am::plugin_manager::RPCPlugin> PluginOpt;
 using test::components::application_manager_test::MockAppServiceManager;
+using test::components::event_engine_test::MockEventDispatcher;
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -86,7 +88,7 @@ const int32_t kConnectionSessionsCount = 2;
 class RPCServiceImplTest : public ::testing::Test {
  public:
   RPCServiceImplTest()
-      : request_controller_(mock_request_controler_)
+      : request_controller_(mock_request_controler_, mock_event_dispatcher_)
       , mock_rpc_protection_manager_(
             std::make_shared<
                 testing::NiceMock<am::MockRPCProtectionManager> >())
@@ -146,6 +148,7 @@ class RPCServiceImplTest : public ::testing::Test {
   testing::NiceMock<MockRequestControlerSettings> mock_request_controler_;
   testing::NiceMock<MockProtocolHandler> mock_protocol_handler_;
   am::request_controller::RequestController request_controller_;
+  MockEventDispatcher mock_event_dispatcher_;
   testing::NiceMock<MockHMIMessageHandler> mock_hmi_handler_;
   testing::NiceMock<MockCommandHolder> mock_command_holder_;
   std::shared_ptr<am::MockRPCProtectionManager> mock_rpc_protection_manager_;

--- a/src/components/application_manager/test/state_controller/state_controller_test.cc
+++ b/src/components/application_manager/test/state_controller/state_controller_test.cc
@@ -1294,12 +1294,12 @@ class StateControllerImplTest : public ::testing::Test {
       switch (state_id) {
         case am::HmiState::StateID::STATE_ID_VR_SESSION: {
           Event vr_start_event(FunctionID::VR_Started);
-          state_ctrl_->on_event(vr_start_event);
+          state_ctrl_->HandleOnEvent(vr_start_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_TTS_SESSION: {
           Event tts_start_event(FunctionID::TTS_Started);
-          state_ctrl_->on_event(tts_start_event);
+          state_ctrl_->HandleOnEvent(tts_start_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_PHONE_CALL: {
@@ -1310,7 +1310,7 @@ class StateControllerImplTest : public ::testing::Test {
           message[am::strings::msg_params][am::hmi_notification::event_name] =
               hmi_apis::Common_EventTypes::PHONE_CALL;
           phone_call_event.set_smart_object(message);
-          state_ctrl_->on_event(phone_call_event);
+          state_ctrl_->HandleOnEvent(phone_call_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_SAFETY_MODE: {
@@ -1321,7 +1321,7 @@ class StateControllerImplTest : public ::testing::Test {
           message[am::strings::msg_params][am::hmi_notification::event_name] =
               hmi_apis::Common_EventTypes::EMERGENCY_EVENT;
           emergency_event.set_smart_object(message);
-          state_ctrl_->on_event(emergency_event);
+          state_ctrl_->HandleOnEvent(emergency_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_NAVI_STREAMING: {
@@ -1365,12 +1365,12 @@ class StateControllerImplTest : public ::testing::Test {
       switch (state_id) {
         case am::HmiState::StateID::STATE_ID_VR_SESSION: {
           Event vr_start_event(FunctionID::VR_Started);
-          state_ctrl_->on_event(vr_start_event);
+          state_ctrl_->HandleOnEvent(vr_start_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_TTS_SESSION: {
           Event tts_start_event(FunctionID::TTS_Started);
-          state_ctrl_->on_event(tts_start_event);
+          state_ctrl_->HandleOnEvent(tts_start_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_PHONE_CALL: {
@@ -1381,7 +1381,7 @@ class StateControllerImplTest : public ::testing::Test {
           message[am::strings::msg_params][am::hmi_notification::event_name] =
               hmi_apis::Common_EventTypes::PHONE_CALL;
           phone_call_event.set_smart_object(message);
-          state_ctrl_->on_event(phone_call_event);
+          state_ctrl_->HandleOnEvent(phone_call_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_SAFETY_MODE: {
@@ -1392,7 +1392,7 @@ class StateControllerImplTest : public ::testing::Test {
           message[am::strings::msg_params][am::hmi_notification::event_name] =
               hmi_apis::Common_EventTypes::EMERGENCY_EVENT;
           emergency_event.set_smart_object(message);
-          state_ctrl_->on_event(emergency_event);
+          state_ctrl_->HandleOnEvent(emergency_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_NAVI_STREAMING: {
@@ -1418,12 +1418,12 @@ class StateControllerImplTest : public ::testing::Test {
       switch (state_id) {
         case am::HmiState::StateID::STATE_ID_VR_SESSION: {
           Event vr_stop_event(FunctionID::VR_Stopped);
-          state_ctrl_->on_event(vr_stop_event);
+          state_ctrl_->HandleOnEvent(vr_stop_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_TTS_SESSION: {
           Event tts_stop_event(FunctionID::TTS_Stopped);
-          state_ctrl_->on_event(tts_stop_event);
+          state_ctrl_->HandleOnEvent(tts_stop_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_PHONE_CALL: {
@@ -1434,7 +1434,7 @@ class StateControllerImplTest : public ::testing::Test {
           message[am::strings::msg_params][am::hmi_notification::event_name] =
               hmi_apis::Common_EventTypes::PHONE_CALL;
           phone_call_event.set_smart_object(message);
-          state_ctrl_->on_event(phone_call_event);
+          state_ctrl_->HandleOnEvent(phone_call_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_SAFETY_MODE: {
@@ -1445,7 +1445,7 @@ class StateControllerImplTest : public ::testing::Test {
           message[am::strings::msg_params][am::hmi_notification::event_name] =
               hmi_apis::Common_EventTypes::EMERGENCY_EVENT;
           emergency_event.set_smart_object(message);
-          state_ctrl_->on_event(emergency_event);
+          state_ctrl_->HandleOnEvent(emergency_event);
           break;
         }
         case am::HmiState::StateID::STATE_ID_NAVI_STREAMING: {
@@ -2286,7 +2286,7 @@ TEST_F(StateControllerImplTest, ActivateAppSuccessReceivedFromHMI) {
     am::event_engine::Event event(
         hmi_apis::FunctionID::BasicCommunication_ActivateApp);
     event.set_smart_object(message);
-    state_ctrl_->on_event(event);
+    state_ctrl_->HandleOnEvent(event);
   }
 }
 
@@ -2348,7 +2348,7 @@ TEST_F(StateControllerImplTest, SendEventBCActivateApp_HMIReceivesError) {
     message[am::strings::params][am::strings::correlation_id] = corr_id;
     am::event_engine::Event event(FunctionID::BasicCommunication_ActivateApp);
     event.set_smart_object(message);
-    state_ctrl_->on_event(event);
+    state_ctrl_->HandleOnEvent(event);
   }
 }
 
@@ -2372,7 +2372,7 @@ TEST_F(StateControllerImplTest, ActivateAppInvalidCorrelationId) {
   message[am::strings::params][am::strings::correlation_id] = corr_id;
   am::event_engine::Event event(FunctionID::BasicCommunication_ActivateApp);
   event.set_smart_object(message);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 }
 
 TEST_F(StateControllerImplTest, ApplyTempStatesForSimpleApp) {
@@ -2866,7 +2866,7 @@ TEST_F(StateControllerImplTest,
 
   // Precondition
   am::event_engine::Event event(hmi_apis::FunctionID::VR_Started);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   HmiStatePtr check_state = FullNotAudibleState();
 
@@ -2900,10 +2900,10 @@ TEST_F(StateControllerImplTest, SetRegularStateMediaToNonMediaApp_VR_Stopped) {
 
   // Precondition
   am::event_engine::Event prev_event(hmi_apis::FunctionID::VR_Started);
-  state_ctrl_->on_event(prev_event);
+  state_ctrl_->HandleOnEvent(prev_event);
 
   am::event_engine::Event next_event(hmi_apis::FunctionID::VR_Stopped);
-  state_ctrl_->on_event(next_event);
+  state_ctrl_->HandleOnEvent(next_event);
 
   // Set state of non-media app after vr has stopped
   HmiStatePtr check_state = FullNotAudibleState();
@@ -2964,7 +2964,7 @@ TEST_F(StateControllerImplTest,
       Common_EventTypes::EMERGENCY_EVENT;
 
   event.set_smart_object(message);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   // Non-media app can't have LIMITED-AUDIO state
   HmiStatePtr check_state = FullNotAudibleState();
@@ -3012,7 +3012,7 @@ TEST_F(StateControllerImplTest,
       hmi_apis::Common_EventTypes::PHONE_CALL;
 
   event.set_smart_object(message);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   am::HmiStatePtr check_state = FullAudibleState();
 
@@ -3048,7 +3048,7 @@ TEST_F(StateControllerImplTest,
       hmi_apis::Common_EventTypes::PHONE_CALL;
 
   event.set_smart_object(message);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   am::HmiStatePtr hmi_state = FullAudibleState();
 
@@ -3082,7 +3082,7 @@ TEST_F(StateControllerImplTest,
       hmi_apis::Common_EventTypes::PHONE_CALL;
 
   event.set_smart_object(message);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   am::HmiStatePtr hmi_state = FullAudibleState();
 
@@ -3119,7 +3119,7 @@ TEST_F(StateControllerImplTest,
       hmi_apis::Common_EventTypes::PHONE_CALL;
 
   event.set_smart_object(message);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   am::HmiStatePtr hmi_state = FullAudibleState();
 
@@ -3156,7 +3156,7 @@ TEST_F(StateControllerImplTest,
       hmi_apis::Common_EventTypes::PHONE_CALL;
 
   event.set_smart_object(message);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   am::HmiStatePtr hmi_state = FullAudibleState();
 
@@ -3211,7 +3211,7 @@ TEST_F(StateControllerImplTest,
   am::WindowIds window_ids = {kDefaultWindowId};
   EXPECT_CALL(*simple_app_ptr_, GetWindowIds()).WillOnce(Return(window_ids));
 
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   EXPECT_EQ(new_state->hmi_level(), mobile_apis::HMILevel::HMI_FULL);
   EXPECT_EQ(new_state->audio_streaming_state(),
@@ -3246,7 +3246,7 @@ TEST_F(StateControllerImplTest, OnEventChangedAudioSourceAppToBackground) {
   am::WindowIds window_ids = {kDefaultWindowId};
   EXPECT_CALL(*simple_app_ptr_, GetWindowIds()).WillOnce(Return(window_ids));
 
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   EXPECT_EQ(new_state->hmi_level(), mobile_apis::HMILevel::HMI_BACKGROUND);
   EXPECT_EQ(new_state->audio_streaming_state(),
@@ -3278,7 +3278,7 @@ TEST_F(StateControllerImplTest, OnEventChangedAudioSourceNavAppToLimited) {
   am::WindowIds window_ids = {kDefaultWindowId};
   EXPECT_CALL(*navi_app_ptr_, GetWindowIds()).WillOnce(Return(window_ids));
 
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   EXPECT_EQ(new_state->hmi_level(), mobile_apis::HMILevel::HMI_LIMITED);
   EXPECT_EQ(new_state->audio_streaming_state(),
@@ -3299,12 +3299,13 @@ TEST_F(StateControllerImplTest, OnEventOnAppDeactivatedIncorrectHmiLevel) {
       .WillOnce(Return(simple_app_));
   EXPECT_CALL(*simple_app_ptr_, hmi_level(kDefaultWindowId))
       .WillOnce(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
+
   EXPECT_CALL(*simple_app_ptr_, RegularHmiState(kDefaultWindowId)).Times(0);
 
   am::WindowIds window_ids = {kDefaultWindowId};
   EXPECT_CALL(*simple_app_ptr_, GetWindowIds()).WillOnce(Return(window_ids));
 
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 }
 
 TEST_F(StateControllerImplTest, OnEventOnAppDeactivatedIncorrectApp) {
@@ -3318,7 +3319,7 @@ TEST_F(StateControllerImplTest, OnEventOnAppDeactivatedIncorrectApp) {
   EXPECT_CALL(app_manager_mock_, application(_))
       .WillOnce(Return(incorrect_app));
   EXPECT_CALL(*simple_app_ptr_, hmi_level(kDefaultWindowId)).Times(0);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 }
 
 TEST_F(StateControllerImplTest, OnEventOnAppDeactivatedAudioApplication) {
@@ -3352,7 +3353,7 @@ TEST_F(StateControllerImplTest, OnEventOnAppDeactivatedAudioApplication) {
   am::WindowIds window_ids = {kDefaultWindowId};
   EXPECT_CALL(*simple_app_ptr_, GetWindowIds()).WillOnce(Return(window_ids));
 
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 }
 
 TEST_F(StateControllerImplTest, OnEventOnAppDeactivatedNotAudioApplication) {
@@ -3387,7 +3388,7 @@ TEST_F(StateControllerImplTest, OnEventOnAppDeactivatedNotAudioApplication) {
   am::WindowIds window_ids = {kDefaultWindowId};
   EXPECT_CALL(*simple_app_ptr_, GetWindowIds()).WillOnce(Return(window_ids));
 
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 }
 
 TEST_F(StateControllerImplTest, OnEventOnAppActivatedIncorrectApp) {
@@ -3402,7 +3403,7 @@ TEST_F(StateControllerImplTest, OnEventOnAppActivatedIncorrectApp) {
   EXPECT_CALL(app_manager_mock_, application(_))
       .WillOnce(Return(incorrect_app));
   EXPECT_CALL(*simple_app_ptr_, app_id()).Times(0);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 }
 
 TEST_F(StateControllerImplTest, OnEventOnAppActivated) {
@@ -3440,7 +3441,7 @@ TEST_F(StateControllerImplTest, OnEventOnAppActivated) {
         std::make_shared<smart_objects::SmartObject>();
     (*activate_app)[am::strings::params][am::strings::correlation_id] = kCorrID;
     SetBCActivateAppRequestToHMI(hmi_apis::Common_HMILevel::FULL, kCorrID);
-    state_ctrl_->on_event(event);
+    state_ctrl_->HandleOnEvent(event);
   }
 }
 
@@ -3476,7 +3477,7 @@ TEST_F(StateControllerImplTest, IsStateActiveApplyNotCorrectTempStates) {
   const hmi_apis::FunctionID::eType event_id = hmi_apis::FunctionID::VR_Started;
   am::event_engine::Event event(event_id);
   event.set_smart_object(msg);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
   EXPECT_FALSE(state_ctrl_->IsStateActive(HmiState::STATE_ID_AUDIO_SOURCE));
 }
 
@@ -3493,19 +3494,19 @@ TEST_F(StateControllerImplTest, OnApplicationRegisteredDifferentStates) {
   msg[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::AUDIO_SOURCE;
   event.set_smart_object(msg);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
   msg[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::PHONE_CALL;
   event.set_smart_object(msg);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
   msg[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::DEACTIVATE_HMI;
   event.set_smart_object(msg);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
   msg[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::EMBEDDED_NAVI;
   event.set_smart_object(msg);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   const am::HmiStatePtr old_state = CreateHmiStateByHmiStateType<am::HmiState>(
       mobile_apis::HMILevel::HMI_FULL,
@@ -3556,11 +3557,11 @@ TEST_F(StateControllerImplTest, OnApplicationRegisteredEqualStates) {
   msg[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::AUDIO_SOURCE;
   event.set_smart_object(msg);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
   msg[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::PHONE_CALL;
   event.set_smart_object(msg);
-  state_ctrl_->on_event(event);
+  state_ctrl_->HandleOnEvent(event);
 
   const am::HmiStatePtr old_state = CreateHmiStateByHmiStateType<am::HmiState>(
       mobile_apis::HMILevel::HMI_FULL,
@@ -3603,7 +3604,7 @@ TEST_F(
   message[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::AUDIO_SOURCE;
   audio_source_event.set_smart_object(message);
-  state_ctrl_->on_event(audio_source_event);
+  state_ctrl_->HandleOnEvent(audio_source_event);
 
   EXPECT_CALL(*media_app_ptr_, is_resuming()).WillRepeatedly(Return(true));
   EXPECT_CALL(*media_app_ptr_, SetRegularState(_, _)).Times(0);
@@ -3624,7 +3625,7 @@ TEST_F(
   message[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::EMBEDDED_NAVI;
   embedded_navi_event.set_smart_object(message);
-  state_ctrl_->on_event(embedded_navi_event);
+  state_ctrl_->HandleOnEvent(embedded_navi_event);
 
   EXPECT_CALL(*media_wep_app_ptr_, is_resuming())
       .Times(2)
@@ -3724,7 +3725,7 @@ TEST_F(StateControllerImplTest,
   ExpectAppWontChangeHmiStateDueToConflictResolving(
       simple_app_, simple_app_ptr_, kCustomWindowId, NoneNotAudibleState());
 
-  state_ctrl_->on_event(activate_widget_event);
+  state_ctrl_->HandleOnEvent(activate_widget_event);
 }
 
 TEST_F(StateControllerImplTest,
@@ -3765,7 +3766,7 @@ TEST_F(StateControllerImplTest,
                 GetBCActivateAppRequestToHMI(_, _, _, _, _))
         .Times(0);
 
-    state_ctrl_->on_event(activate_widget_event);
+    state_ctrl_->HandleOnEvent(activate_widget_event);
   }
 }
 
@@ -3786,7 +3787,7 @@ TEST_F(StateControllerImplTest,
   ExpectAppWontChangeHmiStateDueToConflictResolving(
       simple_app_, simple_app_ptr_, kCustomWindowId, FullNotAudibleState());
 
-  state_ctrl_->on_event(activate_widget_event);
+  state_ctrl_->HandleOnEvent(activate_widget_event);
 }
 
 TEST_F(StateControllerImplTest,
@@ -3827,7 +3828,7 @@ TEST_F(StateControllerImplTest,
                 GetBCActivateAppRequestToHMI(_, _, _, _, _))
         .Times(0);
 
-    state_ctrl_->on_event(activate_widget_event);
+    state_ctrl_->HandleOnEvent(activate_widget_event);
   }
 }
 
@@ -3911,7 +3912,7 @@ TEST_F(StateControllerImplTest,
   message[am::strings::msg_params][am::hmi_notification::event_name] =
       hmi_apis::Common_EventTypes::AUDIO_SOURCE;
   audio_source_event.set_smart_object(message);
-  state_ctrl_->on_event(audio_source_event);
+  state_ctrl_->HandleOnEvent(audio_source_event);
 
   HmiStatePtr initial_state =
       createHmiState(mobile_apis::HMILevel::INVALID_ENUM,

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -672,6 +672,36 @@ class ApplicationManager {
                                 const uint32_t corr_id,
                                 const int32_t function_id) = 0;
 
+  /**
+   * @brief RetainRequestInstance retains request instance by its
+   * connection+correlation key
+   * @param connection_key connection key of application
+   * @param correlation_id correlation id of request
+   * @return true if request was rerained. false if the request with such
+   * connection+correlation key was not found
+   */
+  virtual bool RetainRequestInstance(const uint32_t connection_key,
+                                     const uint32_t correlation_id) = 0;
+
+  /**
+   * @brief RemoveRetainedRequest removes request instance retained before
+   * @param connection_key connection key of application
+   * @param correlation_id correlation id of request
+   */
+  virtual void RemoveRetainedRequest(const uint32_t connection_key,
+                                     const uint32_t correlation_id) = 0;
+
+  /**
+   * @brief IsStillWaitingForResponse check if request is still waiting for
+   * response
+   * @param connection_key connection key of application
+   * @param correlation_id correlation id of request
+   * @return true if request is still waiting for response, otherwise returns
+   * false
+   */
+  virtual bool IsStillWaitingForResponse(
+      const uint32_t connection_key, const uint32_t correlation_id) const = 0;
+
   /*
    * @brief Closes application by id
    *

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -393,6 +393,15 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(GetCommandFactory, application_manager::CommandFactory&());
   MOCK_CONST_METHOD0(get_current_audio_source, uint32_t());
   MOCK_METHOD1(set_current_audio_source, void(const uint32_t));
+  MOCK_METHOD2(RetainRequestInstance,
+               bool(const uint32_t connection_key,
+                    const uint32_t correlation_id));
+  MOCK_METHOD2(RemoveRetainedRequest,
+               void(const uint32_t connection_key,
+                    const uint32_t correlation_id));
+  MOCK_CONST_METHOD2(IsStillWaitingForResponse,
+                     bool(const uint32_t connection_key,
+                          const uint32_t correlation_id));
 };
 
 }  // namespace application_manager_test

--- a/src/components/include/test/application_manager/mock_state_controller.h
+++ b/src/components/include/test/application_manager/mock_state_controller.h
@@ -113,6 +113,7 @@ class MockStateController : public am::StateController {
   MOCK_METHOD2(DeactivateApp,
                void(am::ApplicationSharedPtr app,
                     const am::WindowID window_id));
+  MOCK_METHOD1(OnTimeOutActivateAppRequest, void(uint32_t hmi_app_id));
   MOCK_METHOD0(GetPostponedActivationController,
                application_manager::PostponedActivationController&());
 };

--- a/src/components/include/test/application_manager/mock_state_controller.h
+++ b/src/components/include/test/application_manager/mock_state_controller.h
@@ -113,7 +113,6 @@ class MockStateController : public am::StateController {
   MOCK_METHOD2(DeactivateApp,
                void(am::ApplicationSharedPtr app,
                     const am::WindowID window_id));
-  MOCK_METHOD1(OnTimeOutActivateAppRequest, void(uint32_t hmi_app_id));
   MOCK_METHOD0(GetPostponedActivationController,
                application_manager::PostponedActivationController&());
 };


### PR DESCRIPTION
Fixes #3141, #2935
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Unit tests, ATF

### Summary
* Changed commands requests inheritance structure.
* Fixed data races in request controller.

##### Enhancements
* **CommonRequestImpl** class was reworked in order to keep only common
requests logic. Created new class - **RequestFromMobile** for logic specific for mobile
requests only.
![image](https://user-images.githubusercontent.com/12031221/101053871-f2ccc180-3590-11eb-98c8-407f3ab7bf7d.png)
![image](https://user-images.githubusercontent.com/12031221/101054231-56ef8580-3591-11eb-9257-16ae3cce5ff9.png)

* Reworked logic of handling requests with multiple interfaces.
Used common methods for checks of pending requests.
* Functions **OnUpdateTimeOut** and **HahdleOnEvent** added to **CommandRequestImpl** for correct synchorization and processing of current request state, that helps to avoid data races.
Current states processing:
![image](https://user-images.githubusercontent.com/12031221/101027723-125bee00-3581-11eb-83fd-90c7e4256cd9.png)

##### Bug Fixes

1. Fix data races in request controller

There was a problem that request controller might
destroy the command which is currently executed by
another thread in case of application disconnect.
When app gets disconnected, SDL destroys all pending
and waiting for response requests belongs to
unregistered application. Data race is happening
when request controller destroys the command which
is currently handles response. To resolve this data
race the following changes were done:
- **terminateWaitingForResponseAppRequests** function
was updated to iterate over all pending requests and
consider possibility to terminate it via **CleanUp()**
call. Requests will be terminated only in case of
successful cleanup
- During cleanup, mobile requests unsubscribes from
all events to avoid getting **kProcessEvent** state
- Cleanup is considered as successful in case if
command is in **kAwaiting** state
- In case the command in:
**kAwaitingResponse** - command will be dropped by
request controller as usual as there no data races
**kTimedOut** - command is executing **OnTimeout()** call.
Request controller will keep this command in
**waiting_for_response_** list as it will be dropped
later by another thread after **OnTimeout()** execution
**kProcessEvent** - command is executing **on_event()** call.
Request controller will keep this command in
**waiting_for_response_** list as it will be dropped
later by another thread after **on_event()** execution

2. Prevent command destruction after on_event

Was added workaround to prevent command destruction
after **on_event()** call because some additional acitons
should be done after that. Workaround is to retain
requests shared pointer instance before on_event()
and release it after **on_event()** and state check.
This allows to remove another workaround logic and
provides better control on a command lifetime from
the outside.

### Tasks Remaining:
- [ ] [Task 1]
- [ ] [Task 2]

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
