### PR TITLE
Add vehicle data params to StartSessionAck

### DIFF
--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -700,6 +700,9 @@ class ApplicationManagerImpl
   void RemoveDevice(
       const connection_handler::DeviceHandle& device_handle) OVERRIDE;
 
+  bool GetProtocolVehicleData(
+      connection_handler::ProtocolVehicleData& data) OVERRIDE;
+
   /**
    * @brief OnDeviceSwitchingStart is invoked on device transport switching
    * start (e.g. from Bluetooth to USB) and creates waiting list of applications
@@ -1144,6 +1147,8 @@ class ApplicationManagerImpl
     return is_stopping_;
   }
 
+  bool WaitForHmiIsReady() OVERRIDE;
+
   /**
    * @brief ProcessReconnection handles reconnection flow for application on
    * transport switch
@@ -1182,6 +1187,11 @@ class ApplicationManagerImpl
       std::function<void(plugin_manager::RPCPlugin&)> functor) OVERRIDE;
 
  private:
+  /**
+   * @brief Sets is_stopping flag to true
+   */
+  void InitiateStopping();
+
   /**
    * @brief Adds application to registered applications list and marks it as
    * registered
@@ -1636,6 +1646,9 @@ class ApplicationManagerImpl
   std::vector<TimerSPtr> end_stream_timer_pool_;
   sync_primitives::Lock close_app_timer_pool_lock_;
   sync_primitives::Lock end_stream_timer_pool_lock_;
+
+  mutable sync_primitives::Lock wait_for_hmi_lock_;
+  sync_primitives::ConditionalVariable wait_for_hmi_condvar_;
 
   StateControllerImpl state_ctrl_;
   std::unique_ptr<app_launch::AppLaunchData> app_launch_dto_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/update_device_list_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/update_device_list_request.h
@@ -46,8 +46,7 @@ namespace commands {
 /**
  * @brief UpdateDeviceListRequest command class
  **/
