### PR TITLE
CCB: Fix unit tests stucks

### DIFF
--- a/src/components/application_manager/test/app_launch/app_launch_ctrl_test.cc
+++ b/src/components/application_manager/test/app_launch/app_launch_ctrl_test.cc
@@ -202,7 +202,7 @@ TEST_F(AppLaunchCtrlTest, StoredAppIsLaunchedAfterDeviceConnected) {
   app_launch::ApplicationDataPtr app_to_launch = GetTestAppData(0);
   MockAppPtr app = GetTestApp(0);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   applications_on_device.push_back(app_to_launch);
   EXPECT_CALL(app_launch_data_mock_,
               GetApplicationDataByDevice(app_to_launch->device_mac_))
@@ -224,7 +224,7 @@ TEST_F(AppLaunchCtrlTest, RelaunchAppIfNotRegisteredMultipleTimes) {
   app_launch::ApplicationDataPtr app_to_launch = GetTestAppData(0);
   applications_on_device.push_back(app_to_launch);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   const uint32_t times = settings_.app_launch_max_retry_attempt();
   EXPECT_CALL(app_launch_data_mock_,
               GetApplicationDataByDevice(app_to_launch->device_mac_))
@@ -253,7 +253,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleApps) {
     apps.push_back(it->second);
   }
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   const uint32_t times = apps_and_data.size();
   EXPECT_CALL(app_launch_data_mock_, GetApplicationDataByDevice(DeviceMac(1)))
       .WillOnce(Return(apps));
@@ -285,7 +285,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsNoRegister) {
     apps.push_back(it->second);
   }
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   const uint32_t times =
       settings_.app_launch_max_retry_attempt() * apps_and_data.size();
   EXPECT_CALL(app_launch_data_mock_, GetApplicationDataByDevice(DeviceMac(1)))
@@ -343,7 +343,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsInHMILevelOrder) {
     apps.push_back(app_data);
   }
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   const uint32_t times = apps_and_data.size();
   EXPECT_CALL(app_launch_data_mock_, GetApplicationDataByDevice(DeviceMac(1)))
       .WillOnce(Return(apps));

--- a/src/components/application_manager/test/app_launch/app_launch_ctrl_test.cc
+++ b/src/components/application_manager/test/app_launch/app_launch_ctrl_test.cc
@@ -202,7 +202,7 @@ TEST_F(AppLaunchCtrlTest, StoredAppIsLaunchedAfterDeviceConnected) {
   app_launch::ApplicationDataPtr app_to_launch = GetTestAppData(0);
   MockAppPtr app = GetTestApp(0);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   applications_on_device.push_back(app_to_launch);
   EXPECT_CALL(app_launch_data_mock_,
               GetApplicationDataByDevice(app_to_launch->device_mac_))
@@ -212,11 +212,11 @@ TEST_F(AppLaunchCtrlTest, StoredAppIsLaunchedAfterDeviceConnected) {
       RunAppOnDevice(app_to_launch->device_mac_, app_to_launch->bundle_id_))
       .Times(AtLeast(1))
       .WillOnce(DoAll(InvokeOnAppRegistered(app_launch_ctrl_.get(), app.get()),
-                      NotifyTestAsyncWaiter(&waiter)));
+                      NotifyTestAsyncWaiter(waiter)));
   app_launch_ctrl_->OnDeviceConnected(app_to_launch->device_mac_);
   const uint32_t wait_time =
       MAX_TEST_DURATION + settings_.app_launch_wait_time();
-  EXPECT_TRUE(waiter.WaitFor(1, wait_time));
+  EXPECT_TRUE(waiter->WaitFor(1, wait_time));
 }
 
 TEST_F(AppLaunchCtrlTest, RelaunchAppIfNotRegisteredMultipleTimes) {
@@ -224,7 +224,7 @@ TEST_F(AppLaunchCtrlTest, RelaunchAppIfNotRegisteredMultipleTimes) {
   app_launch::ApplicationDataPtr app_to_launch = GetTestAppData(0);
   applications_on_device.push_back(app_to_launch);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   const uint32_t times = settings_.app_launch_max_retry_attempt();
   EXPECT_CALL(app_launch_data_mock_,
               GetApplicationDataByDevice(app_to_launch->device_mac_))
@@ -234,14 +234,14 @@ TEST_F(AppLaunchCtrlTest, RelaunchAppIfNotRegisteredMultipleTimes) {
       connection_handler_mock_,
       RunAppOnDevice(app_to_launch->device_mac_, app_to_launch->bundle_id_))
       .Times(times)
-      .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
+      .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
 
   app_launch_ctrl_->OnDeviceConnected(app_to_launch->device_mac_);
   const uint32_t wait_time = MAX_TEST_DURATION +
                              settings_.app_launch_wait_time() +
                              settings_.app_launch_max_retry_attempt() *
                                  settings_.app_launch_retry_wait_time();
-  EXPECT_TRUE(waiter.WaitFor(times, wait_time));
+  EXPECT_TRUE(waiter->WaitFor(times, wait_time));
 }
 
 TEST_F(AppLaunchCtrlTest, LaunchMultipleApps) {
@@ -253,7 +253,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleApps) {
     apps.push_back(it->second);
   }
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   const uint32_t times = apps_and_data.size();
   EXPECT_CALL(app_launch_data_mock_, GetApplicationDataByDevice(DeviceMac(1)))
       .WillOnce(Return(apps));
@@ -267,13 +267,13 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleApps) {
         .Times(AtLeast(1))
         .WillOnce(DoAll(
             InvokeOnAppRegistered(app_launch_ctrl_.get(), it->first.get()),
-            NotifyTestAsyncWaiter(&waiter)));
+            NotifyTestAsyncWaiter(waiter)));
   }
   app_launch_ctrl_->OnDeviceConnected(DeviceMac(1));
   const uint32_t wait_time = MAX_TEST_DURATION +
                              settings_.app_launch_wait_time() +
                              apps.size() * settings_.wait_time_between_apps();
-  waiter.WaitFor(times, wait_time);
+  waiter->WaitFor(times, wait_time);
 }
 
 TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsNoRegister) {
@@ -285,7 +285,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsNoRegister) {
     apps.push_back(it->second);
   }
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   const uint32_t times =
       settings_.app_launch_max_retry_attempt() * apps_and_data.size();
   EXPECT_CALL(app_launch_data_mock_, GetApplicationDataByDevice(DeviceMac(1)))
@@ -300,13 +300,13 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsNoRegister) {
                 RunAppOnDevice(app_data.second->device_mac_,
                                app_data.second->bundle_id_))
         .Times(settings_.app_launch_max_retry_attempt())
-        .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
+        .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
   }
   app_launch_ctrl_->OnDeviceConnected(DeviceMac(1));
   const uint32_t wait_time = MAX_TEST_DURATION +
                              settings_.app_launch_wait_time() +
                              apps.size() * settings_.wait_time_between_apps();
-  waiter.WaitFor(times, wait_time);
+  waiter->WaitFor(times, wait_time);
 }
 
 TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsInHMILevelOrder) {
@@ -343,7 +343,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsInHMILevelOrder) {
     apps.push_back(app_data);
   }
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   const uint32_t times = apps_and_data.size();
   EXPECT_CALL(app_launch_data_mock_, GetApplicationDataByDevice(DeviceMac(1)))
       .WillOnce(Return(apps));
@@ -356,7 +356,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsInHMILevelOrder) {
         .Times(AtLeast(1))
         .WillRepeatedly(DoAll(
             InvokeOnAppRegistered(app_launch_ctrl_.get(), it->first.get()),
-            NotifyTestAsyncWaiter(&waiter)));
+            NotifyTestAsyncWaiter(waiter)));
   }
 
   app_launch_ctrl_->OnDeviceConnected(DeviceMac(1));
@@ -364,7 +364,7 @@ TEST_F(AppLaunchCtrlTest, LaunchMultipleAppsInHMILevelOrder) {
   const uint32_t wait_time = MAX_TEST_DURATION +
                              settings_.app_launch_wait_time() +
                              apps.size() * settings_.wait_time_between_apps();
-  waiter.WaitFor(times, wait_time);
+  waiter->WaitFor(times, wait_time);
 }
 
 }  // namespace app_launch_test

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -292,40 +292,6 @@ class PolicyHandlerTest : public ::testing::Test {
   }
 };
 
