### PR TITLE
Fix streamer adapter queue restart

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -674,6 +674,8 @@ ApplicationSharedPtr ApplicationManagerImpl::RegisterApplication(
       static_cast<protocol_handler::MajorProtocolVersion>(
           message[strings::params][strings::protocol_version].asInt());
   application->set_protocol_version(protocol_version);
+  connection_handler_->BindProtocolVersionWithSession(connection_key,
+                                                      protocol_version);
 
   // Keep HMI add id in case app is present in "waiting for registration" list
   apps_to_register_list_lock_ptr_->Acquire();

--- a/src/components/media_manager/src/media_manager_impl.cc
+++ b/src/components/media_manager/src/media_manager_impl.cc
@@ -336,7 +336,8 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
     auto video_stream = std::dynamic_pointer_cast<StreamerAdapter>(
         streamer_[protocol_handler::ServiceType::kMobileNav]);
 
-    if (audio_stream.use_count() != 0) {
+    if (audio_stream.use_count() != 0 &&
+        "pipe" == settings().audio_server_type()) {
       size_t audio_queue_size = audio_stream->GetMsgQueueSize();
       SDL_LOG_DEBUG("# Messages in audio queue = " << audio_queue_size);
       if (audio_queue_size > 0) {
@@ -344,7 +345,8 @@ void MediaManagerImpl::FramesProcessed(int32_t application_key,
       }
     }
 
-    if (video_stream.use_count() != 0) {
+    if (video_stream.use_count() != 0 &&
+        "pipe" == settings().video_server_type()) {
       size_t video_queue_size = video_stream->GetMsgQueueSize();
       SDL_LOG_DEBUG("# Messages in video queue = " << video_queue_size);
       if (video_queue_size > 0) {

--- a/src/components/media_manager/src/streamer_adapter.cc
+++ b/src/components/media_manager/src/streamer_adapter.cc
@@ -85,8 +85,7 @@ void StreamerAdapter::StopActivity(int32_t application_key) {
   }
 
   DCHECK(streamer_);
-  streamer_->exitThreadMain();
-  messages_.Reset();
+  thread_->Stop(threads::Thread::kThreadStopDelegate);
 
   for (std::set<MediaListenerPtr>::iterator it = media_listeners_.begin();
        media_listeners_.end() != it;
@@ -129,7 +128,12 @@ void StreamerAdapter::Streamer::threadMain() {
     SDL_LOG_ERROR("Unable to connect");
     return;
   }
+
   stop_flag_ = false;
+  if (adapter_->messages_.IsShuttingDown()) {
+    adapter_->messages_.Reset();
+  }
+
   while (!stop_flag_) {
     adapter_->messages_.wait();
     while (!adapter_->messages_.empty()) {


### PR DESCRIPTION
Fixes `https://github.com/smartdevicelink/sdl_core/issues/3603`

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Will be tested manually

### Summary
There was noticed an issue with the streamer thread restart. This issue is happening when streaming activity was stopped and the started again in scope of the same session. In case when `StopActivity()` is called then `StreamerAdapter::Streamer::exitThreadMain` is called on stop which causes `messages_` queue to go to shutdown to avoid new messages be added into the queue.
This also marks the queue as shutting down. After that, when the same session adapter `StartActivity()` called and thread restarted, messages queue might be still shutting down.
To avoid that, `Reset()` will be called on thread start in order to reset shutting down flag. Also, `exitThreadMain()` method was replaced with `Stop()` method to properly wait for streaming thread to be completely stopped.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/