### PR TITLE
Adding support for numeric keyboard

### DIFF
--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1326,6 +1326,7 @@
   <element name="QWERTY" />
   <element name="QWERTZ" />
   <element name="AZERTY" />
+  <element name="NUMERIC"/>
 </enum>
 
 <enum name="KeyboardEvent">
@@ -3623,6 +3624,26 @@
     <param name="maximumNumberOfWindows" type="Integer" mandatory="true" />
   </struct>
 
+  <struct name="ConfigurableKeyboards">
+    <description>
+      Describes number of cofigurable Keys for Special characters.
+    </description>
+    <param name="keyboardLayout" type="KeyboardLayout" mandatory="true"/>
+    <param name="numConfigurableKeys" type="Integer" mandatory="true"/>
+  </struct>
+
+  <struct name="KeyboardCapabilities">
+    <param name="maskInputCharactersSupported" type="Boolean" mandatory="false">
+      <description>Availability of capability to mask input characters using keyboard. True: Available, False: Not Available</description>
+    </param>
+    <param name="supportedKeyboardLayouts" type="KeyboardLayout" minsize="1" maxsize="1000" array="true" mandatory="false">
+      <description>Supported keyboard layouts by HMI.</description>
+    </param>
+    <param name="configurableKeys" type="ConfigurableKeyboards" minsize="1" maxsize="1000" array="true" mandatory="false">
+      <description>Get Number of Keys for Special characters, App can customize as per their needs.</description>
+    </param>
+  </struct>
+
   <struct name="WindowCapability">
     <param name="windowID" type="Integer" mandatory="false">
       <description>
@@ -3656,6 +3677,9 @@
     </param>
     <param name="dynamicUpdateCapabilities" type="DynamicUpdateCapabilities" mandatory="false">
       <description>Contains the head unit's capabilities for dynamic updating features declaring if the module will send dynamic update RPCs.</description>
+    </param>
+    <param name="keyboardCapabilities" type="KeyboardCapabilities" mandatory="false">
+      <description>See KeyboardCapabilities</description>
     </param>
   </struct>
 


### PR DESCRIPTION
Fixes [FORDTCN-7949](https://adc.luxoft.com/jira/browse/FORDTCN-7949)

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
TBD

### Summary
There is a need in adding support for numeric keyboard. To solve this problem new struct "KeyboardCapabilities" is added to HMI API to inform apps about keyboard capabilities of HMI. Also "NUMERIC" value is added to "KeyboardLayout" enum. This enum value should allow apps to use numeric keypad.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