-namespace {
-/**
- * @brief The WaitAsync class
- * can wait for a certain amount of function calls from different
- * threads, or a timeout expires.
- */
-class WaitAsync {
- public:
-  WaitAsync(const uint32_t count, const uint32_t timeout)
-      : count_(count), timeout_(timeout) {}
-
-  void Notify() {
-    count_--;
-    cond_var_.NotifyOne();
-  }
-
-  bool Wait(sync_primitives::AutoLock& auto_lock) {
-    while (count_ > 0) {
-      sync_primitives::ConditionalVariable::WaitStatus wait_status =
-          cond_var_.WaitFor(auto_lock, timeout_);
-      if (wait_status == sync_primitives::ConditionalVariable::kTimeout) {
-        return false;
-      }
-    }
-    return true;
-  }
-
- private:
-  int count_;
-  const uint32_t timeout_;
-  sync_primitives::ConditionalVariable cond_var_;
-};
-}  // namespace
-
 TEST_F(PolicyHandlerTest, LoadPolicyLibrary_Method_ExpectLibraryLoaded) {
   // Check before policy enabled from ini file
   EXPECT_CALL(policy_settings_, enable_policy()).WillRepeatedly(Return(false));
@@ -2259,24 +2225,20 @@ TEST_F(PolicyHandlerTest,
   EXPECT_CALL(*mock_app_, policy_app_id()).WillOnce(Return(kPolicyAppId_));
   EXPECT_CALL(*mock_app_, device()).WillOnce(Return(device));
 
-  sync_primitives::Lock wait_hmi_lock_first;
-  sync_primitives::AutoLock auto_lock_first(wait_hmi_lock_first);
-  WaitAsync waiter_first(kCallsCount_, kTimeout_);
+  auto waiter_first = TestAsyncWaiter::createInstance();
 #ifdef EXTERNAL_PROPRIETARY_MODE
   EXPECT_CALL(*mock_policy_manager_, SetUserConsentForApp(_, _))
-      .WillOnce(NotifyAsync(&waiter_first));
+      .WillOnce(NotifyTestAsyncWaiter(waiter_first));
 #else
   EXPECT_CALL(*mock_policy_manager_, SetUserConsentForApp(_))
-      .WillOnce(NotifyAsync(&waiter_first));
+      .WillOnce(NotifyTestAsyncWaiter(waiter_first));
 #endif
   ExternalConsentStatusItem item(1u, 1u, kStatusOn);
   ExternalConsentStatus external_consent_status;
   external_consent_status.insert(item);
 
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  sync_primitives::Lock wait_hmi_lock_second;
-  sync_primitives::AutoLock auto_lock_second(wait_hmi_lock_second);
-  WaitAsync waiter_second(kCallsCount_, kTimeout_);
+  auto waiter_second = TestAsyncWaiter::createInstance();
 
   EXPECT_CALL(*mock_policy_manager_,
               SetExternalConsentStatus(external_consent_status))
@@ -2287,9 +2249,9 @@ TEST_F(PolicyHandlerTest,
   policy_handler_.OnAppPermissionConsent(kConnectionKey_, permissions);
 
 #endif
-  EXPECT_TRUE(waiter_first.Wait(auto_lock_first));
+  EXPECT_TRUE(waiter_first->WaitFor(kCallsCount_, kTimeout_));
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  EXPECT_TRUE(waiter_second.Wait(auto_lock_second));
+  EXPECT_TRUE(waiter_second->WaitFor(kCallsCount_, kTimeout_));
 #endif
 }
 
@@ -2310,9 +2272,7 @@ TEST_F(PolicyHandlerTest,
 
   permissions.group_permissions.push_back(group_permission_allowed);
 
-  sync_primitives::Lock wait_hmi_lock;
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
-  WaitAsync waiter(kCallsCount_, kTimeout_);
+  auto waiter = TestAsyncWaiter::createInstance();
 
   EXPECT_CALL(app_manager_, application(_)).Times(0);
 
@@ -2329,7 +2289,7 @@ TEST_F(PolicyHandlerTest,
   policy_handler_.OnAppPermissionConsent(invalid_connection_key, permissions);
 #endif
 
-  EXPECT_FALSE(waiter.Wait(auto_lock));
+  EXPECT_FALSE(waiter->WaitFor(kCallsCount_, kTimeout_));
 }
 
 TEST_F(PolicyHandlerTest,
@@ -2349,9 +2309,7 @@ TEST_F(PolicyHandlerTest,
 
   permissions.group_permissions.push_back(group_permission_allowed);
 
-  sync_primitives::Lock wait_hmi_lock;
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
-  WaitAsync waiter(kCallsCount_, kTimeout_);
+  auto waiter = TestAsyncWaiter::createInstance();
 
   EXPECT_CALL(app_manager_, application(_)).Times(0);
 
@@ -2370,7 +2328,7 @@ TEST_F(PolicyHandlerTest,
   policy_handler_.OnAppPermissionConsent(invalid_connection_key, permissions);
 #endif
 
-  EXPECT_FALSE(waiter.Wait(auto_lock));
+  EXPECT_FALSE(waiter->WaitFor(kCallsCount_, kTimeout_));
 }
 
 ACTION_P(SetDeviceParamsMacAdress, mac_adress) {
@@ -2422,13 +2380,11 @@ TEST_F(PolicyHandlerTest,
   ExternalConsentStatus external_consent_status;
   external_consent_status.insert(item);
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  sync_primitives::Lock wait_hmi_lock;
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
-  WaitAsync waiter(kCallsCount_, kTimeout_);
+  auto waiter = TestAsyncWaiter::createInstance();
 
   EXPECT_CALL(*mock_policy_manager_,
               SetExternalConsentStatus(external_consent_status))
-      .WillOnce(DoAll(NotifyAsync(&waiter), Return(true)));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   policy_handler_.OnAppPermissionConsent(
       invalid_connection_key, permissions, external_consent_status);
 #else
@@ -2437,7 +2393,7 @@ TEST_F(PolicyHandlerTest,
 
   Mock::VerifyAndClearExpectations(mock_app_.get());
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  EXPECT_TRUE(waiter.Wait(auto_lock));
+  EXPECT_TRUE(waiter->WaitFor(kCallsCount_, kTimeout_));
 #endif
 }
 
@@ -2486,9 +2442,7 @@ TEST_F(PolicyHandlerTest,
   ExternalConsentStatus external_consent_status;
   external_consent_status.insert(item);
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  sync_primitives::Lock wait_hmi_lock;
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
-  WaitAsync waiter(kCallsCount_, kTimeout_);
+  auto waiter = TestAsyncWaiter::createInstance();
 
   ON_CALL(*mock_policy_manager_, IsNeedToUpdateExternalConsentStatus(_))
       .WillByDefault(Return(false));
@@ -2503,7 +2457,7 @@ TEST_F(PolicyHandlerTest,
 
   Mock::VerifyAndClearExpectations(mock_app_.get());
 #ifdef EXTERNAL_PROPRIETARY_MODE
-  EXPECT_FALSE(waiter.Wait(auto_lock));
+  EXPECT_FALSE(waiter->WaitFor(kCallsCount_, kTimeout_));
 #endif
 }
 
@@ -2554,32 +2508,26 @@ TEST_F(PolicyHandlerTest, AddStatisticsInfo_UnknownStatistics_UNSUCCESS) {
 TEST_F(PolicyHandlerTest, AddStatisticsInfo_SUCCESS) {
   EnablePolicyAndPolicyManagerMock();
 
-  sync_primitives::Lock wait_hmi_lock;
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
-  WaitAsync waiter(kCallsCount_, kTimeout_);
+  auto waiter = TestAsyncWaiter::createInstance();
 
   EXPECT_CALL(*mock_policy_manager_, Increment(_))
-      .WillOnce(NotifyAsync(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   policy_handler_.AddStatisticsInfo(
       hmi_apis::Common_StatisticsType::iAPP_BUFFER_FULL);
-  EXPECT_TRUE(waiter.Wait(auto_lock));
+  EXPECT_TRUE(waiter->WaitFor(kCallsCount_, kTimeout_));
 }
 
 TEST_F(PolicyHandlerTest, OnSystemError_SUCCESS) {
   EnablePolicyAndPolicyManagerMock();
 
-  //sync_primitives::Lock wait_hmi_lock;
-  //sync_primitives::AutoLock auto_lock(wait_hmi_lock);
   auto waiter_first = TestAsyncWaiter::createInstance();
-  //WaitAsync waiter_first(kCallsCount_, kTimeout_);
   EXPECT_CALL(*mock_policy_manager_, Increment(_))
       .WillOnce(NotifyTestAsyncWaiter(waiter_first));
 
   policy_handler_.OnSystemError(hmi_apis::Common_SystemError::SYNC_REBOOTED);
   EXPECT_TRUE(waiter_first->WaitFor(kCallsCount_, kTimeout_));
 
-  //WaitAsync waiter1(kCallsCount_, kTimeout_);
   auto waiter_second = TestAsyncWaiter::createInstance();
 
   EXPECT_CALL(*mock_policy_manager_, Increment(_))

--- a/src/components/application_manager/test/request_controller/request_controller_test.cc
+++ b/src/components/application_manager/test/request_controller/request_controller_test.cc
@@ -162,8 +162,7 @@ class RequestControllerTestClass : public ::testing::Test {
 TEST_F(RequestControllerTestClass,
        AddMobileRequest_DuplicateCorrelationId_INVALID_ID) {
   RequestPtr request_valid = GetMockRequest();
-  std::shared_ptr<TestAsyncWaiter> waiter_valid =
-      std::make_shared<TestAsyncWaiter>();
+  auto waiter_valid = TestAsyncWaiter::createInstance();
   ON_CALL(*request_valid, default_timeout()).WillByDefault(Return(0));
   EXPECT_CALL(*request_valid, Init()).WillOnce(Return(true));
   EXPECT_CALL(*request_valid, Run())
@@ -180,8 +179,7 @@ TEST_F(RequestControllerTestClass,
   // The command should not be run if another command with the same
   // correlation_id is waiting for a response
   RequestPtr request_dup_corr_id = GetMockRequest();
-  std::shared_ptr<TestAsyncWaiter> waiter_dup =
-      std::make_shared<TestAsyncWaiter>();
+  auto waiter_dup = TestAsyncWaiter::createInstance();
   ON_CALL(*request_dup_corr_id, default_timeout()).WillByDefault(Return(0));
   EXPECT_CALL(*request_dup_corr_id, Init()).WillOnce(Return(true));
   ON_CALL(*request_dup_corr_id, Run())
@@ -284,7 +282,7 @@ TEST_F(RequestControllerTestClass, OnTimer_SUCCESS) {
   RequestPtr mock_request = GetMockRequest(
       kDefaultCorrelationID, kDefaultConnectionKey, request_timeout);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_EQ(RequestController::SUCCESS,
             AddRequest(default_settings_,
                        mock_request,

--- a/src/components/application_manager/test/rpc_passing_handler_test.cc
+++ b/src/components/application_manager/test/rpc_passing_handler_test.cc
@@ -390,7 +390,7 @@ TEST_F(RPCPassingHandlerTest,
 
 TEST_F(RPCPassingHandlerTest, RPCPassingTest_REQUEST_Timeout) {
   uint32_t timeout_in_ms = 4;
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
 
   app_services_.push_back(CreateAppService(
       kConnectionKey_NAV_ASP, "Navigation service", "NAVIGATION"));

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -1045,34 +1045,34 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithCommonReason) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kMobileNav, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kAudio, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kBulk, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kRpc, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   connection_handler_->CloseSession(connection_key_, kCommon);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
 TEST_F(ConnectionHandlerTest, CloseSessionWithFloodReason) {
@@ -1087,34 +1087,34 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithFloodReason) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kMobileNav, kFlood))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kAudio, kFlood))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kBulk, kFlood))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kRpc, kFlood))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   connection_handler_->CloseSession(connection_key_, kFlood);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
 TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
@@ -1129,7 +1129,7 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
@@ -1138,24 +1138,24 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kMobileNav, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kAudio, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kBulk, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kRpc, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   connection_handler_->CloseSession(connection_key_, kMalformed);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
 TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
@@ -1170,7 +1170,7 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
@@ -1179,24 +1179,24 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kMobileNav, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kAudio, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kBulk, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kRpc, kMalformed))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   connection_handler_->CloseConnectionSessions(uid_, kMalformed);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
 TEST_F(ConnectionHandlerTest, CloseConnectionSessionsInvalidConnectionId) {
@@ -1229,34 +1229,34 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithCommonReason) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   InSequence seq;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kMobileNav, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kAudio, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kBulk, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_connection_handler_observer,
               OnServiceEndedCallback(connection_key_, kRpc, kCommon))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   connection_handler_->CloseConnectionSessions(uid_, kCommon);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
 TEST_F(ConnectionHandlerTest, StartService_withServices) {

--- a/src/components/connection_handler/test/connection_handler_impl_test.cc
+++ b/src/components/connection_handler/test/connection_handler_impl_test.cc
@@ -1045,7 +1045,7 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithCommonReason) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
@@ -1087,7 +1087,7 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithFloodReason) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
@@ -1129,7 +1129,7 @@ TEST_F(ConnectionHandlerTest, CloseSessionWithMalformedMessage) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
@@ -1170,7 +1170,7 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithMalformedMessage) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))
@@ -1229,7 +1229,7 @@ TEST_F(ConnectionHandlerTest, CloseConnectionSessionsWithCommonReason) {
 
   connection_handler_->set_protocol_handler(&mock_protocol_handler_);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_protocol_handler_,
               SendEndSession(uid_, out_context_.new_session_id_))

--- a/src/components/connection_handler/test/heart_beat_monitor_test.cc
+++ b/src/components/connection_handler/test/heart_beat_monitor_test.cc
@@ -123,19 +123,19 @@ TEST_F(HeartBeatMonitorTest, TimerElapsed) {
 
   const uint32_t session = connection_->AddNewSession(kDefaultConnectionHandle);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, session, _))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter),
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
                       RemoveSession(connection_, session)));
   times++;
   EXPECT_CALL(connection_handler_mock_, SendHeartBeat(_, session))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   connection_->StartHeartBeat(session);
 