-class UpdateDeviceListRequest : public app_mngr::commands::RequestToHMI,
-                                public app_mngr::event_engine::EventObserver {
+class UpdateDeviceListRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief UpdateDeviceListRequest class constructor
@@ -70,23 +69,7 @@ class UpdateDeviceListRequest : public app_mngr::commands::RequestToHMI,
    **/
   virtual void Run();
 
-  /**
-   * @brief Interface method that is called whenever new event received
-   * Need to observe OnHMIReady event, to send UpdateDeviceListRequest
-   * when HMI will be ready
-   * @param event The received event
-   */
-  virtual void on_event(const app_mngr::event_engine::Event& event);
-
-  /**
-   * @brief Need to stop execution StopMethod if HMI did not started
-   */
-  virtual bool CleanUp();
-
  private:
-  sync_primitives::Lock wait_hmi_lock;
-  sync_primitives::ConditionalVariable termination_condition_;
-
   DISALLOW_COPY_AND_ASSIGN(UpdateDeviceListRequest);
 };
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/register_app_interface_request.h
@@ -261,12 +261,6 @@ class RegisterAppInterfaceRequest
       const smart_objects::SmartObject& message);
 
   /**
-   * @brief WaitForHMIIsReady blocking function. Waits for HMI be ready for
-   * requests processing
-   */
-  void WaitForHMIIsReady();
-
-  /**
    * @brief FillApplicationParams set app application attributes from the RAI
    * request
    * @param application applicaiton to fill params

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/button_get_capabilities_response.cc
@@ -60,11 +60,10 @@ void ButtonGetCapabilitiesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::Buttons_GetCapabilities);
-
   if (hmi_apis::Common_Result::SUCCESS != code) {
     SDL_LOG_ERROR("Error is returned. Capabilities won't be updated.");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::Buttons_GetCapabilities);
     return;
   }
 
@@ -80,6 +79,9 @@ void ButtonGetCapabilitiesResponse::Run() {
         (*message_)[strings::msg_params]
                    [hmi_response::preset_bank_capabilities]);
   }
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::Buttons_GetCapabilities);
 
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
           hmi_interface::buttons, sections_to_update, message_->getSchema())) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_response.cc
@@ -74,11 +74,12 @@ void GetSystemInfoResponse::Run() {
   policy_handler_.OnGetSystemInfo(
       info.ccpu_version, info.wers_country_code, info.language);
 
-  hmi_capabilities_.OnSoftwareVersionReceived(info.ccpu_version);
   if (!info.hardware_version.empty()) {
     policy_handler_.OnHardwareVersionReceived(info.hardware_version);
     hmi_capabilities_.set_hardware_version(info.hardware_version);
   }
+
+  hmi_capabilities_.OnSoftwareVersionReceived(info.ccpu_version);
 }
 
 const SystemInfo GetSystemInfoResponse::GetSystemInfo() const {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/rc_get_capabilities_response.cc
@@ -58,11 +58,10 @@ void RCGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::RC_GetCapabilities);
-
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::RC_GetCapabilities);
     return;
   }
 
@@ -87,6 +86,9 @@ void RCGetCapabilitiesResponse::Run() {
   }
 
   hmi_capabilities_.set_rc_supported(rc_capability_exists);
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::RC_GetCapabilities);
 
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
           hmi_interface::rc, sections_to_update, message_->getSchema())) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_capabilities_response.cc
@@ -57,11 +57,10 @@ void TTSGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::TTS_GetCapabilities);
-
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::TTS_GetCapabilities);
     return;
   }
 
@@ -79,6 +78,9 @@ void TTSGetCapabilitiesResponse::Run() {
         (*message_)[strings::msg_params]
                    [hmi_response::prerecorded_speech_capabilities]);
   }
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::TTS_GetCapabilities);
 
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
           hmi_interface::tts, sections_to_update, message_->getSchema())) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_language_response.cc
@@ -61,11 +61,10 @@ void TTSGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::TTS_GetLanguage);
-
   if (Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::TTS_GetLanguage);
     return;
   }
 
@@ -78,6 +77,9 @@ void TTSGetLanguageResponse::Run() {
   }
 
   hmi_capabilities_.set_active_tts_language(language);
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::TTS_GetLanguage);
 
   std::vector<std::string> sections_to_update{hmi_response::language};
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/tts_get_supported_languages_response.cc
@@ -61,16 +61,18 @@ void TTSGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::TTS_GetSupportedLanguages);
-
   if (hmi_apis::Common_Result::SUCCESS != code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::TTS_GetSupportedLanguages);
     return;
   }
 
   hmi_capabilities_.set_tts_supported_languages(
       (*message_)[strings::msg_params][hmi_response::languages]);
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::TTS_GetSupportedLanguages);
 
   std::vector<std::string> sections_to_update{hmi_response::languages};
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_capabilities_response.cc
@@ -58,11 +58,10 @@ void UIGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::UI_GetCapabilities);
-
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::UI_GetCapabilities);
     return;
   }
 
@@ -164,6 +163,9 @@ void UIGetCapabilitiesResponse::Run() {
     hmi_capabilities_.set_pcm_stream_capabilities(
         msg_params[strings::pcm_stream_capabilities]);
   }
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::UI_GetCapabilities);
 
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
           hmi_interface::ui, sections_to_update, message_->getSchema())) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_language_response.cc
@@ -61,11 +61,10 @@ void UIGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::UI_GetLanguage);
-
   if (Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::UI_GetLanguage);
     return;
   }
 
@@ -78,6 +77,9 @@ void UIGetLanguageResponse::Run() {
   }
 
   hmi_capabilities_.set_active_ui_language(language);
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::UI_GetLanguage);
 
   std::vector<std::string> sections_to_update{hmi_response::language};
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/ui_get_supported_languages_response.cc
@@ -61,16 +61,18 @@ void UIGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::UI_GetSupportedLanguages);
-
   if (hmi_apis::Common_Result::SUCCESS != code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::UI_GetSupportedLanguages);
     return;
   }
 
   hmi_capabilities_.set_ui_supported_languages(
       (*message_)[strings::msg_params][hmi_response::languages]);
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::UI_GetSupportedLanguages);
 
   std::vector<std::string> sections_to_update{hmi_response::languages};
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/update_device_list_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/update_device_list_request.cc
@@ -53,51 +53,27 @@ UpdateDeviceListRequest::UpdateDeviceListRequest(
                    application_manager,
                    rpc_service,
                    hmi_capabilities,
-                   policy_handle)
-    , EventObserver(application_manager_.event_dispatcher()) {}
+                   policy_handle) {}
 
 UpdateDeviceListRequest::~UpdateDeviceListRequest() {}
 
 void UpdateDeviceListRequest::Run() {
   SDL_LOG_AUTO_TRACE();
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
   // Fix problem with SDL and HMI HTML. This problem is not actual for HMI PASA.
   // Flag conditional compilation for specific customer is used in order to
   // exclude
   // hit code to RTC
-  if (true == application_manager_.get_settings().launch_hmi()) {
-    if (!application_manager_.IsHMICooperating()) {
-      SDL_LOG_INFO("Wait for HMI Cooperation");
-      subscribe_on_event(hmi_apis::FunctionID::BasicCommunication_OnReady);
-      termination_condition_.Wait(auto_lock);
-      SDL_LOG_DEBUG("HMI Cooperation OK");
+  if (application_manager_.get_settings().launch_hmi()) {
+    SDL_LOG_INFO("Wait for HMI Cooperation");
+    if (!application_manager_.WaitForHmiIsReady()) {
+      SDL_LOG_ERROR("HMI is not ready");
+      return;
     }
+
+    SDL_LOG_DEBUG("HMI Cooperation is OK");
   }
 
   SendRequest();
-}
-
-void UpdateDeviceListRequest::on_event(const event_engine::Event& event) {
-  SDL_LOG_AUTO_TRACE();
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
-  switch (event.id()) {
-    case hmi_apis::FunctionID::BasicCommunication_OnReady: {
-      SDL_LOG_INFO("received OnReady");
-      unsubscribe_from_event(hmi_apis::FunctionID::BasicCommunication_OnReady);
-      termination_condition_.Broadcast();
-      break;
-    };
-    default: {
-      SDL_LOG_ERROR("Unknown event " << event.id());
-      break;
-    };
-  }
-}
-
-bool UpdateDeviceListRequest::CleanUp() {
-  sync_primitives::AutoLock auto_lock(wait_hmi_lock);
-  termination_condition_.Broadcast();
-  return true;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_capabilities_response.cc
@@ -57,11 +57,10 @@ void VRGetCapabilitiesResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::VR_GetCapabilities);
-
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::VR_GetCapabilities);
     return;
   }
 
@@ -73,6 +72,9 @@ void VRGetCapabilitiesResponse::Run() {
     sections_to_update.push_back(strings::vr_capabilities);
     hmi_capabilities_.set_vr_capabilities(msg_params[strings::vr_capabilities]);
   }
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::VR_GetCapabilities);
 
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
           hmi_interface::vr, sections_to_update, message_->getSchema())) {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_language_response.cc
@@ -61,11 +61,10 @@ void VRGetLanguageResponse::Run() {
   const Common_Result::eType result_code = static_cast<Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::VR_GetLanguage);
-
   if (Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::VR_GetLanguage);
     return;
   }
 
@@ -78,6 +77,9 @@ void VRGetLanguageResponse::Run() {
   }
 
   hmi_capabilities_.set_active_vr_language(language);
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::VR_GetLanguage);
 
   std::vector<std::string> sections_to_update{hmi_response::language};
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/vr_get_supported_languages_response.cc
@@ -62,20 +62,24 @@ void VRGetSupportedLanguagesResponse::Run() {
       static_cast<hmi_apis::Common_Result::eType>(
           (*message_)[strings::params][hmi_response::code].asInt());
 
+  if (hmi_apis::Common_Result::SUCCESS != code) {
+    SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::VR_GetSupportedLanguages);
+    return;
+  }
+
+  HMICapabilities& hmi_capabilities = hmi_capabilities_;
+  hmi_capabilities.set_vr_supported_languages(
+      (*message_)[strings::msg_params][hmi_response::languages]);
+
   hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
       hmi_apis::FunctionID::VR_GetSupportedLanguages);
 
-  if (hmi_apis::Common_Result::SUCCESS == code) {
-    HMICapabilities& hmi_capabilities = hmi_capabilities_;
-    hmi_capabilities.set_vr_supported_languages(
-        (*message_)[strings::msg_params][hmi_response::languages]);
-
-    std::vector<std::string> sections_to_update{hmi_response::languages};
-    if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
-            hmi_interface::vr, sections_to_update, message_->getSchema())) {
-      SDL_LOG_ERROR(
-          "Failed to save VR.GetSupportedLanguages response to cache");
-    }
+  std::vector<std::string> sections_to_update{hmi_response::languages};
+  if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
+          hmi_interface::vr, sections_to_update, message_->getSchema())) {
+    SDL_LOG_ERROR("Failed to save VR.GetSupportedLanguages response to cache");
   }
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -159,18 +159,6 @@ uint32_t RegisterAppInterfaceRequest::default_timeout() const {
   return 0;
 }
 
-void RegisterAppInterfaceRequest::WaitForHMIIsReady() {
-  while (!application_manager_.IsStopping() &&
-         !application_manager_.IsHMICooperating()) {
-    SDL_LOG_DEBUG("Waiting for the HMI... conn_key="
-                  << connection_key() << ", correlation_id=" << correlation_id()
-                  << ", default_timeout=" << default_timeout()
-                  << ", thread=" << pthread_self());
-    sleep(1);
-    // TODO(DK): timer_->StartWait(1);
-  }
-}
-
 void RegisterAppInterfaceRequest::FillApplicationParams(
     ApplicationSharedPtr application) {
   SDL_LOG_AUTO_TRACE();
@@ -488,10 +476,8 @@ void RegisterAppInterfaceRequest::Run() {
   SDL_LOG_AUTO_TRACE();
   SDL_LOG_DEBUG("Connection key is " << connection_key());
 
-  WaitForHMIIsReady();
-
-  if (application_manager_.IsStopping()) {
-    SDL_LOG_WARN("The ApplicationManager is stopping!");
+  if (!application_manager_.WaitForHmiIsReady()) {
+    SDL_LOG_WARN("Failed to wait for HMI readiness");
     return;
   }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/update_device_list_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/update_device_list_request_test.cc
@@ -92,10 +92,6 @@ class UpdateDeviceListRequestTest
 TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
   MessageSharedPtr command_msg = CreateCommandMsg();
 
-  EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher_));
-  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
-
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
 
@@ -103,7 +99,7 @@ TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
 
   EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(false));
 
-  EXPECT_CALL(app_mngr_, IsHMICooperating()).Times(0);
+  EXPECT_CALL(app_mngr_, WaitForHmiIsReady()).Times(0);
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
 
   command->Run();
@@ -114,12 +110,8 @@ TEST_F(UpdateDeviceListRequestTest, RUN_LaunchHMIReturnsFalse) {
             CommandImpl::protocol_version_);
 }
 
-TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS) {
+TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESS) {
   MessageSharedPtr command_msg = CreateCommandMsg();
-
-  EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher_));
-  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
 
   UpdateDeviceListRequestPtr command(
       CreateCommand<UpdateDeviceListRequest>(command_msg));
@@ -128,7 +120,7 @@ TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS) {
 
   EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(true));
 
-  EXPECT_CALL(app_mngr_, IsHMICooperating()).WillOnce(Return(true));
+  EXPECT_CALL(app_mngr_, WaitForHmiIsReady()).WillOnce(Return(true));
   EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(command_msg));
 
   command->Run();
@@ -139,29 +131,20 @@ TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsTrue_SUCCESSS) {
             CommandImpl::protocol_version_);
 }
 
-TEST_F(UpdateDeviceListRequestTest, OnEvent_WrongEventId_UNSUCCESS) {
-  Event event(Event::EventID::INVALID_ENUM);
+TEST_F(UpdateDeviceListRequestTest, RUN_HMICooperatingReturnsFalse_UNSUCCESS) {
+  MessageSharedPtr command_msg = CreateCommandMsg();
 
-  EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher_));
-  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
+  UpdateDeviceListRequestPtr command(
+      CreateCommand<UpdateDeviceListRequest>(command_msg));
 
-  UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());
+  EXPECT_CALL(app_mngr_, get_settings()).WillOnce(ReturnRef(settings_));
 
-  command->on_event(event);
-}
+  EXPECT_CALL(settings_, launch_hmi()).WillOnce(Return(true));
 
-TEST_F(UpdateDeviceListRequestTest, OnEvent_SUCCESS) {
-  Event event(Event::EventID::BasicCommunication_OnReady);
+  EXPECT_CALL(app_mngr_, WaitForHmiIsReady()).WillOnce(Return(false));
+  EXPECT_CALL(mock_rpc_service_, SendMessageToHMI(_)).Times(0);
 
-  EXPECT_CALL(app_mngr_, event_dispatcher())
-      .WillOnce(ReturnRef(mock_event_dispatcher_));
-  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_, _));
-  EXPECT_CALL(mock_event_dispatcher_, remove_observer(_));
-
-  UpdateDeviceListRequestPtr command(CreateCommand<UpdateDeviceListRequest>());
-
-  command->on_event(event);
+  command->Run();
 }
 
 }  // namespace update_device_list_request

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -198,7 +198,7 @@ class RegisterAppInterfaceRequestTest
   void InitGetters() {
     ON_CALL(app_mngr_, GetCorrectMobileIDFromMessage(msg_))
         .WillByDefault(Return(kAppId1));
-    ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(true));
+    ON_CALL(app_mngr_, WaitForHmiIsReady()).WillByDefault(Return(true));
     ON_CALL(app_mngr_, resume_controller())
         .WillByDefault(ReturnRef(mock_resume_crt_));
     ON_CALL(app_mngr_, connection_handler())
@@ -418,11 +418,7 @@ TEST_F(RegisterAppInterfaceRequestTest, DefaultTimeout_CheckIfZero_SUCCESS) {
 TEST_F(RegisterAppInterfaceRequestTest, Run_MinimalData_SUCCESS) {
   InitBasicMessage();
   (*msg_)[am::strings::msg_params][am::strings::hash_id] = kAppId1;
-  EXPECT_CALL(app_mngr_, IsStopping())
-      .WillOnce(Return(false))
-      .WillOnce(Return(true))
-      .WillOnce(Return(false));
-  ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
+  EXPECT_CALL(app_mngr_, WaitForHmiIsReady()).WillOnce(Return(true));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(_, _)).WillOnce(Return(false));
 
   ON_CALL(mock_connection_handler_,
@@ -506,11 +502,7 @@ TEST_F(RegisterAppInterfaceRequestTest,
        Run_HmiInterfacesStateAvailable_SUCCESS) {
   InitBasicMessage();
 
-  EXPECT_CALL(app_mngr_, IsStopping())
-      .WillOnce(Return(false))
-      .WillOnce(Return(true))
-      .WillOnce(Return(false));
-  ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
+  ON_CALL(app_mngr_, WaitForHmiIsReady()).WillByDefault(Return(true));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(_, _)).WillOnce(Return(false));
 
   ON_CALL(mock_connection_handler_,
@@ -810,11 +802,8 @@ TEST_F(RegisterAppInterfaceRequestTest,
 
   InitBasicMessage();
   (*msg_)[am::strings::params][am::strings::connection_key] = kConnectionKey2;
-  EXPECT_CALL(app_mngr_, IsStopping())
-      .WillOnce(Return(false))
-      .WillOnce(Return(true))
-      .WillOnce(Return(false));
-  ON_CALL(app_mngr_, IsHMICooperating()).WillByDefault(Return(false));
+
+  ON_CALL(app_mngr_, WaitForHmiIsReady()).WillByDefault(Return(true));
   EXPECT_CALL(app_mngr_, IsApplicationForbidden(kConnectionKey2, kAppId1))
       .WillOnce(Return(false));
 

--- a/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
+++ b/src/components/application_manager/rpc_plugins/vehicle_info_plugin/src/commands/hmi/vi_get_vehicle_type_response.cc
@@ -55,17 +55,19 @@ void VIGetVehicleTypeResponse::Run() {
   const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
       (*message_)[strings::params][hmi_response::code].asInt());
 
-  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
-      hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
-
   if (hmi_apis::Common_Result::SUCCESS != result_code) {
     SDL_LOG_DEBUG("Request was not successful. Don't change HMI capabilities");
+    hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+        hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
     return;
   }
 
   std::vector<std::string> sections_to_update{hmi_response::vehicle_type};
   hmi_capabilities_.set_vehicle_type(
       (*message_)[strings::msg_params][hmi_response::vehicle_type]);
+
+  hmi_capabilities_.UpdateRequestsRequiredForCapabilities(
+      hmi_apis::FunctionID::VehicleInfo_GetVehicleType);
 
   if (!hmi_capabilities_.SaveCachedCapabilitiesToFile(
           hmi_interface::vehicle_info,

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -230,7 +230,7 @@ ApplicationManagerImpl::ApplicationManagerImpl(
 ApplicationManagerImpl::~ApplicationManagerImpl() {
   SDL_LOG_AUTO_TRACE();
 
-  is_stopping_.store(true);
+  InitiateStopping();
   SendOnSDLClose();
   media_manager_ = NULL;
   hmi_handler_ = NULL;
@@ -1608,6 +1608,58 @@ void ApplicationManagerImpl::OnDeviceListUpdated(
   RefreshCloudAppInformation();
 }
 
+bool ApplicationManagerImpl::WaitForHmiIsReady() {
+  sync_primitives::AutoLock lock(wait_for_hmi_lock_);
+  if (!IsStopping() && !IsHMICooperating()) {
+    SDL_LOG_DEBUG("Waiting for the HMI cooperation...");
+    wait_for_hmi_condvar_.Wait(lock);
+  }
+
+  if (IsStopping()) {
+    SDL_LOG_WARN("System is terminating...");
+    return false;
+  }
+
+  return IsHMICooperating();
+}
+
+bool ApplicationManagerImpl::GetProtocolVehicleData(
+    connection_handler::ProtocolVehicleData& data) {
+  SDL_LOG_AUTO_TRACE();
+  using namespace protocol_handler::strings;
+
+  if (!WaitForHmiIsReady()) {
+    SDL_LOG_ERROR("Failed to wait for HMI readiness");
+    return false;
+  }
+
+  const auto vehicle_type_ptr = hmi_capabilities_->vehicle_type();
+  if (vehicle_type_ptr) {
+    if (vehicle_type_ptr->keyExists(vehicle_make)) {
+      data.vehicle_make = vehicle_type_ptr->getElement(vehicle_make).asString();
+    }
+
+    if (vehicle_type_ptr->keyExists(vehicle_model)) {
+      data.vehicle_model =
+          vehicle_type_ptr->getElement(vehicle_model).asString();
+    }
+
+    if (vehicle_type_ptr->keyExists(vehicle_model_year)) {
+      data.vehicle_year =
+          vehicle_type_ptr->getElement(vehicle_model_year).asString();
+    }
+
+    if (vehicle_type_ptr->keyExists(vehicle_trim)) {
+      data.vehicle_trim = vehicle_type_ptr->getElement(vehicle_trim).asString();
+    }
+  }
+
+  data.vehicle_system_software_version = hmi_capabilities_->ccpu_version();
+  data.vehicle_system_hardware_version = hmi_capabilities_->hardware_version();
+
+  return true;
+}
+
 void ApplicationManagerImpl::OnFindNewApplicationsRequest() {
   connection_handler().ConnectToAllDevices();
   SDL_LOG_DEBUG("Starting application list update timer");
@@ -2547,7 +2599,7 @@ bool ApplicationManagerImpl::Init(
 
 bool ApplicationManagerImpl::Stop() {
   SDL_LOG_AUTO_TRACE();
-  is_stopping_.store(true);
+  InitiateStopping();
   application_list_update_timer_.Stop();
   try {
     if (unregister_reason_ ==
@@ -2971,7 +3023,7 @@ void ApplicationManagerImpl::SetUnregisterAllApplicationsReason(
 void ApplicationManagerImpl::HeadUnitReset(
     mobile_api::AppInterfaceUnregisteredReason::eType reason) {
   SDL_LOG_AUTO_TRACE();
-  is_stopping_.store(true);
+  InitiateStopping();
   switch (reason) {
     case mobile_api::AppInterfaceUnregisteredReason::MASTER_RESET: {
       SDL_LOG_TRACE("Performing MASTER_RESET");
@@ -4124,7 +4176,17 @@ bool ApplicationManagerImpl::IsHMICooperating() const {
 }
 
 void ApplicationManagerImpl::SetHMICooperating(const bool hmi_cooperating) {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(wait_for_hmi_lock_);
   hmi_cooperating_ = hmi_cooperating;
+  wait_for_hmi_condvar_.Broadcast();
+}
+
+void ApplicationManagerImpl::InitiateStopping() {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(wait_for_hmi_lock_);
+  is_stopping_.store(true);
+  wait_for_hmi_condvar_.Broadcast();
 }
 
 void ApplicationManagerImpl::OnApplicationListUpdateTimer() {

--- a/src/components/application_manager/src/rpc_service_impl.cc
+++ b/src/components/application_manager/src/rpc_service_impl.cc
@@ -390,7 +390,10 @@ bool RPCServiceImpl::ManageHMICommand(const commands::MessageSharedPtr message,
 
   if (command->Init()) {
     command->Run();
-    if (kResponse == message_type) {
+    if (helpers::Compare<int32_t, helpers::EQ, helpers::ONE>(
+            message_type, kResponse, kErrorResponse) &&
+        message->getElement(strings::params)
+            .keyExists(strings::correlation_id)) {
       const uint32_t correlation_id =
           (*(message.get()))[strings::params][strings::correlation_id].asUInt();
       const int32_t function_id =

--- a/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
+++ b/src/components/connection_handler/include/connection_handler/connection_handler_impl.h
@@ -648,6 +648,8 @@ class ConnectionHandlerImpl
 
   void CreateWebEngineDevice() OVERRIDE;
 
+  bool GetProtocolVehicleData(ProtocolVehicleData& data) OVERRIDE;
+
  private:
   /**
    * \brief Disconnect application.

--- a/src/components/connection_handler/src/connection_handler_impl.cc
+++ b/src/components/connection_handler/src/connection_handler_impl.cc
@@ -919,6 +919,15 @@ void ConnectionHandlerImpl::CreateWebEngineDevice() {
   transport_manager_.CreateWebEngineDevice();
 }
 
+bool ConnectionHandlerImpl::GetProtocolVehicleData(ProtocolVehicleData& data) {
+  sync_primitives::AutoReadLock read_lock(connection_handler_observer_lock_);
+  if (connection_handler_observer_) {
+    return connection_handler_observer_->GetProtocolVehicleData(data);
+  }
+
+  return false;
+}
+
 const std::string
 ConnectionHandlerImpl::TransportTypeProfileStringFromConnHandle(
     transport_manager::ConnectionUID connection_handle) const {

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -620,6 +620,12 @@ class ApplicationManager {
 
   virtual bool IsStopping() const = 0;
 
+  /**
+   * @brief Waits for HMI readiness and blocks thread if it's not ready yet
+   * @return true if HMI is ready and cooperating, otherwise returns false
+   */
+  virtual bool WaitForHmiIsReady() = 0;
+
   virtual void RemoveAppFromTTSGlobalPropertiesList(const uint32_t app_id) = 0;
 
   /**

--- a/src/components/include/connection_handler/connection_handler.h
+++ b/src/components/include/connection_handler/connection_handler.h
@@ -58,6 +58,18 @@ enum CloseSessionReason {
 
 class ConnectionHandlerObserver;
 
+/**
+ * @brief Helper structure to collect all required vehicle data
+ */
+struct ProtocolVehicleData {
+  std::string vehicle_make;
+  std::string vehicle_model;
+  std::string vehicle_year;
+  std::string vehicle_trim;
+  std::string vehicle_system_software_version;
+  std::string vehicle_system_hardware_version;
+};
+
 // The SessionConnectionMap keeps track of the primary and secondary transports
 // associated with a session ID
 typedef struct {
@@ -343,6 +355,14 @@ class ConnectionHandler {
    */
   virtual const transport_manager::DeviceInfo& GetWebEngineDeviceInfo()
       const = 0;
+
+  /**
+   * @brief Collects all vehicle data required by a protocol layer
+   * @param data output structure to store received vehicle data
+   * @return true if data has been received successfully, otherwise returns
+   * false
+   */
+  virtual bool GetProtocolVehicleData(ProtocolVehicleData& data) = 0;
 
   /**
    * @brief Called when HMI cooperation is started,

--- a/src/components/include/connection_handler/connection_handler_observer.h
+++ b/src/components/include/connection_handler/connection_handler_observer.h
@@ -177,6 +177,14 @@ class ConnectionHandlerObserver {
    */
   virtual void OnWebEngineDeviceCreated() = 0;
 
+  /**
+   * @brief Collects all vehicle data required by a protocol layer
+   * @param data output structure to store received vehicle data
+   * @return true if data has been received successfully, otherwise returns
+   * false
+   */
+  virtual bool GetProtocolVehicleData(ProtocolVehicleData& data) = 0;
+
  protected:
   /**
    * \brief Destructor

--- a/src/components/include/protocol/bson_object_keys.h
+++ b/src/components/include/protocol/bson_object_keys.h
@@ -49,6 +49,12 @@ extern const char* tcp_ip_address;
 extern const char* tcp_port;
 extern const char* reason;
 extern const char* auth_token;
+extern const char* vehicle_make;
+extern const char* vehicle_model;
+extern const char* vehicle_model_year;
+extern const char* vehicle_trim;
+extern const char* vehicle_system_software_version;
+extern const char* vehicle_system_hardware_version;
 
 }  // namespace strings
 

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -230,6 +230,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD1(IsAppsQueriedFrom,
                      bool(const connection_handler::DeviceHandle handle));
   MOCK_CONST_METHOD0(IsStopping, bool());
+  MOCK_METHOD0(WaitForHmiIsReady, bool());
   MOCK_METHOD1(RemoveAppFromTTSGlobalPropertiesList,
                void(const uint32_t app_id));
   MOCK_METHOD2(ResetGlobalProperties,

--- a/src/components/include/test/connection_handler/mock_connection_handler.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler.h
@@ -139,6 +139,8 @@ class MockConnectionHandler : public connection_handler::ConnectionHandler {
       OnSecondaryTransportEnded,
       void(const transport_manager::ConnectionUID primary_connection_handle,
            const transport_manager::ConnectionUID secondary_connection_handle));
+  MOCK_METHOD1(GetProtocolVehicleData,
+               bool(connection_handler::ProtocolVehicleData& data));
   MOCK_METHOD0(CreateWebEngineDevice, void());
   MOCK_CONST_METHOD0(GetWebEngineDeviceInfo, transport_manager::DeviceInfo&());
 };

--- a/src/components/include/test/connection_handler/mock_connection_handler_observer.h
+++ b/src/components/include/test/connection_handler/mock_connection_handler_observer.h
@@ -83,6 +83,8 @@ class MockConnectionHandlerObserver
   MOCK_METHOD2(SetPendingApplicationState,
                void(const transport_manager::ConnectionUID connection_id,
                     const transport_manager::DeviceInfo& device_info));
+  MOCK_METHOD1(GetProtocolVehicleData,
+               bool(connection_handler::ProtocolVehicleData& data));
 };
 
 }  // namespace connection_handler_test

--- a/src/components/protocol/src/bson_object_keys.cc
+++ b/src/components/protocol/src/bson_object_keys.cc
@@ -19,6 +19,12 @@ const char* tcp_ip_address = "tcpIpAddress";
 const char* tcp_port = "tcpPort";
 const char* reason = "reason";
 const char* auth_token = "authToken";
+const char* vehicle_make = "make";
+const char* vehicle_model = "model";
+const char* vehicle_model_year = "modelYear";
+const char* vehicle_trim = "trim";
+const char* vehicle_system_software_version = "systemSoftwareVersion";
+const char* vehicle_system_hardware_version = "systemHardwareVersion";
 
 }  // namespace strings
 

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -733,6 +733,14 @@ class ProtocolHandlerImpl
       const uint8_t session_id,
       const bool protection) const;
 
+  /**
+   * @brief Writes available protocol vehicle data into structured bson
+   * @param params bson params to write into
+   * @param data data to write
+   */
+  void WriteProtocolVehicleData(
+      BsonObject& params, const connection_handler::ProtocolVehicleData& data);
+
   const ProtocolHandlerSettings& settings_;
 
   /**


### PR DESCRIPTION
Fixes #[issue number]

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
- Add vehicle data params to StartSessionAck
- Added some unit tests to cover happy path
- Additionally, implemented new waiter-function for blocking threads until HMI readiness and release them once all data became available

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
