### PR TITLE
CCB: Co-Existence: Dummy Icon remains when iOS device is disconnected

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3224,15 +3224,17 @@ void ApplicationManagerImpl::UnregisterApplication(
   ApplicationSharedPtr app_to_remove;
   connection_handler::DeviceHandle handle = 0;
   {
-    sync_primitives::AutoLock lock(applications_list_lock_ptr_);
-    auto it_app = applications_.begin();
-    while (applications_.end() != it_app) {
-      if (app_id == (*it_app)->app_id()) {
-        app_to_remove = *it_app;
-        applications_.erase(it_app++);
-        break;
-      } else {
-        ++it_app;
+    {
+      sync_primitives::AutoLock lock(applications_list_lock_ptr_);
+      auto it_app = applications_.begin();
+      while (applications_.end() != it_app) {
+        if (app_id == (*it_app)->app_id()) {
+          app_to_remove = *it_app;
+          applications_.erase(it_app++);
+          break;
+        } else {
+          ++it_app;
+        }
       }
     }
     if (!app_to_remove) {

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3244,6 +3244,8 @@ void ApplicationManagerImpl::UnregisterApplication(
       return;
     }
 
+    resume_controller().RemoveFromResumption(app_id);
+
     if (is_resuming) {
       resume_controller().SaveApplication(app_to_remove);
     } else {


### PR DESCRIPTION
Added RemoveFromResumption call into the unregister procedure in application_manager_impl.cc

Fixes #3409

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Unit test, ATF

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