-  EXPECT_TRUE(waiter.WaitFor(
+  EXPECT_TRUE(waiter->WaitFor(
       times,
       2 * timeout_ * MICROSECONDS_IN_MILLISECONDS + MICROSECONDS_IN_SECOND));
 }
@@ -166,13 +166,13 @@ TEST_F(HeartBeatMonitorTest, NotKeptAlive) {
 
   const uint32_t session = connection_->AddNewSession(kDefaultConnectionHandle);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, SendHeartBeat(_, session))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, session, _))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter),
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
                       RemoveSession(connection_, session)));
   times++;
 
@@ -180,7 +180,7 @@ TEST_F(HeartBeatMonitorTest, NotKeptAlive) {
   usleep(timeout_);
   connection_->KeepAlive(session);
 
-  EXPECT_TRUE(waiter.WaitFor(
+  EXPECT_TRUE(waiter->WaitFor(
       times,
       2 * timeout_ * MICROSECONDS_IN_MILLISECONDS + MICROSECONDS_IN_SECOND));
 }
@@ -203,28 +203,28 @@ TEST_F(HeartBeatMonitorTest, TwoSessionsElapsed) {
   const uint32_t kSession2 =
       connection_->AddNewSession(kAnotherConnectionHandle);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, kSession1, _))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter),
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
                       RemoveSession(connection_, kSession1)));
   times++;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, kSession2, _))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter),
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
                       RemoveSession(connection_, kSession2)));
   times++;
 
   EXPECT_CALL(connection_handler_mock_, SendHeartBeat(_, kSession1))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(connection_handler_mock_, SendHeartBeat(_, kSession2))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   connection_->StartHeartBeat(kSession1);
   connection_->StartHeartBeat(kSession2);
 
-  EXPECT_TRUE(waiter.WaitFor(
+  EXPECT_TRUE(waiter->WaitFor(
       times,
       2 * timeout_ * MICROSECONDS_IN_MILLISECONDS + MICROSECONDS_IN_SECOND));
 }
@@ -256,21 +256,21 @@ TEST_F(HeartBeatMonitorTest, DecreaseHeartBeatTimeout) {
   const uint32_t kSession =
       connection_->AddNewSession(kDefaultConnectionHandle);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, kSession, _))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter),
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
                       RemoveSession(connection_, kSession)));
   times++;
   EXPECT_CALL(connection_handler_mock_, SendHeartBeat(_, kSession))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   const uint32_t new_timeout = timeout_ - kTime_offset;
   connection_->StartHeartBeat(kSession);
   connection_->SetHeartBeatTimeout(new_timeout, kSession);
 
-  EXPECT_TRUE(waiter.WaitFor(
+  EXPECT_TRUE(waiter->WaitFor(
       times,
       2 * timeout_ * MICROSECONDS_IN_MILLISECONDS + MICROSECONDS_IN_SECOND));
 }

--- a/src/components/connection_handler/test/heart_beat_monitor_test.cc
+++ b/src/components/connection_handler/test/heart_beat_monitor_test.cc
@@ -123,7 +123,7 @@ TEST_F(HeartBeatMonitorTest, TimerElapsed) {
 
   const uint32_t session = connection_->AddNewSession(kDefaultConnectionHandle);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, session, _))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
@@ -166,7 +166,7 @@ TEST_F(HeartBeatMonitorTest, NotKeptAlive) {
 
   const uint32_t session = connection_->AddNewSession(kDefaultConnectionHandle);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, SendHeartBeat(_, session))
       .WillOnce(NotifyTestAsyncWaiter(waiter));
@@ -203,7 +203,7 @@ TEST_F(HeartBeatMonitorTest, TwoSessionsElapsed) {
   const uint32_t kSession2 =
       connection_->AddNewSession(kAnotherConnectionHandle);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, kSession1, _))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),
@@ -256,7 +256,7 @@ TEST_F(HeartBeatMonitorTest, DecreaseHeartBeatTimeout) {
   const uint32_t kSession =
       connection_->AddNewSession(kDefaultConnectionHandle);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(connection_handler_mock_, CloseSession(_, kSession, _))
       .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter),

--- a/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
+++ b/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
@@ -175,11 +175,11 @@ TEST_F(HMIMessageHandlerImplTest, OnMessageReceived_InvalidObserver_Cancelled) {
 TEST_F(HMIMessageHandlerImplTest, SendMessageToHMI_Success) {
   hmi_message_handler::MessageSharedPointer message = CreateMessage();
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
 
   MockHMIMessageAdapterImpl message_adapter(hmi_handler_);
   EXPECT_CALL(message_adapter, SendMessageToHMI(message))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   hmi_handler_->AddHMIMessageAdapter(&message_adapter);
   hmi_handler_->SendMessageToHMI(message);
@@ -187,7 +187,7 @@ TEST_F(HMIMessageHandlerImplTest, SendMessageToHMI_Success) {
   // Wait for the message to be processed
   hmi_handler_->messages_to_hmi()->WaitDumpQueue();
 
-  EXPECT_TRUE(waiter.WaitFor(1, 100));
+  EXPECT_TRUE(waiter->WaitFor(1, 100));
 }
 
 TEST(WebsocketSessionTest, SendMessage_UnpreparedConnection_WithoutFall) {

--- a/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
+++ b/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
@@ -175,7 +175,7 @@ TEST_F(HMIMessageHandlerImplTest, OnMessageReceived_InvalidObserver_Cancelled) {
 TEST_F(HMIMessageHandlerImplTest, SendMessageToHMI_Success) {
   hmi_message_handler::MessageSharedPointer message = CreateMessage();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
 
   MockHMIMessageAdapterImpl message_adapter(hmi_handler_);
   EXPECT_CALL(message_adapter, SendMessageToHMI(message))

--- a/src/components/include/test/utils/test_async_waiter.h
+++ b/src/components/include/test/utils/test_async_waiter.h
@@ -48,8 +48,7 @@ namespace test {
  *
  * Usage example:
  * TEST() {
- *   std::shared_ptr<TestAsyncWaiter> waiter =
- *     std::make_shared<TestAsyncWaiter>();
+ *   auto waiter = TestAsyncWaiter::createInstance();
  *   EXPECT_CALL(mock, InterestingCall())
  *       .Times(n)
  *       .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
@@ -58,8 +57,6 @@ namespace test {
  */
 class TestAsyncWaiter {
  public:
-  TestAsyncWaiter() : notified_(false), count_(0), lock_(), cond_var_() {}
-
   /**
    * @brief WaitFor
    * Waits for specified number of notifications but not longer
@@ -81,6 +78,10 @@ class TestAsyncWaiter {
     return true;
   }
 
+  static std::shared_ptr<TestAsyncWaiter> createInstance() {
+    return std::shared_ptr<TestAsyncWaiter>(new TestAsyncWaiter());
+  }
+
   /**
    * @brief Notify
    * Notifies async waiter
@@ -93,6 +94,8 @@ class TestAsyncWaiter {
   }
 
  private:
+  TestAsyncWaiter() : notified_(false), count_(0), lock_(), cond_var_() {}
+
   bool notified_;
   uint32_t count_;
   sync_primitives::Lock lock_;

--- a/src/components/include/test/utils/test_async_waiter.h
+++ b/src/components/include/test/utils/test_async_waiter.h
@@ -48,11 +48,12 @@ namespace test {
  *
  * Usage example:
  * TEST() {
- *   TestAsyncWaiter waiter;
+ *   std::shared_ptr<TestAsyncWaiter> waiter =
+ *     std::make_shared<TestAsyncWaiter>();
  *   EXPECT_CALL(mock, InterestingCall())
  *       .Times(n)
- *       .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
- *   EXPECT_TRUE(waiter.WaitFor(n, 1000));
+ *       .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
+ *   EXPECT_TRUE(waiter->WaitFor(n, 1000));
  * }
  */
 class TestAsyncWaiter {

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -546,7 +546,7 @@ TEST_F(ProtocolHandlerImplTest,
   const int call_times = 5;
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   ServiceType service_type;
   // Expect verification of allowed transport
@@ -638,7 +638,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverReject) {
   const bool callback_protection_flag = PROTECTION_OFF;
 #endif  // ENABLE_SECURITY
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   ServiceType service_type;
   // Expect verification of allowed transport
@@ -721,7 +721,7 @@ TEST_F(ProtocolHandlerImplTest,
   AddConnection();
   const ServiceType start_service = kRpc;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -783,7 +783,7 @@ TEST_F(ProtocolHandlerImplTest,
 TEST_F(ProtocolHandlerImplTest, StartSession_Protected_SessionObserverAccept) {
   SetProtocolVersion2();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -851,7 +851,7 @@ TEST_F(ProtocolHandlerImplTest,
                                                   std::string("BTMAC")),
                                        connection_id2);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   // Expect verification of allowed transport
@@ -1024,7 +1024,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Audio_RejectByTransportType) {
   AddConnection();
   const ServiceType start_service = kAudio;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -1066,7 +1066,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Video_RejectByTransportType) {
   AddConnection();
   const ServiceType start_service = kMobileNav;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -1106,7 +1106,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_Video_RejectByTransportType) {
  * ProtocolHandler shall send NAck on session_observer rejection
  */
 TEST_F(ProtocolHandlerImplTest, EndSession_SessionObserverReject) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -1146,7 +1146,7 @@ TEST_F(ProtocolHandlerImplTest, EndSession_SessionObserverReject) {
  * ProtocolHandler shall send NAck on wrong hash code
  */
 TEST_F(ProtocolHandlerImplTest, EndSession_Success) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -1182,7 +1182,7 @@ TEST_F(ProtocolHandlerImplTest, EndSession_Success) {
 #ifdef ENABLE_SECURITY
 TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtocoloV1) {
   using namespace protocol_handler;
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -1260,7 +1260,7 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionUnprotected) {
   AddSecurityManager();
   const ServiceType start_service = kRpc;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -1322,7 +1322,7 @@ TEST_F(ProtocolHandlerImplTest, SecurityEnable_StartSessionProtected_Fail) {
   AddSecurityManager();
   const ServiceType start_service = kRpc;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   protocol_handler::SessionContext context = GetSessionContext(connection_id,
@@ -1400,7 +1400,7 @@ TEST_F(ProtocolHandlerImplTest,
   AddSecurityManager();
   const ServiceType start_service = kRpc;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -1483,7 +1483,7 @@ TEST_F(ProtocolHandlerImplTest,
   AddSecurityManager();
   const ServiceType start_service = kRpc;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   protocol_handler::SessionContext context = GetSessionContext(connection_id,
                                                                NEW_SESSION_ID,
@@ -1588,7 +1588,7 @@ TEST_F(ProtocolHandlerImplTest,
   ON_CALL(protocol_handler_settings_mock, force_protected_service())
       .WillByDefault(ReturnRefOfCopy(services));
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -1701,7 +1701,7 @@ TEST_F(
   ON_CALL(protocol_handler_settings_mock, force_protected_service())
       .WillByDefault(ReturnRefOfCopy(services));
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -1812,7 +1812,7 @@ TEST_F(ProtocolHandlerImplTest,
   ON_CALL(protocol_handler_settings_mock, force_protected_service())
       .WillByDefault(ReturnRefOfCopy(services));
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect verification of allowed transport
   EXPECT_CALL(session_observer_mock,
@@ -1939,7 +1939,7 @@ void ProtocolHandlerImplTest::VerifySecondaryTransportParamsInStartSessionAck(
       .WillRepeatedly(Return(maximum_rpc_payload_size));
   InitProtocolHandlerImpl(0u, 0u);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 5;
@@ -2075,7 +2075,7 @@ void ProtocolHandlerImplTest::VerifyCloudAppParamsInStartSessionAck(
       .WillRepeatedly(Return(maximum_rpc_payload_size));
   InitProtocolHandlerImpl(0u, 0u);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 5;
@@ -2543,7 +2543,7 @@ TEST_F(
 // Secondary transport param should not be included for apps with v5.0.0
 TEST_F(ProtocolHandlerImplTest,
        StartSessionAck_Unprotected_NoSecondaryTransportParamsForV5) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 5;
@@ -2715,7 +2715,7 @@ TEST_F(ProtocolHandlerImplTest, StartSessionAck_CloudAppAuthTokenAvailable) {
 
 TEST_F(ProtocolHandlerImplTest,
        TransportEventUpdate_afterVersionNegotiation_TCPEnabled) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 5;
@@ -2838,7 +2838,7 @@ TEST_F(ProtocolHandlerImplTest,
 
 TEST_F(ProtocolHandlerImplTest,
        TransportEventUpdate_afterVersionNegotiation_TCPDisabled) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 5;
@@ -2962,7 +2962,7 @@ TEST_F(ProtocolHandlerImplTest,
   using connection_handler::SessionConnectionMap;
   using connection_handler::SessionTransports;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   char tcp_address[] = "172.16.2.3";
@@ -3029,7 +3029,7 @@ TEST_F(ProtocolHandlerImplTest,
   using connection_handler::SessionConnectionMap;
   using connection_handler::SessionTransports;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   char tcp_address[] = "172.16.2.3";
@@ -3105,7 +3105,7 @@ TEST_F(ProtocolHandlerImplTest,
 TEST_F(ProtocolHandlerImplTest, RegisterSecondaryTransport_SUCCESS) {
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   transport_manager::ConnectionUID primary_connection_id = 123;
@@ -3140,7 +3140,7 @@ TEST_F(ProtocolHandlerImplTest, RegisterSecondaryTransport_SUCCESS) {
 TEST_F(ProtocolHandlerImplTest, RegisterSecondaryTransport_FAILURE) {
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   transport_manager::ConnectionUID primary_connection_id = 123;
@@ -3179,7 +3179,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification) {
   InitProtocolHandlerImpl(period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3224,7 +3224,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_ThresholdValue) {
   InitProtocolHandlerImpl(period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3268,7 +3268,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_VideoFrameSkip) {
   InitProtocolHandlerImpl(period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3304,7 +3304,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_AudioFrameSkip) {
   InitProtocolHandlerImpl(period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3340,7 +3340,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerificationDisable) {
   InitProtocolHandlerImpl(period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3376,7 +3376,7 @@ TEST_F(ProtocolHandlerImplTest, MalformedVerificationDisable) {
   InitProtocolHandlerImpl(0u, 0u, false, period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3408,7 +3408,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_MalformedLimitVerification) {
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3463,7 +3463,7 @@ TEST_F(ProtocolHandlerImplTest,
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3542,7 +3542,7 @@ TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_MalformedOnly) {
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3602,7 +3602,7 @@ TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_NullTimePeriod) {
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3635,7 +3635,7 @@ TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_NullCount) {
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
   AddConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3728,7 +3728,7 @@ TEST_F(ProtocolHandlerImplTest,
 TEST_F(ProtocolHandlerImplTest,
        DISABLED_SendEndServicePrivate_EndSession_MessageSent) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3755,7 +3755,7 @@ TEST_F(ProtocolHandlerImplTest,
 TEST_F(ProtocolHandlerImplTest,
        SendEndServicePrivate_ServiceTypeControl_MessageSent) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3794,7 +3794,7 @@ TEST_F(ProtocolHandlerImplTest, SendHeartBeat_NoConnection_NotSent) {
 
 TEST_F(ProtocolHandlerImplTest, SendHeartBeat_Successful) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3819,7 +3819,7 @@ TEST_F(ProtocolHandlerImplTest, SendHeartBeat_Successful) {
 
 TEST_F(ProtocolHandlerImplTest, SendHeartBeatAck_Successful) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3849,7 +3849,7 @@ TEST_F(ProtocolHandlerImplTest, SendHeartBeatAck_Successful) {
 TEST_F(ProtocolHandlerImplTest,
        SendHeartBeatAck_ProtocolVersionUsedFail_Cancelled) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3873,7 +3873,7 @@ TEST_F(ProtocolHandlerImplTest,
 TEST_F(ProtocolHandlerImplTest,
        DISABLED_SendHeartBeatAck_WrongProtocolVersion_NotSent) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3907,7 +3907,7 @@ TEST_F(ProtocolHandlerImplTest,
 TEST_F(ProtocolHandlerImplTest,
        SendMessageToMobileApp_SendSingleControlMessage) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3948,7 +3948,7 @@ TEST_F(ProtocolHandlerImplTest,
 TEST_F(ProtocolHandlerImplTest,
        SendMessageToMobileApp_SendSingleNonControlMessage) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -3993,7 +3993,7 @@ TEST_F(ProtocolHandlerImplTest,
 
 TEST_F(ProtocolHandlerImplTest, SendMessageToMobileApp_SendMultiframeMessage) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4052,7 +4052,7 @@ TEST_F(ProtocolHandlerImplTest, SendMessageToMobileApp_SendMultiframeMessage) {
 TEST_F(ProtocolHandlerImplTest,
        SendMessageToMobileApp_NullMessagePointer_Cancelled) {
   // Arrange
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4465,7 +4465,7 @@ TEST_F(ProtocolHandlerImplTest, GetHashId_ProtocolVersion5_ValidData) {
 }
 
 TEST_F(ProtocolHandlerImplTest, SetHashId_CorrectHashId) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 3;
@@ -4508,7 +4508,7 @@ TEST_F(ProtocolHandlerImplTest, SetHashId_CorrectHashId) {
 }
 
 TEST_F(ProtocolHandlerImplTest, SetHashId_HASH_ID_NOT_SUPPORTED) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 3;
@@ -4543,7 +4543,7 @@ TEST_F(ProtocolHandlerImplTest, SetHashId_HASH_ID_NOT_SUPPORTED) {
 }
 
 TEST_F(ProtocolHandlerImplTest, SetHashId_HASH_ID_WRONG) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   const uint8_t input_protocol_version = 3;
@@ -4580,7 +4580,7 @@ TEST_F(ProtocolHandlerImplTest, SetHashId_HASH_ID_WRONG) {
 
 TEST_F(ProtocolHandlerImplTest, PopValidAndExpiredMultiframes) {
   using namespace protocol_handler;
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4624,7 +4624,7 @@ TEST_F(ProtocolHandlerImplTest, PopValidAndExpiredMultiframes) {
 }
 
 TEST_F(ProtocolHandlerImplTest, HandleFromMobile_FrameTypeSingle_Handled) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4651,7 +4651,7 @@ TEST_F(ProtocolHandlerImplTest, HandleFromMobile_FrameTypeSingle_Handled) {
 
 #ifdef ENABLE_SECURITY
 TEST_F(ProtocolHandlerImplTest, EncryptFrame_NoSecurityManagerSet_Cancelled) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4682,7 +4682,7 @@ TEST_F(ProtocolHandlerImplTest, EncryptFrame_NoSecurityManagerSet_Cancelled) {
 
 TEST_F(ProtocolHandlerImplTest,
        EncryptFrame_ControlFrameType_ContinueUnencrypted) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4713,7 +4713,7 @@ TEST_F(ProtocolHandlerImplTest,
 
 TEST_F(ProtocolHandlerImplTest,
        EncryptFrame_SSLContextInitNotCompleted_ContinueUnencrypted) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4752,7 +4752,7 @@ TEST_F(ProtocolHandlerImplTest,
 
 TEST_F(ProtocolHandlerImplTest,
        EncryptFrame_EncryptFailed_ContinueUnencrypted) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4805,7 +4805,7 @@ TEST_F(ProtocolHandlerImplTest,
 
 TEST_F(ProtocolHandlerImplTest,
        EncryptFrame_EncryptSucceeded_ContinueEncrypted) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4854,7 +4854,7 @@ TEST_F(ProtocolHandlerImplTest,
 }
 
 TEST_F(ProtocolHandlerImplTest, DecryptFrame_NoSecurityManager_Cancelled) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4886,7 +4886,7 @@ TEST_F(ProtocolHandlerImplTest, DecryptFrame_NoSecurityManager_Cancelled) {
 
 TEST_F(ProtocolHandlerImplTest,
        DISABLED_DecryptFrame_ProtectionFlagOff_ContinueUndecrypted) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4920,7 +4920,7 @@ TEST_F(ProtocolHandlerImplTest,
 
 TEST_F(ProtocolHandlerImplTest,
        DISABLED_DecryptFrame_FrameTypeControl_ContinueUndecrypted) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4957,7 +4957,7 @@ TEST_F(ProtocolHandlerImplTest,
 
 TEST_F(ProtocolHandlerImplTest,
        DecryptFrame_SSLContextInitNotCompleted_Cancelled) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -4991,7 +4991,7 @@ TEST_F(ProtocolHandlerImplTest,
 }
 
 TEST_F(ProtocolHandlerImplTest, DecryptFrame_DecryptFailed_Cancelled) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -5035,7 +5035,7 @@ TEST_F(ProtocolHandlerImplTest, DecryptFrame_DecryptFailed_Cancelled) {
 
 TEST_F(ProtocolHandlerImplTest,
        DecryptFrame_DecryptSucceeded_ContinueDecrypted) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -5102,7 +5102,7 @@ TEST_F(ProtocolHandlerImplTest, SendFrame_EncryptFailed_FAIL) {
 #endif  // ENABLE_SECURITY
 
 TEST_F(ProtocolHandlerImplTest, SendServiceDataAck_PreVersion5) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -5129,7 +5129,7 @@ TEST_F(ProtocolHandlerImplTest, SendServiceDataAck_PreVersion5) {
 }
 
 TEST_F(ProtocolHandlerImplTest, SendServiceDataAck_AfterVersion5) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
@@ -5242,7 +5242,7 @@ TEST_F(ProtocolHandlerImplTest, StartSession_NACKReason_SessionObserverReject) {
       .WillRepeatedly(ReturnNull());
 #endif  // ENABLE_SECURITY
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   ServiceType service_type;
   // Expect verification of allowed transport
@@ -5333,7 +5333,7 @@ TEST_F(ProtocolHandlerImplTest,
   const utils::SemanticVersion min_reason_param_version(5, 3, 0);
   std::string err_reason =
       "Wrong hash_id for session " + std::to_string(session_id);
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);

--- a/src/components/protocol_handler/test/protocol_handler_tm_test.cc
+++ b/src/components/protocol_handler/test/protocol_handler_tm_test.cc
@@ -240,6 +240,7 @@ class ProtocolHandlerImplTest : public ::testing::Test {
     const_cast<protocol_handler::impl::ToMobileQueue&>(
         protocol_handler_impl->get_to_mobile_queue())
         .WaitDumpQueue();
+    protocol_handler_impl->Stop();
   }
 
   // Emulate connection establish
@@ -3173,7 +3174,7 @@ TEST_F(ProtocolHandlerImplTest, RegisterSecondaryTransport_FAILURE) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -3218,7 +3219,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_ThresholdValue) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification_ThresholdValue) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -3262,7 +3263,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_ThresholdValue) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_VideoFrameSkip) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification_VideoFrameSkip) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -3298,7 +3299,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_VideoFrameSkip) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_AudioFrameSkip) {
+TEST_F(ProtocolHandlerImplTest, FloodVerification_AudioFrameSkip) {
   const size_t period_msec = 10000;
   const size_t max_messages = 1000;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -3334,7 +3335,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerification_AudioFrameSkip) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest, DISABLED_FloodVerificationDisable) {
+TEST_F(ProtocolHandlerImplTest, FloodVerificationDisable) {
   const size_t period_msec = 0;
   const size_t max_messages = 0;
   InitProtocolHandlerImpl(period_msec, max_messages);
@@ -3402,7 +3403,7 @@ TEST_F(ProtocolHandlerImplTest, MalformedVerificationDisable) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest, DISABLED_MalformedLimitVerification) {
+TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification) {
   const size_t period_msec = 10000;
   const size_t max_messages = 100;
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
@@ -3456,8 +3457,7 @@ TEST_F(ProtocolHandlerImplTest, DISABLED_MalformedLimitVerification) {
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest,
-       DISABLED_MalformedLimitVerification_MalformedStock) {
+TEST_F(ProtocolHandlerImplTest, MalformedLimitVerification_MalformedStock) {
   const size_t period_msec = 10000;
   const size_t max_messages = 100;
   InitProtocolHandlerImpl(0u, 0u, true, period_msec, max_messages);
@@ -3725,8 +3725,7 @@ TEST_F(ProtocolHandlerImplTest,
   protocol_handler_impl->SendEndSession(connection_id, session_id);
 }
 
-TEST_F(ProtocolHandlerImplTest,
-       DISABLED_SendEndServicePrivate_EndSession_MessageSent) {
+TEST_F(ProtocolHandlerImplTest, SendEndServicePrivate_EndSession_MessageSent) {
   // Arrange
   auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
@@ -3870,8 +3869,7 @@ TEST_F(ProtocolHandlerImplTest,
   EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 
-TEST_F(ProtocolHandlerImplTest,
-       DISABLED_SendHeartBeatAck_WrongProtocolVersion_NotSent) {
+TEST_F(ProtocolHandlerImplTest, SendHeartBeatAck_WrongProtocolVersion_NotSent) {
   // Arrange
   auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
@@ -4885,28 +4883,29 @@ TEST_F(ProtocolHandlerImplTest, DecryptFrame_NoSecurityManager_Cancelled) {
 }
 
 TEST_F(ProtocolHandlerImplTest,
-       DISABLED_DecryptFrame_ProtectionFlagOff_ContinueUndecrypted) {
+       DecryptFrame_ProtectionFlagOff_ContinueUndecrypted) {
   auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 
   AddSession(waiter, times);
-
-  const uint8_t data_size = 0u;
+  const uint8_t data_size = 1u;
+  const uint8_t data_value = 7u;
   ProtocolFramePtr frame_ptr =
       std::make_shared<ProtocolPacket>(connection_id,
                                        PROTOCOL_VERSION_3,
                                        PROTECTION_OFF,
-                                       FRAME_TYPE_FIRST,
+                                       FRAME_TYPE_SINGLE,
                                        kAudio,
-                                       FRAME_DATA_FIRST,
+                                       FRAME_DATA_SINGLE,
                                        session_id,
                                        data_size,
                                        message_id,
-                                       null_data_);
+                                       &data_value);
   EXPECT_CALL(ssl_context_mock, Decrypt(_, _, _, _)).Times(0);
 
   protocol_handler_impl->SetTelemetryObserver(&telemetry_observer_mock);
   EXPECT_CALL(telemetry_observer_mock, StartMessageProcess(message_id, _));
+  EXPECT_CALL(telemetry_observer_mock, EndMessageProcess(_));
 
   connection_handler::SessionTransports st;
   st.primary_transport = connection_id;
@@ -4919,7 +4918,7 @@ TEST_F(ProtocolHandlerImplTest,
 }
 
 TEST_F(ProtocolHandlerImplTest,
-       DISABLED_DecryptFrame_FrameTypeControl_ContinueUndecrypted) {
+       DecryptFrame_FrameTypeControl_ContinueUndecrypted) {
   auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
 

--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -284,7 +284,7 @@ TEST_F(SecurityManagerTest, SecurityManager_NULLCryptoManager) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _));
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
@@ -377,7 +377,7 @@ TEST_F(SecurityManagerTest, GetInvalidQueryId) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
       .WillOnce(NotifyTestAsyncWaiter(waiter));
@@ -577,7 +577,7 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_WrongDataSize) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _));
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
@@ -607,7 +607,7 @@ TEST_F(SecurityManagerTest, DISABLED_ProcessHandshakeData_ServiceNotProtected) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
       .WillOnce(NotifyTestAsyncWaiter(waiter));
@@ -658,7 +658,7 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_InvalidData) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
       .Times(handshake_emulates)
@@ -740,7 +740,7 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_Answer) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
       .Times(handshake_emulates)
@@ -813,7 +813,7 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_HandshakeFinished) {
   // Count handshake calls
   const int handshake_emulates = 6;
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   uint32_t times = 0;
   // Expect no errors
   // Expect notifying listeners (success)

--- a/src/components/security_manager/test/security_manager_test.cc
+++ b/src/components/security_manager/test/security_manager_test.cc
@@ -284,7 +284,7 @@ TEST_F(SecurityManagerTest, SecurityManager_NULLCryptoManager) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _));
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
@@ -295,14 +295,14 @@ TEST_F(SecurityManagerTest, SecurityManager_NULLCryptoManager) {
                   InternalErrorWithErrId(SecurityManager::ERROR_NOT_SUPPORTED),
                   false,
                   kIsFinal))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   const SecurityQuery::QueryHeader header(SecurityQuery::REQUEST,
                                           // It could be any query id
                                           SecurityQuery::INVALID_QUERY_ID);
   const uint8_t data = 0;
   EmulateMobileMessage(header, &data, 1);
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 /*
  * Shall skip all OnMobileMessageSent
@@ -377,14 +377,14 @@ TEST_F(SecurityManagerTest, GetInvalidQueryId) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times++;
 
   // Expect InternalError with ERROR_ID
@@ -394,14 +394,14 @@ TEST_F(SecurityManagerTest, GetInvalidQueryId) {
           InternalErrorWithErrId(SecurityManager::ERROR_INVALID_QUERY_ID),
           false,
           kIsFinal))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   const SecurityQuery::QueryHeader header(SecurityQuery::REQUEST,
                                           SecurityQuery::INVALID_QUERY_ID);
   const uint8_t data = 0;
   EmulateMobileMessage(header, &data, 1);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 }
 /*
  * Shall send Internall Error on call
@@ -577,7 +577,7 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_WrongDataSize) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _));
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
@@ -590,11 +590,11 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_WrongDataSize) {
           InternalErrorWithErrId(SecurityManager::ERROR_INVALID_QUERY_SIZE),
           false,
           kIsFinal))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   EmulateMobileMessageHandshake(NULL, 0);
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 /*
  * Shall send InternallError on
@@ -607,14 +607,14 @@ TEST_F(SecurityManagerTest, DISABLED_ProcessHandshakeData_ServiceNotProtected) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times++;
   EXPECT_CALL(
       mock_protocol_handler,
@@ -622,24 +622,24 @@ TEST_F(SecurityManagerTest, DISABLED_ProcessHandshakeData_ServiceNotProtected) {
           InternalErrorWithErrId(SecurityManager::ERROR_SERVICE_NOT_PROTECTED),
           false,
           kIsFinal))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   times++;
 
   // Expect notifying listeners (unsuccess)
   EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(kKey, SSLContext::Handshake_Result_Fail))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times++;
 
   // Emulate SessionObserver result
   EXPECT_CALL(mock_session_observer, GetSSLContext(kKey, kControl))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), ReturnNull()));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), ReturnNull()));
   times++;
 
   const uint8_t data[] = {0x1, 0x2};
   EmulateMobileMessageHandshake(data, sizeof(data) / sizeof(data[0]));
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 
   // Listener was destroyed after OnHandshakeDone call
   mock_sm_listener.release();
@@ -658,16 +658,16 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_InvalidData) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
       .Times(handshake_emulates)
-      .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
+      .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
   times += handshake_emulates;
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
       .Times(handshake_emulates)
-      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times += handshake_emulates;
 
   // Expect InternalError with ERROR_ID
@@ -678,12 +678,12 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_InvalidData) {
           false,
           kIsFinal))
       .Times(handshake_emulates)
-      .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
+      .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
   times += handshake_emulates;
   // Expect notifying listeners (unsuccess)
   EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(kKey, SSLContext::Handshake_Result_Fail))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times++;
 
   // Emulate SessionObserver and CryptoManager result
@@ -700,19 +700,19 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_InvalidData) {
                       _))
       .WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                       SetArgPointee<3>(handshake_data_out_size),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_AbnormalFail)))
       .WillOnce(DoAll(SetArgPointee<2>((uint8_t*)NULL),
                       SetArgPointee<3>(handshake_data_out_size),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_AbnormalFail)))
       .WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                       SetArgPointee<3>(0),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_AbnormalFail)))
       .WillOnce(DoAll(SetArgPointee<2>((uint8_t*)NULL),
                       SetArgPointee<3>(0),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_AbnormalFail)));
   times += 4;  // matches to each single call above
 
@@ -723,7 +723,7 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_InvalidData) {
   EmulateMobileMessageHandshake(
       handshake_data, handshake_data_size, handshake_emulates);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 
   // Listener was destroyed after OnHandshakeDone call
   mock_sm_listener.release();
@@ -740,16 +740,16 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_Answer) {
   uint32_t connection_id = 0;
   uint8_t session_id = 0;
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   EXPECT_CALL(mock_session_observer, PairFromKey(kKey, _, _))
       .Times(handshake_emulates)
-      .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
+      .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
   times += handshake_emulates;
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
       .Times(handshake_emulates)
-      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times += handshake_emulates;
 
   // Get size of raw message after
@@ -758,23 +758,23 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_Answer) {
               SendMessageToMobileApp(
                   RawMessageEqSize(raw_message_size), false, kIsFinal))
       .Times(handshake_emulates)
-      .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
+      .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
   times += handshake_emulates;
 
   // Expect notifying listeners (unsuccess)
   EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(kKey, SSLContext::Handshake_Result_Fail))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times++;
 
   // Emulate SessionObserver and CryptoManager result
   EXPECT_CALL(mock_ssl_context_exists, IsInitCompleted())
       .Times(handshake_emulates)
-      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(&waiter), Return(false)));
+      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(waiter), Return(false)));
   times += handshake_emulates;
   EXPECT_CALL(mock_session_observer, GetSSLContext(kKey, kControl))
       .Times(handshake_emulates)
-      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(&waiter),
+      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(waiter),
                             Return(&mock_ssl_context_exists)));
   times += handshake_emulates;
 
@@ -787,18 +787,18 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_Answer) {
                       _))
       .WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                       SetArgPointee<3>(handshake_data_out_size),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_Success)))
       .WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                       SetArgPointee<3>(handshake_data_out_size),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_Fail)));
   times += 2;  // matches to each single call above
 
   EmulateMobileMessageHandshake(
       handshake_data, handshake_data_size, handshake_emulates);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 
   // Listener was destroyed after OnHandshakeDone call
   mock_sm_listener.release();
@@ -813,24 +813,24 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_HandshakeFinished) {
   // Count handshake calls
   const int handshake_emulates = 6;
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   uint32_t times = 0;
   // Expect no errors
   // Expect notifying listeners (success)
   EXPECT_CALL(*mock_sm_listener,
               OnHandshakeDone(kKey, SSLContext::Handshake_Result_Success))
-      .WillOnce(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillOnce(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times++;
 
   // Emulate SessionObserver and CryptoManager result
   EXPECT_CALL(mock_session_observer, GetSSLContext(kKey, kControl))
       .Times(handshake_emulates)
-      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(&waiter),
+      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(waiter),
                             Return(&mock_ssl_context_exists)));
   times += handshake_emulates;
   EXPECT_CALL(mock_ssl_context_exists, IsInitCompleted())
       .Times(handshake_emulates)
-      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times += handshake_emulates;
 
   EXPECT_CALL(
@@ -843,31 +843,31 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_HandshakeFinished) {
       // two states with correct out data
       WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                      SetArgPointee<3>(handshake_data_out_size),
-                     NotifyTestAsyncWaiter(&waiter),
+                     NotifyTestAsyncWaiter(waiter),
                      Return(SSLContext::Handshake_Result_Success)))
       .WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                       SetArgPointee<3>(handshake_data_out_size),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_Fail)))
       .
       // two states with with null pointer data
       WillOnce(DoAll(SetArgPointee<2>((uint8_t*)NULL),
                      SetArgPointee<3>(handshake_data_out_size),
-                     NotifyTestAsyncWaiter(&waiter),
+                     NotifyTestAsyncWaiter(waiter),
                      Return(SSLContext::Handshake_Result_Success)))
       .WillOnce(DoAll(SetArgPointee<2>((uint8_t*)NULL),
                       SetArgPointee<3>(handshake_data_out_size),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_Fail)))
       .
       // two states with with null data size
       WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                      SetArgPointee<3>(0),
-                     NotifyTestAsyncWaiter(&waiter),
+                     NotifyTestAsyncWaiter(waiter),
                      Return(SSLContext::Handshake_Result_Success)))
       .WillOnce(DoAll(SetArgPointee<2>(handshake_data_out_pointer),
                       SetArgPointee<3>(0),
-                      NotifyTestAsyncWaiter(&waiter),
+                      NotifyTestAsyncWaiter(waiter),
                       Return(SSLContext::Handshake_Result_Success)));
   times += 6;  // matches to each single call above
 
@@ -880,19 +880,19 @@ TEST_F(SecurityManagerTest, ProcessHandshakeData_HandshakeFinished) {
   EXPECT_CALL(mock_session_observer,
               ProtocolVersionUsed(connection_id, session_id, An<uint8_t&>()))
       .Times(2)
-      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(&waiter), Return(true)));
+      .WillRepeatedly(DoAll(NotifyTestAsyncWaiter(waiter), Return(true)));
   times += 2;  // matches to the number above
 
   EXPECT_CALL(mock_protocol_handler, SendMessageToMobileApp(_, false, kIsFinal))
       .Times(2)
-      .WillRepeatedly(NotifyTestAsyncWaiter(&waiter));
+      .WillRepeatedly(NotifyTestAsyncWaiter(waiter));
   times += 2;  // matches to the number above
 
   // Expect NO InternalError with ERROR_ID
   EmulateMobileMessageHandshake(
       handshake_data, handshake_data_size, handshake_emulates);
 
-  EXPECT_TRUE(waiter.WaitFor(times, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(times, kAsyncExpectationsTimeout));
 
   // Listener was destroyed after OnHandshakeDone call
   mock_sm_listener.release();

--- a/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
+++ b/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
@@ -119,10 +119,10 @@ TEST_F(NetworkInterfaceListenerTest, Start_success) {
 
   // after stated, it is expected that the listener notifies current IP address
   // (if it's available)
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(mock_tcp_client_listener_,
               OnIPAddressUpdated(entries[0].ipv4_address, ""))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   EXPECT_TRUE(interface_listener_impl_->Start());
 
@@ -131,7 +131,7 @@ TEST_F(NetworkInterfaceListenerTest, Start_success) {
 
   EXPECT_TRUE(interface_listener_impl_->GetThread()->IsRunning());
 
-  EXPECT_TRUE(waiter.WaitFor(1, kStartNotificationTimeoutMsec));
+  EXPECT_TRUE(waiter->WaitFor(1, kStartNotificationTimeoutMsec));
 
   Deinit();
 }

--- a/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
+++ b/src/components/transport_manager/test/platform_specific/linux/linux_network_interface_listener_test.cc
@@ -119,7 +119,7 @@ TEST_F(NetworkInterfaceListenerTest, Start_success) {
 
   // after stated, it is expected that the listener notifies current IP address
   // (if it's available)
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(mock_tcp_client_listener_,
               OnIPAddressUpdated(entries[0].ipv4_address, ""))
       .WillOnce(NotifyTestAsyncWaiter(waiter));

--- a/src/components/transport_manager/test/tcp_client_listener_test.cc
+++ b/src/components/transport_manager/test/tcp_client_listener_test.cc
@@ -250,7 +250,7 @@ TEST_P(TcpClientListenerTest, ClientConnection) {
   int s = socket(AF_INET, SOCK_STREAM, 0);
   EXPECT_TRUE(0 <= s);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
 
   // controller should be notified of AddDevice event
   DeviceSptr mock_device = std::make_shared<MockTCPDevice>(
@@ -258,7 +258,7 @@ TEST_P(TcpClientListenerTest, ClientConnection) {
   EXPECT_CALL(adapter_controller_mock_, AddDevice(_))
       .WillOnce(Return(mock_device));
   EXPECT_CALL(adapter_controller_mock_, ConnectionCreated(_, _, _))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   // adapter_controller_mock_ may also receive ConnectDone() and
   // ConnectionFinished() from ThreadedSocketConnection. Ignore them as hey are
@@ -273,7 +273,7 @@ TEST_P(TcpClientListenerTest, ClientConnection) {
                     client_addr_len));
 
   // since the connection is handled on another thread, wait for some time
-  EXPECT_TRUE(waiter.WaitFor(1, kConnectionCreatedTimeoutMsec));
+  EXPECT_TRUE(waiter->WaitFor(1, kConnectionCreatedTimeoutMsec));
 
   close(s);
 

--- a/src/components/transport_manager/test/tcp_client_listener_test.cc
+++ b/src/components/transport_manager/test/tcp_client_listener_test.cc
@@ -250,7 +250,7 @@ TEST_P(TcpClientListenerTest, ClientConnection) {
   int s = socket(AF_INET, SOCK_STREAM, 0);
   EXPECT_TRUE(0 <= s);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
 
   // controller should be notified of AddDevice event
   DeviceSptr mock_device = std::make_shared<MockTCPDevice>(

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -555,11 +555,11 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice) {
   // Arrange
   HandleConnection();
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
-          DoAll(NotifyTestAsyncWaiter(&waiter), Return(TransportAdapter::OK)));
+          DoAll(NotifyTestAsyncWaiter(waiter), Return(TransportAdapter::OK)));
 
 #ifdef TELEMETRY_MONITOR
   EXPECT_CALL(mock_metric_observer_, StartRawMsg(test_message_.get()));
@@ -567,7 +567,7 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice) {
 
   EXPECT_EQ(E_SUCCESS, tm_.SendMessageToDevice(test_message_));
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, SendMessageToDevice_SendingFailed) {
@@ -578,30 +578,30 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice_SendingFailed) {
   EXPECT_CALL(mock_metric_observer_, StartRawMsg(_));
 #endif  // TELEMETRY_MONITOR
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(Return(TransportAdapter::FAIL));
 
   EXPECT_CALL(*tm_listener_, OnTMMessageSendFailed(_, test_message_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   EXPECT_EQ(E_SUCCESS, tm_.SendMessageToDevice(test_message_));
 #ifdef TELEMETRY_MONITOR
   EXPECT_CALL(mock_metric_observer_, StopRawMsg(_)).Times(0);
 #endif  // TELEMETRY_MONITOR
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, SendMessageToDevice_StartTimeObserver) {
   // Arrange
   HandleConnection();
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
-          DoAll(NotifyTestAsyncWaiter(&waiter), Return(TransportAdapter::OK)));
+          DoAll(NotifyTestAsyncWaiter(waiter), Return(TransportAdapter::OK)));
 
 #ifdef TELEMETRY_MONITOR
   EXPECT_CALL(mock_metric_observer_, StartRawMsg(_));
@@ -609,18 +609,18 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice_StartTimeObserver) {
 
   EXPECT_EQ(E_SUCCESS, tm_.SendMessageToDevice(test_message_));
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, SendMessageToDevice_SendDone) {
   // Arrange
   HandleConnection();
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
-          DoAll(NotifyTestAsyncWaiter(&waiter), Return(TransportAdapter::OK)));
+          DoAll(NotifyTestAsyncWaiter(waiter), Return(TransportAdapter::OK)));
 
 #ifdef TELEMETRY_MONITOR
   EXPECT_CALL(mock_metric_observer_, StartRawMsg(test_message_.get()));
@@ -630,7 +630,7 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice_SendDone) {
 
   HandleSendDone();
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(
@@ -639,11 +639,11 @@ TEST_F(
   // Arrange
   HandleConnection();
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
-          DoAll(NotifyTestAsyncWaiter(&waiter), Return(TransportAdapter::OK)));
+          DoAll(NotifyTestAsyncWaiter(waiter), Return(TransportAdapter::OK)));
 
 #ifdef TELEMETRY_MONITOR
   EXPECT_CALL(mock_metric_observer_, StartRawMsg(test_message_.get()));
@@ -654,7 +654,7 @@ TEST_F(
 
   HandleSendFailed();
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, RemoveDevice_DeviceWasAdded) {
@@ -749,7 +749,7 @@ TEST_F(TransportManagerImplTest, UpdateDeviceList_RemoveDevice) {
  * Tests which check correct handling and receiving events
  */
 TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceDone) {
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   TransportAdapterEvent test_event(EventTypeEnum::ON_SEARCH_DONE,
                                    mock_adapter_,
                                    mac_address_,
@@ -758,15 +758,15 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceDone) {
                                    error_);
 
   EXPECT_CALL(*tm_listener_, OnScanDevicesFinished())
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   tm_.ReceiveEventFromDevice(test_event);
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceFail) {
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   TransportAdapterEvent test_event(EventTypeEnum::ON_SEARCH_FAIL,
                                    mock_adapter_,
                                    mac_address_,
@@ -775,11 +775,11 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceFail) {
                                    error_);
 
   EXPECT_CALL(*tm_listener_, OnScanDevicesFailed(_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   tm_.ReceiveEventFromDevice(test_event);
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_DeviceListUpdated) {
@@ -793,7 +793,7 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_DeviceListUpdated) {
   std::vector<DeviceInfo> vector_dev_info;
   vector_dev_info.push_back(dev_info_);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(*mock_adapter_, GetDeviceList())
       .Times(AtLeast(1))
       .WillRepeatedly(Return(device_list_));
@@ -805,14 +805,14 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_DeviceListUpdated) {
       .WillRepeatedly(Return(dev_info_.connection_type()));
 
   EXPECT_CALL(*tm_listener_, OnDeviceFound(dev_info_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
   EXPECT_CALL(*tm_listener_, OnDeviceAdded(dev_info_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   tm_.ReceiveEventFromDevice(test_event);
   device_list_.pop_back();
 
-  EXPECT_TRUE(waiter.WaitFor(2, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(2, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, CheckEvents) {
@@ -972,13 +972,13 @@ TEST_F(TransportManagerImplTest, HandleMessage_ConnectionNotExist) {
               SendData(mac_address_, application_id_, test_message_))
       .Times(0);
 
-  TestAsyncWaiter waiter;
+  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
   EXPECT_CALL(*tm_listener_, OnTMMessageSendFailed(_, test_message_))
-      .WillOnce(NotifyTestAsyncWaiter(&waiter));
+      .WillOnce(NotifyTestAsyncWaiter(waiter));
 
   tm_.TestHandle(test_message_);
 
-  EXPECT_TRUE(waiter.WaitFor(1, kAsyncExpectationsTimeout));
+  EXPECT_TRUE(waiter->WaitFor(1, kAsyncExpectationsTimeout));
 }
 
 TEST_F(TransportManagerImplTest, SearchDevices_TMIsNotInitialized) {

--- a/src/components/transport_manager/test/transport_manager_impl_test.cc
+++ b/src/components/transport_manager/test/transport_manager_impl_test.cc
@@ -555,7 +555,7 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice) {
   // Arrange
   HandleConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
@@ -578,7 +578,7 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice_SendingFailed) {
   EXPECT_CALL(mock_metric_observer_, StartRawMsg(_));
 #endif  // TELEMETRY_MONITOR
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(Return(TransportAdapter::FAIL));
@@ -597,7 +597,7 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice_StartTimeObserver) {
   // Arrange
   HandleConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
@@ -616,7 +616,7 @@ TEST_F(TransportManagerImplTest, SendMessageToDevice_SendDone) {
   // Arrange
   HandleConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
@@ -639,7 +639,7 @@ TEST_F(
   // Arrange
   HandleConnection();
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(*mock_adapter_,
               SendData(mac_address_, application_id_, test_message_))
       .WillOnce(
@@ -749,7 +749,7 @@ TEST_F(TransportManagerImplTest, UpdateDeviceList_RemoveDevice) {
  * Tests which check correct handling and receiving events
  */
 TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceDone) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   TransportAdapterEvent test_event(EventTypeEnum::ON_SEARCH_DONE,
                                    mock_adapter_,
                                    mac_address_,
@@ -766,7 +766,7 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceDone) {
 }
 
 TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_OnSearchDeviceFail) {
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   TransportAdapterEvent test_event(EventTypeEnum::ON_SEARCH_FAIL,
                                    mock_adapter_,
                                    mac_address_,
@@ -793,7 +793,7 @@ TEST_F(TransportManagerImplTest, ReceiveEventFromDevice_DeviceListUpdated) {
   std::vector<DeviceInfo> vector_dev_info;
   vector_dev_info.push_back(dev_info_);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(*mock_adapter_, GetDeviceList())
       .Times(AtLeast(1))
       .WillRepeatedly(Return(device_list_));
@@ -972,7 +972,7 @@ TEST_F(TransportManagerImplTest, HandleMessage_ConnectionNotExist) {
               SendData(mac_address_, application_id_, test_message_))
       .Times(0);
 
-  std::shared_ptr<TestAsyncWaiter> waiter = std::make_shared<TestAsyncWaiter>();
+  auto waiter = TestAsyncWaiter::createInstance();
   EXPECT_CALL(*tm_listener_, OnTMMessageSendFailed(_, test_message_))
       .WillOnce(NotifyTestAsyncWaiter(waiter));
 


### PR DESCRIPTION
Was replaced TestAsyncWaiter references with shared_ptr, which 
avoid invalid references to TestAsyncWaiter when it goes out of scope,
which can(sometimes, but not always) lead to hard-to-trace-and-reproduce
segfaults, deadlocks and sigaborts.

Fixes #3405

This PR is **ready** for review.

### Risk
This PR makes **no ** API changes.

### Testing Plan
Unit tests, ATF

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
