### PR TITLE
[SDL-0293] Handle new hardware version param in RAI and policy classes

### DIFF
--- a/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
+++ b/src/components/application_manager/include/application_manager/hmi_capabilities_impl.h
@@ -81,6 +81,10 @@ class HMICapabilitiesImpl : public HMICapabilities {
 
   const std::string& ccpu_version() const OVERRIDE;
 
+  void set_hardware_version(const std::string& hardware_version) OVERRIDE;
+
+  const std::string& hardware_version() const OVERRIDE;
+
   bool attenuated_supported() const OVERRIDE;
 
   void set_attenuated_supported(const bool state) OVERRIDE;
@@ -476,6 +480,7 @@ class HMICapabilitiesImpl : public HMICapabilities {
   bool is_rc_supported_;
   bool is_driver_distraction_supported_;
   std::string ccpu_version_;
+  std::string hardware_version_;
   smart_objects::SmartObjectSPtr navigation_capability_;
   smart_objects::SmartObjectSPtr phone_capability_;
   smart_objects::SmartObjectSPtr video_streaming_capability_;

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -386,9 +386,13 @@ class PolicyHandler : public PolicyHandlerInterface,
                        const std::string& wers_country_code,
                        const std::string& language) OVERRIDE;
 
+  void OnHardwareVersionReceived(const std::string& hardware_version) OVERRIDE;
+
   void SetPreloadedPtFlag(const bool is_preloaded) OVERRIDE;
 
   std::string GetCCPUVersionFromPT() const OVERRIDE;
+
+  std::string GetHardwareVersionFromPT() const OVERRIDE;
 
   /**
    * @brief Sends GetVehicleData request in case when Vechicle info is ready.

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -336,6 +336,7 @@ extern const char* video_streaming;
 extern const char* remote_control;
 extern const char* sdl_version;
 extern const char* system_software_version;
+extern const char* system_hardware_version;
 extern const char* priority;
 extern const char* engine_oil_life;
 extern const char* oem_custom_data_type;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/get_system_info_response.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/get_system_info_response.h
@@ -45,6 +45,7 @@ struct SystemInfo {
   std::string ccpu_version;
   std::string wers_country_code;
   std::string language;
+  std::string hardware_version;
 };
 
 /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/get_system_info_response.cc
@@ -59,6 +59,8 @@ void GetSystemInfoResponse::Run() {
       (*message_)[strings::params][hmi_response::code].asInt());
 
   hmi_capabilities_.set_ccpu_version(policy_handler_.GetCCPUVersionFromPT());
+  hmi_capabilities_.set_hardware_version(
+      policy_handler_.GetHardwareVersionFromPT());
 
   if (hmi_apis::Common_Result::SUCCESS != code) {
     SDL_LOG_WARN("GetSystemError returns an error code " << code);
@@ -73,6 +75,10 @@ void GetSystemInfoResponse::Run() {
       info.ccpu_version, info.wers_country_code, info.language);
 
   hmi_capabilities_.OnSoftwareVersionReceived(info.ccpu_version);
+  if (!info.hardware_version.empty()) {
+    policy_handler_.OnHardwareVersionReceived(info.hardware_version);
+    hmi_capabilities_.set_hardware_version(info.hardware_version);
+  }
 }
 
 const SystemInfo GetSystemInfoResponse::GetSystemInfo() const {
@@ -89,6 +95,12 @@ const SystemInfo GetSystemInfoResponse::GetSystemInfo() const {
   info.language = application_manager::EnumToString(
       static_cast<hmi_apis::Common_Language::eType>(lang_code));
 
+  if ((*message_)[strings::msg_params].keyExists(
+          strings::system_hardware_version)) {
+    info.hardware_version =
+        (*message_)[strings::msg_params][strings::system_hardware_version]
+            .asString();
+  }
   return info;
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/register_app_interface_request.cc
@@ -970,6 +970,11 @@ void RegisterAppInterfaceRequest::SendRegisterAppInterfaceResponseToMobile(
     response_params[strings::system_software_version] = ccpu_version;
   }
 
+  const std::string hardware_version = hmi_capabilities_.hardware_version();
+  if (!hardware_version.empty()) {
+    response_params[strings::system_hardware_version] = hardware_version;
+  }
+
   if (ApplicationType::kSwitchedApplicationWrongHashId == app_type) {
     SDL_LOG_DEBUG(
         "Application has been switched from another transport, "

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/register_app_interface_request_test.cc
@@ -209,6 +209,8 @@ class RegisterAppInterfaceRequestTest
         .WillByDefault(ReturnRef(kDummyString));
     ON_CALL(mock_hmi_capabilities_, ccpu_version())
         .WillByDefault(ReturnRef(kDummyString));
+    ON_CALL(mock_hmi_capabilities_, hardware_version())
+        .WillByDefault(ReturnRef(kDummyString));
     ON_CALL(mock_hmi_capabilities_, speech_capabilities())
         .WillByDefault(Return(smart_objects::SmartObjectSPtr()));
     ON_CALL(mock_hmi_capabilities_, prerecorded_speech())

--- a/src/components/application_manager/src/hmi_capabilities_impl.cc
+++ b/src/components/application_manager/src/hmi_capabilities_impl.cc
@@ -1860,6 +1860,15 @@ const std::string& HMICapabilitiesImpl::ccpu_version() const {
   return ccpu_version_;
 }
 
+void HMICapabilitiesImpl::set_hardware_version(
+    const std::string& hardware_version) {
+  hardware_version_ = hardware_version;
+}
+
+const std::string& HMICapabilitiesImpl::hardware_version() const {
+  return hardware_version_;
+}
+
 void HMICapabilitiesImpl::convert_json_languages_to_obj(
     const Json::Value& json_languages,
     smart_objects::SmartObject& languages) const {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1097,11 +1097,26 @@ void PolicyHandler::OnGetSystemInfo(const std::string& ccpu_version,
   policy_manager->SetSystemInfo(ccpu_version, wers_country_code, language);
 }
 
+void PolicyHandler::OnHardwareVersionReceived(
+    const std::string& hardware_version) {
+  SDL_LOG_AUTO_TRACE();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_VOID(policy_manager);
+  policy_manager->SetHardwareVersion(hardware_version);
+}
+
 std::string PolicyHandler::GetCCPUVersionFromPT() const {
   SDL_LOG_AUTO_TRACE();
   const auto policy_manager = LoadPolicyManager();
   POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::string());
   return policy_manager->GetCCPUVersionFromPT();
+}
+
+std::string PolicyHandler::GetHardwareVersionFromPT() const {
+  SDL_LOG_AUTO_TRACE();
+  const auto policy_manager = LoadPolicyManager();
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, std::string());
+  return policy_manager->GetHardwareVersionFromPT();
 }
 
 void PolicyHandler::OnVIIsReady() {

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -303,6 +303,7 @@ const char* video_streaming = "videoStreaming";
 const char* remote_control = "remoteControl";
 const char* sdl_version = "sdlVersion";
 const char* system_software_version = "systemSoftwareVersion";
+const char* system_hardware_version = "systemHardwareVersion";
 const char* priority = "priority";
 const char* engine_oil_life = "engineOilLife";
 const char* oem_custom_data_type = "oemCustomDataType";

--- a/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
+++ b/src/components/application_manager/test/include/application_manager/mock_hmi_capabilities.h
@@ -212,6 +212,8 @@ class MockHMICapabilities : public ::application_manager::HMICapabilities {
 
   MOCK_CONST_METHOD0(ccpu_version, const std::string&());
   MOCK_METHOD1(set_ccpu_version, void(const std::string& ccpu_version));
+  MOCK_CONST_METHOD0(hardware_version, const std::string&());
+  MOCK_METHOD1(set_hardware_version, void(const std::string& hardware_version));
   MOCK_METHOD1(OnSoftwareVersionReceived,
                void(const std::string& ccpu_version));
   MOCK_METHOD0(UpdateCachedCapabilities, void());

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1323,19 +1323,6 @@ TEST_F(PolicyHandlerTest, OnSystemInfoChanged) {
   policy_handler_.OnSystemInfoChanged(language);
 }
 
-TEST_F(PolicyHandlerTest, OnGetSystemInfo) {
-  // Arrange
-  ChangePolicyManagerToMock();
-  // Check expectations
-  const std::string ccpu_version("4.1.3.B_EB355B");
-  const std::string wers_country_code("WAEGB");
-  const std::string language("ru-ru");
-  EXPECT_CALL(*mock_policy_manager_,
-              SetSystemInfo(ccpu_version, wers_country_code, language));
-  // Act
-  policy_handler_.OnGetSystemInfo(ccpu_version, wers_country_code, language);
-}
-
 TEST_F(PolicyHandlerTest, IsApplicationRevoked) {
   // Arrange
   EnablePolicy();

--- a/src/components/include/application_manager/hmi_capabilities.h
+++ b/src/components/include/application_manager/hmi_capabilities.h
@@ -97,9 +97,24 @@ class HMICapabilities {
 
   /**
    * @brief Returns software version of the target
-   * @return TRUE if it supported, otherwise FALSE
+   * @return string representation of software version if supported, otherwise
+   * empty string
    */
   virtual const std::string& ccpu_version() const = 0;
+
+  /**
+   * @brief Interface used to store information about hardware version of the
+   * target
+   * @param hardware_version Received system/hmi hardware version
+   */
+  virtual void set_hardware_version(const std::string& hardware_version) = 0;
+
+  /**
+   * @brief Returns hardware version of the target
+   * @return string representation of hardware version if supported, otherwise
+   * empty string
+   */
+  virtual const std::string& hardware_version() const = 0;
 
   /**
    * @brief Retrieves if mixing audio is supported by HMI

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -332,10 +332,24 @@ class PolicyHandlerInterface : public VehicleDataItemProvider {
                                const std::string& language) = 0;
 
   /**
+   * @brief Save hardware version from GetSystemInfo request to policy table, if
+   * present
+   * @param hardware_version Hardware version
+   */
+  virtual void OnHardwareVersionReceived(
+      const std::string& hardware_version) = 0;
+
+  /**
    * @brief Get information about last ccpu_version from PT
    * @return ccpu_version from PT
    */
   virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
+   * @brief Get information about last hardware version from PT
+   * @return hardware version from PT
+   */
+  virtual std::string GetHardwareVersionFromPT() const = 0;
 
   /**
    * @brief Sends GetVehicleData request in case when Vechicle info is ready.

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -433,10 +433,23 @@ class PolicyManager : public usage_statistics::StatisticsManager,
                              const std::string& language) = 0;
 
   /**
+   * @brief Set hardware version from GetSystemInfo response to policy table, if
+   * present
+   * @param hardware_version Hardware version
+   */
+  virtual void SetHardwareVersion(const std::string& hardware_version) = 0;
+
+  /**
    * @brief Get information about last ccpu_version from PT
    * @return ccpu_version from PT
    */
   virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
+   * @brief Get information about last hardware version from PT
+   * @return hardware version from PT
+   */
+  virtual std::string GetHardwareVersionFromPT() const = 0;
 
   /**
    * @brief Send OnPermissionsUpdated for choosen application

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -424,10 +424,23 @@ class PolicyManager : public usage_statistics::StatisticsManager,
                              const std::string& language) = 0;
 
   /**
+   * @brief Set hardware version from GetSystemInfo response to policy table, if
+   * present
+   * @param hardware_version Hardware version
+   */
+  virtual void SetHardwareVersion(const std::string& hardware_version) = 0;
+
+  /**
    * @brief Get information about last ccpu_version from PT
    * @return ccpu_version from PT
    */
   virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
+   * @brief Get information about last hardware version from PT
+   * @return hardware version from PT
+   */
+  virtual std::string GetHardwareVersionFromPT() const = 0;
 
   /**
    * @brief Send OnPermissionsUpdated for choosen application

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -186,7 +186,10 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
                void(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_METHOD1(OnHardwareVersionReceived,
+               void(const std::string& hardware_version));
   MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
+  MOCK_CONST_METHOD0(GetHardwareVersionFromPT, std::string());
   MOCK_METHOD0(OnVIIsReady, void());
   MOCK_METHOD1(OnVehicleDataUpdated,
                void(const smart_objects::SmartObject& message));

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -207,7 +207,9 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
                bool(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_METHOD1(SetHardwareVersion, void(const std::string& hardware_version));
   MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
+  MOCK_CONST_METHOD0(GetHardwareVersionFromPT, std::string());
   MOCK_CONST_METHOD0(IsMetaInfoPresent, bool());
   MOCK_METHOD1(SetSystemLanguage, bool(const std::string& language));
   MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -173,6 +173,7 @@ class MockPolicyManager : public PolicyManager {
                void(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_METHOD1(SetHardwareVersion, void(const std::string& hardware_version));
   MOCK_METHOD1(SetPreloadedPtFlag, void(const bool is_preloaded));
   MOCK_METHOD2(SendNotificationOnPermissionsUpdated,
                void(const std::string& device_id,
@@ -308,6 +309,7 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(RetrySequenceFailed, void());
   MOCK_METHOD0(ResetTimeout, void());
   MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
+  MOCK_CONST_METHOD0(GetHardwareVersionFromPT, std::string());
 };
 }  // namespace policy_manager_test
 }  // namespace components

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -181,7 +181,9 @@ class MockCacheManagerInterface : public CacheManagerInterface {
                bool(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_METHOD1(SetHardwareVersion, void(const std::string& hardware_version));
   MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
+  MOCK_CONST_METHOD0(GetHardwareVersionFromPT, std::string());
   MOCK_CONST_METHOD0(IsMetaInfoPresent, bool());
   MOCK_METHOD1(SetSystemLanguage, bool(const std::string& language));
   MOCK_METHOD1(Increment, void(usage_statistics::GlobalCounterId type));

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -172,6 +172,7 @@ class MockPolicyManager : public PolicyManager {
                void(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& language));
+  MOCK_METHOD1(SetHardwareVersion, void(const std::string& hardware_version));
   MOCK_METHOD1(SetPreloadedPtFlag, void(const bool is_preloaded));
   MOCK_METHOD2(SendNotificationOnPermissionsUpdated,
                void(const std::string& device_id,
@@ -311,6 +312,7 @@ class MockPolicyManager : public PolicyManager {
                      RequestSubType::State(const std::string& policy_app_id));
   MOCK_METHOD0(ResetTimeout, void());
   MOCK_CONST_METHOD0(GetCCPUVersionFromPT, std::string());
+  MOCK_CONST_METHOD0(GetHardwareVersionFromPT, std::string());
 };
 
 }  // namespace policy_manager_test

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -597,19 +597,19 @@ class CacheManager : public CacheManagerInterface {
    */
   void SetPreloadedPtFlag(const bool is_preloaded) OVERRIDE;
 
-  /**
-   * @brief Records information about head unit system to PT
-   * @return bool Success of operation
-   */
   bool SetMetaInfo(const std::string& ccpu_version,
                    const std::string& wers_country_code,
-                   const std::string& language);
+                   const std::string& language) OVERRIDE;
+
+  void SetHardwareVersion(const std::string& hardware_version) OVERRIDE;
 
   /**
    * @brief Get information about last ccpu_version from PT
    * @return ccpu_version from PT
    */
   std::string GetCCPUVersionFromPT() const;
+
+  std::string GetHardwareVersionFromPT() const OVERRIDE;
 
   /**
    * @brief Checks, if specific head unit is present in PT

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -645,7 +645,7 @@ class CacheManagerInterface {
   virtual void SetPreloadedPtFlag(const bool is_preloaded) = 0;
 
   /**
-   * @brief Records information about head unit system to PT
+   * @brief Records mandatory information about head unit system to PT
    * @return bool Success of operation
    */
   virtual bool SetMetaInfo(const std::string& ccpu_version,
@@ -653,10 +653,22 @@ class CacheManagerInterface {
                            const std::string& language) = 0;
 
   /**
+   * @brief Records information about hardware version to PT
+   * @param hardware_version Hardware version
+   */
+  virtual void SetHardwareVersion(const std::string& hardware_version) = 0;
+
+  /**
    * @brief Get information about last ccpu_version from PT
    * @return ccpu_version from PT
    */
   virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
+   * @brief Get information about last hardware version from PT
+   * @return hardware version from PT
+   */
+  virtual std::string GetHardwareVersionFromPT() const = 0;
 
   /**
    * @brief Checks, if specific head unit is present in PT

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -435,9 +435,13 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& wers_country_code,
                      const std::string& language) OVERRIDE;
 
+  void SetHardwareVersion(const std::string& hardware_version) OVERRIDE;
+
   void SetPreloadedPtFlag(const bool is_preloaded) OVERRIDE;
 
   std::string GetCCPUVersionFromPT() const OVERRIDE;
+
+  std::string GetHardwareVersionFromPT() const OVERRIDE;
 
   /**
    * @brief Get number of notification by priority

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -490,6 +490,7 @@ struct ModuleMeta : CompositeType {
   Optional<String<0, 500> > ccpu_version;
   Optional<String<0, 250> > language;
   Optional<String<0, 250> > wers_country_code;
+  Optional<String<0, 500> > hardware_version;
   Optional<Integer<uint32_t, 0, ODO_MAX> > pt_exchanged_at_odometer_x;
   Optional<Integer<uint16_t, 0, 65535> > pt_exchanged_x_days_after_epoch;
   Optional<Integer<uint16_t, 0, 65535> > ignition_cycles_since_last_exchange;

--- a/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
+++ b/src/components/policy/policy_external/include/policy/policy_table_interface_ext.xml
@@ -221,6 +221,7 @@
         <param name="ccpu_version" type="String" maxlength="250" mandatory="false"/>
         <param name="language" type="String" maxlength="250" mandatory="false"/>
         <param name="wers_country_code" type="String" maxlength="250" mandatory="false"/>
+        <param name="hardware_version" type="String" maxlength="500" mandatory="false"/>
         <param name="pt_exchanged_at_odometer_x" type="Integer" minvalue="0" maxvalue="65535" mandatory="false"/>
         <param name="pt_exchanged_x_days_after_epoch" type="Integer" minvalue="0" maxvalue="65535" mandatory="false"/>
         <param name="ignition_cycles_since_last_exchange" type="Integer" minvalue="0" maxvalue="65535" mandatory="false"/>

--- a/src/components/policy/policy_external/include/policy/pt_ext_representation.h
+++ b/src/components/policy/policy_external/include/policy/pt_ext_representation.h
@@ -198,12 +198,18 @@ class PTExtRepresentation : public virtual PTRepresentation {
                                           const std::string& language) = 0;
 
   /**
-   * @brief Records information about head unit system to PT
+   * @brief Records mandatory information about head unit system to PT
    * @return bool Success of operation
    */
   virtual bool SetMetaInfo(const std::string& ccpu_version,
                            const std::string& wers_country_code,
                            const std::string& language) = 0;
+
+  /**
+   * @brief Records information about hardware version to PT
+   * @param hardware_version Hardware version
+   */
+  virtual void SetHardwareVersion(const std::string& hardware_version) = 0;
 
   /**
    * @brief Checks, if specific head unit is present in PT

--- a/src/components/policy/policy_external/include/policy/sql_pt_ext_queries.h
+++ b/src/components/policy/policy_external/include/policy/sql_pt_ext_queries.h
@@ -65,6 +65,7 @@ extern const std::string kInsertExternalConsentStatusGroups;
 extern const std::string kCountUnconsentedGroups;
 extern const std::string kSelectModuleMeta;
 extern const std::string kUpdateMetaParams;
+extern const std::string kUpdateMetaHardwareVersion;
 extern const std::string kUpdateModuleMetaVinParam;
 extern const std::string kSaveModuleMeta;
 extern const std::string kSelectMetaParams;

--- a/src/components/policy/policy_external/include/policy/sql_pt_ext_representation.h
+++ b/src/components/policy/policy_external/include/policy/sql_pt_ext_representation.h
@@ -94,7 +94,9 @@ class SQLPTExtRepresentation : public SQLPTRepresentation,
 
   bool SetMetaInfo(const std::string& ccpu_version,
                    const std::string& wers_country_code,
-                   const std::string& language);
+                   const std::string& language) OVERRIDE;
+
+  void SetHardwareVersion(const std::string& hardware_version) OVERRIDE;
 
   bool IsMetaInfoPresent();
 

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -2047,7 +2047,8 @@ void CacheManager::PersistData() {
             *(*copy_pt.policy_table.module_meta).wers_country_code,
             *(*copy_pt.policy_table.module_meta).language);
         ex_backup_->SetVINValue(*(*copy_pt.policy_table.module_meta).vin);
-
+        ex_backup_->SetHardwareVersion(
+            *(*copy_pt.policy_table.module_meta).hardware_version);
         // Save unpaired flag for devices
         policy_table::DeviceData::const_iterator it_device =
             copy_pt.policy_table.device_data->begin();
@@ -2300,11 +2301,31 @@ bool CacheManager::SetMetaInfo(const std::string& ccpu_version,
   return true;
 }
 
+void CacheManager::SetHardwareVersion(const std::string& hardware_version) {
+  SDL_LOG_AUTO_TRACE();
+  CACHE_MANAGER_CHECK_VOID();
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+
+  *pt_->policy_table.module_meta->hardware_version = hardware_version;
+  Backup();
+}
+
 std::string CacheManager::GetCCPUVersionFromPT() const {
   SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+
   rpc::Optional<policy_table::ModuleMeta>& module_meta =
       pt_->policy_table.module_meta;
   return *(module_meta->ccpu_version);
+}
+
+std::string CacheManager::GetHardwareVersionFromPT() const {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+
+  rpc::Optional<policy_table::ModuleMeta>& module_meta =
+      pt_->policy_table.module_meta;
+  return *(module_meta->hardware_version);
 }
 
 bool CacheManager::IsMetaInfoPresent() const {

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1617,9 +1617,20 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
   cache_->SetMetaInfo(ccpu_version, wers_country_code, language);
 }
 
+void PolicyManagerImpl::SetHardwareVersion(
+    const std::string& hardware_version) {
+  SDL_LOG_AUTO_TRACE();
+  cache_->SetHardwareVersion(hardware_version);
+}
+
 std::string PolicyManagerImpl::GetCCPUVersionFromPT() const {
   SDL_LOG_AUTO_TRACE();
   return cache_->GetCCPUVersionFromPT();
+}
+
+std::string PolicyManagerImpl::GetHardwareVersionFromPT() const {
+  SDL_LOG_AUTO_TRACE();
+  return cache_->GetHardwareVersionFromPT();
 }
 
 uint32_t PolicyManagerImpl::GetNotificationsNumber(const std::string& priority,

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -1424,6 +1424,7 @@ ModuleMeta::ModuleMeta(const Json::Value* value__)
     , ccpu_version(impl::ValueMember(value__, "ccpu_version"))
     , language(impl::ValueMember(value__, "language"))
     , wers_country_code(impl::ValueMember(value__, "wers_country_code"))
+    , hardware_version(impl::ValueMember(value__, "hardware_version"))
     , pt_exchanged_at_odometer_x(
           impl::ValueMember(value__, "pt_exchanged_at_odometer_x"))
     , pt_exchanged_x_days_after_epoch(
@@ -1437,6 +1438,7 @@ Json::Value ModuleMeta::ToJsonValue() const {
   impl::WriteJsonField("ccpu_version", ccpu_version, &result__);
   impl::WriteJsonField("language", language, &result__);
   impl::WriteJsonField("wers_country_code", wers_country_code, &result__);
+  impl::WriteJsonField("hardware_version", hardware_version, &result__);
   impl::WriteJsonField(
       "pt_exchanged_at_odometer_x", pt_exchanged_at_odometer_x, &result__);
   impl::WriteJsonField("pt_exchanged_x_days_after_epoch",
@@ -1462,6 +1464,11 @@ bool ModuleMeta::is_valid() const {
   if (!wers_country_code.is_valid()) {
     return false;
   }
+
+  if (!hardware_version.is_valid()) {
+    return false;
+  }
+
   if (!pt_exchanged_at_odometer_x.is_valid()) {
     return false;
   }
@@ -1492,6 +1499,11 @@ bool ModuleMeta::struct_empty() const {
   if (wers_country_code.is_initialized()) {
     return false;
   }
+
+  if (hardware_version.is_initialized()) {
+    return false;
+  }
+
   if (pt_exchanged_at_odometer_x.is_initialized()) {
     return false;
   }
@@ -1506,6 +1518,7 @@ bool ModuleMeta::struct_empty() const {
   if (vin.is_initialized()) {
     return false;
   }
+
   return true;
 }
 
@@ -1522,6 +1535,10 @@ void ModuleMeta::ReportErrors(rpc::ValidationReport* report__) const {
   if (!wers_country_code.is_valid()) {
     wers_country_code.ReportErrors(
         &report__->ReportSubobject("wers_country_code"));
+  }
+  if (!hardware_version.is_valid()) {
+    hardware_version.ReportErrors(
+        &report__->ReportSubobject("hardware_version"));
   }
   if (!pt_exchanged_at_odometer_x.is_valid()) {
     pt_exchanged_at_odometer_x.ReportErrors(
@@ -1551,6 +1568,7 @@ void ModuleMeta::SetPolicyTableType(PolicyTableType pt_type) {
   ccpu_version.SetPolicyTableType(pt_type);
   language.SetPolicyTableType(pt_type);
   wers_country_code.SetPolicyTableType(pt_type);
+  hardware_version.SetPolicyTableType(pt_type);
   pt_exchanged_at_odometer_x.SetPolicyTableType(pt_type);
   pt_exchanged_x_days_after_epoch.SetPolicyTableType(pt_type);
   ignition_cycles_since_last_exchange.SetPolicyTableType(pt_type);

--- a/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_queries.cc
@@ -170,18 +170,27 @@ const std::string kCountUnconsentedGroups =
     " WHERE (`a`.`functional_group_id` = `f`.`id`"
     " AND`f`.`user_consent_prompt` IS NULL))";
 
-const std::string kSelectModuleMeta = "SELECT* FROM `module_meta`";
+const std::string kSelectModuleMeta =
+    "SELECT `ccpu_version`, `language`, "
+    "`wers_country_code`, `hardware_version`, `pt_exchanged_at_odometer_x`, "
+    "`pt_exchanged_x_days_after_epoch`, "
+    "`ignition_cycles_since_last_exchange`, `vin` "
+    "FROM `module_meta`";
 
 const std::string kUpdateMetaParams =
     "UPDATE `module_meta` SET "
-    "`ccpu_version` = ?, `wers_country_code` = ?, `language` = ? ";
+    "`ccpu_version` = ?, `wers_country_code` = ?, `language` = ?";
+
+const std::string kUpdateMetaHardwareVersion =
+    "UPDATE `module_meta` SET `hardware_version` = ? ";
 
 const std::string kUpdateModuleMetaVinParam =
     "UPDATE `module_meta` SET `vin` = ? ";
 
 const std::string kSaveModuleMeta =
     "UPDATE `module_meta` SET `ccpu_version` = ?, `language` = ?,"
-    "`wers_country_code` = ?, `pt_exchanged_at_odometer_x` = ?,"
+    "`wers_country_code` = ?, `hardware_version` = ?, "
+    "`pt_exchanged_at_odometer_x` = ?,"
     "`pt_exchanged_x_days_after_epoch` = ?,"
     "`ignition_cycles_since_last_exchange` = ?, `vin` = ?";
 

--- a/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_ext_representation.cc
@@ -600,6 +600,22 @@ bool SQLPTExtRepresentation::SetMetaInfo(const std::string& ccpu_version,
   return true;
 }
 
+void SQLPTExtRepresentation::SetHardwareVersion(
+    const std::string& hardware_version) {
+  SDL_LOG_AUTO_TRACE();
+  utils::dbms::SQLQuery query(db());
+  if (!query.Prepare(sql_pt_ext::kUpdateMetaHardwareVersion)) {
+    SDL_LOG_WARN("Incorrect statement for insert to module meta.");
+    return;
+  }
+
+  query.Bind(0, hardware_version);
+
+  if (!query.Exec()) {
+    SDL_LOG_WARN("Incorrect insert to module meta.");
+  }
+}
+
 bool SQLPTExtRepresentation::IsMetaInfoPresent() {
   SDL_LOG_AUTO_TRACE();
   utils::dbms::SQLQuery query(db());
@@ -1320,10 +1336,11 @@ void SQLPTExtRepresentation::GatherModuleMeta(
     *meta->ccpu_version = query.GetString(0);
     *meta->language = query.GetString(1);
     *meta->wers_country_code = query.GetString(2);
-    *meta->pt_exchanged_at_odometer_x = query.GetInteger(3);
-    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(4);
-    *meta->ignition_cycles_since_last_exchange = query.GetInteger(5);
-    *meta->vin = query.GetString(6);
+    *meta->hardware_version = query.GetString(3);
+    *meta->pt_exchanged_at_odometer_x = query.GetInteger(4);
+    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(5);
+    *meta->ignition_cycles_since_last_exchange = query.GetInteger(6);
+    *meta->vin = query.GetString(7);
   }
 }
 
@@ -1652,10 +1669,11 @@ bool SQLPTExtRepresentation::SaveModuleMeta(
   query.Bind(0, *(meta.ccpu_version));
   query.Bind(1, *(meta.language));
   query.Bind(2, *(meta.wers_country_code));
-  query.Bind(3, odometer);
-  query.Bind(4, *(meta.pt_exchanged_x_days_after_epoch));
-  query.Bind(5, *(meta.ignition_cycles_since_last_exchange));
-  query.Bind(6, *(meta.vin));
+  query.Bind(3, *(meta.hardware_version));
+  query.Bind(4, odometer);
+  query.Bind(5, *(meta.pt_exchanged_x_days_after_epoch));
+  query.Bind(6, *(meta.ignition_cycles_since_last_exchange));
+  query.Bind(7, *(meta.vin));
 
   if (!query.Exec()) {
     SDL_LOG_WARN("Incorrect update for module_meta.");

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -59,6 +59,7 @@ const std::string kCreateSchema =
     "  `ccpu_version` VARCHAR(45), "
     "  `language` VARCHAR(45), "
     "  `wers_country_code` VARCHAR(45), "
+    "  `hardware_version` VARCHAR(45), "
     "  `pt_exchanged_at_odometer_x` INTEGER NOT NULL DEFAULT 0, "
     "  `pt_exchanged_x_days_after_epoch` INTEGER NOT NULL DEFAULT 0, "
     "  `ignition_cycles_since_last_exchange` INTEGER NOT NULL DEFAULT 0, "

--- a/src/components/policy/policy_external/test/cache_manager_test.cc
+++ b/src/components/policy/policy_external/test/cache_manager_test.cc
@@ -2169,6 +2169,18 @@ TEST_F(CacheManagerTest, RemoveAppConsentForGroup_GroupIsRemoved) {
   EXPECT_FALSE(unconsented_groups_after_removal.empty());
 }
 
+TEST_F(CacheManagerTest, GetHardwareVersion_ValueWasSetBefore_ReturnValue) {
+  std::string hardware_version = "1.1.1.1";
+  cache_manager_->SetHardwareVersion(hardware_version);
+  EXPECT_EQ(hardware_version, cache_manager_->GetHardwareVersionFromPT());
+}
+
+TEST_F(CacheManagerTest,
+       GetHardwareVersion_ValueNotSettedBefore_ReturnEmptyString) {
+  std::string empty_string = "";
+  EXPECT_EQ(empty_string, cache_manager_->GetHardwareVersionFromPT());
+}
+
 }  // namespace policy_test
 }  // namespace components
 }  // namespace test

--- a/src/components/policy/policy_external/test/include/policy/mock_pt_ext_representation.h
+++ b/src/components/policy/policy_external/test/include/policy/mock_pt_ext_representation.h
@@ -105,6 +105,7 @@ class MockPTExtRepresentation : public MockPTRepresentation,
                bool(const std::string& ccpu_version,
                     const std::string& wers_country_code,
                     const std::string& vin));
+  MOCK_METHOD1(SetHardwareVersion, void(const std::string& hardware_version));
   MOCK_METHOD0(IsMetaInfoPresent, bool());
   MOCK_METHOD1(SetSystemLanguage, bool(const std::string& language));
   MOCK_METHOD0(GetKmFromSuccessfulExchange, int());

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -544,19 +544,19 @@ class CacheManager : public CacheManagerInterface {
    */
   void SetPreloadedPtFlag(const bool is_preloaded) OVERRIDE;
 
-  /**
-   * @brief Records information about head unit system to PT
-   * @return bool Success of operation
-   */
   bool SetMetaInfo(const std::string& ccpu_version,
                    const std::string& wers_country_code,
-                   const std::string& language);
+                   const std::string& language) OVERRIDE;
+
+  void SetHardwareVersion(const std::string& hardware_version) OVERRIDE;
 
   /**
    * @brief Get information about last ccpu_version from PT
    * @return ccpu_version from PT
    */
   std::string GetCCPUVersionFromPT() const;
+
+  std::string GetHardwareVersionFromPT() const OVERRIDE;
 
   /**
    * @brief Checks, if specific head unit is present in PT

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -586,7 +586,7 @@ class CacheManagerInterface {
   virtual void SetPreloadedPtFlag(const bool is_preloaded) = 0;
 
   /**
-   * @brief Records information about head unit system to PT
+   * @brief Records mandatory information about head unit system to PT
    * @return bool Success of operation
    */
   virtual bool SetMetaInfo(const std::string& ccpu_version,
@@ -594,10 +594,22 @@ class CacheManagerInterface {
                            const std::string& language) = 0;
 
   /**
+   * @brief Records information about hardware version to PT
+   * @param hardware_version Hardware version
+   */
+  virtual void SetHardwareVersion(const std::string& hardware_version) = 0;
+
+  /**
    * @brief Get information about last ccpu_version from PT
    * @return ccpu_version from PT
    */
   virtual std::string GetCCPUVersionFromPT() const = 0;
+
+  /**
+   * @brief Get information about last hardware version from PT
+   * @return string representation of hardware version from PT, empty if absent
+   */
+  virtual std::string GetHardwareVersionFromPT() const = 0;
 
   /**
    * @brief Checks, if specific head unit is present in PT

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -451,9 +451,13 @@ class PolicyManagerImpl : public PolicyManager {
                      const std::string& wers_country_code,
                      const std::string& language) OVERRIDE;
 
+  void SetHardwareVersion(const std::string& hardware_version) OVERRIDE;
+
   void SetPreloadedPtFlag(const bool is_preloaded) OVERRIDE;
 
   std::string GetCCPUVersionFromPT() const OVERRIDE;
+
+  std::string GetHardwareVersionFromPT() const OVERRIDE;
 
   /**
    * @brief Get number of notification by priority

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -430,6 +430,7 @@ struct ModuleMeta : CompositeType {
   Optional<Integer<uint16_t, 0, 65535> > pt_exchanged_x_days_after_epoch;
   Optional<Integer<uint16_t, 0, 65535> > ignition_cycles_since_last_exchange;
   Optional<String<0, 500> > ccpu_version;
+  Optional<String<0, 500> > hardware_version;
 
  public:
   ModuleMeta();

--- a/src/components/policy/policy_regular/include/policy/pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/pt_representation.h
@@ -152,10 +152,16 @@ class PTRepresentation {
   virtual EndpointUrls GetUpdateUrls(int service_type) = 0;
 
   /**
-   * @brief Records information about head unit system to PT
+   * @brief Records mandatory information about head unit system to PT
    * @return bool Success of operation
    */
   virtual bool SetMetaInfo(const std::string& ccpu_version) = 0;
+
+  /**
+   * @brief Records information about hardware version to PT
+   * @param hardware_version Hardware version
+   */
+  virtual void SetHardwareVersion(const std::string& hardware_version) = 0;
 
   /**
    * @brief Get allowed number of notifications

--- a/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_queries.h
@@ -145,6 +145,7 @@ extern const std::string kUpdateDBVersion;
 extern const std::string kSaveModuleMeta;
 extern const std::string kSelectModuleMeta;
 extern const std::string kUpdateMetaParams;
+extern const std::string kUpdateMetaHardwareVersion;
 extern const std::string kInsertVehicleDataItem;
 extern const std::string kSelectVehicleDataItem;
 extern const std::string kDeleteVehicleDataItems;

--- a/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
+++ b/src/components/policy/policy_regular/include/policy/sql_pt_representation.h
@@ -90,7 +90,8 @@ class SQLPTRepresentation : public virtual PTRepresentation {
                          StringArray* nicknames = NULL,
                          StringArray* app_hmi_types = NULL);
   bool GetFunctionalGroupings(policy_table::FunctionalGroupings& groups);
-  bool SetMetaInfo(const std::string& ccpu_version);
+  bool SetMetaInfo(const std::string& ccpu_version) OVERRIDE;
+  void SetHardwareVersion(const std::string& hardware_version) OVERRIDE;
 #ifdef BUILD_TESTS
   uint32_t open_counter() {
     return open_counter_;

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1337,7 +1337,7 @@ void CacheManager::PersistData() {
       }
 
       backup_->SetMetaInfo(*(*copy_pt.policy_table.module_meta).ccpu_version);
-      ex_backup_->SetHardwareVersion(
+      backup_->SetHardwareVersion(
           *(*copy_pt.policy_table.module_meta).hardware_version);
 
       // In case of extended policy the meta info should be backuped as well.

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -1337,6 +1337,8 @@ void CacheManager::PersistData() {
       }
 
       backup_->SetMetaInfo(*(*copy_pt.policy_table.module_meta).ccpu_version);
+      ex_backup_->SetHardwareVersion(
+          *(*copy_pt.policy_table.module_meta).hardware_version);
 
       // In case of extended policy the meta info should be backuped as well.
       backup_->WriteDb();
@@ -1490,11 +1492,31 @@ bool CacheManager::SetMetaInfo(const std::string& ccpu_version,
   return true;
 }
 
+void CacheManager::SetHardwareVersion(const std::string& hardware_version) {
+  SDL_LOG_AUTO_TRACE();
+  CACHE_MANAGER_CHECK_VOID();
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+
+  *pt_->policy_table.module_meta->hardware_version = hardware_version;
+  Backup();
+}
+
 std::string CacheManager::GetCCPUVersionFromPT() const {
   SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+
   rpc::Optional<policy_table::ModuleMeta>& module_meta =
       pt_->policy_table.module_meta;
   return *(module_meta->ccpu_version);
+}
+
+std::string CacheManager::GetHardwareVersionFromPT() const {
+  SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+
+  rpc::Optional<policy_table::ModuleMeta>& module_meta =
+      pt_->policy_table.module_meta;
+  return *(module_meta->hardware_version);
 }
 
 bool CacheManager::IsMetaInfoPresent() const {

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -1217,9 +1217,20 @@ void PolicyManagerImpl::SetSystemInfo(const std::string& ccpu_version,
   cache_->SetMetaInfo(ccpu_version, wers_country_code, language);
 }
 
+void PolicyManagerImpl::SetHardwareVersion(
+    const std::string& hardware_version) {
+  SDL_LOG_AUTO_TRACE();
+  cache_->SetHardwareVersion(hardware_version);
+}
+
 std::string PolicyManagerImpl::GetCCPUVersionFromPT() const {
   SDL_LOG_AUTO_TRACE();
   return cache_->GetCCPUVersionFromPT();
+}
+
+std::string PolicyManagerImpl::GetHardwareVersionFromPT() const {
+  SDL_LOG_AUTO_TRACE();
+  return cache_->GetHardwareVersionFromPT();
 }
 
 uint32_t PolicyManagerImpl::GetNotificationsNumber(const std::string& priority,

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -1297,7 +1297,8 @@ ModuleMeta::ModuleMeta(const Json::Value* value__)
           impl::ValueMember(value__, "pt_exchanged_x_days_after_epoch"))
     , ignition_cycles_since_last_exchange(
           impl::ValueMember(value__, "ignition_cycles_since_last_exchange"))
-    , ccpu_version(impl::ValueMember(value__, "ccpu_version")) {}
+    , ccpu_version(impl::ValueMember(value__, "ccpu_version"))
+    , hardware_version(impl::ValueMember(value__, "hardware_version")) {}
 
 Json::Value ModuleMeta::ToJsonValue() const {
   Json::Value result__(Json::objectValue);
@@ -1317,6 +1318,9 @@ bool ModuleMeta::is_valid() const {
     return initialization_state__ == kInitialized && Validate();
   }
   if (!ccpu_version.is_valid()) {
+    return false;
+  }
+  if (!hardware_version.is_valid()) {
     return false;
   }
   if (!pt_exchanged_at_odometer_x.is_valid()) {
@@ -1339,6 +1343,9 @@ bool ModuleMeta::struct_empty() const {
   if (ccpu_version.is_initialized()) {
     return false;
   }
+  if (hardware_version.is_initialized()) {
+    return false;
+  }
   if (pt_exchanged_at_odometer_x.is_initialized()) {
     return false;
   }
@@ -1358,6 +1365,10 @@ void ModuleMeta::ReportErrors(rpc::ValidationReport* report__) const {
   }
   if (!ccpu_version.is_valid()) {
     ccpu_version.ReportErrors(&report__->ReportSubobject("ccpu_version"));
+  }
+  if (!hardware_version.is_valid()) {
+    hardware_version.ReportErrors(
+        &report__->ReportSubobject("hardware_version"));
   }
   if (!pt_exchanged_at_odometer_x.is_valid()) {
     pt_exchanged_at_odometer_x.ReportErrors(

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -60,7 +60,8 @@ const std::string kCreateSchema =
     "  `pt_exchanged_x_days_after_epoch` INTEGER NOT NULL DEFAULT 0, "
     "  `ignition_cycles_since_last_exchange` INTEGER NOT NULL DEFAULT 0, "
     "  `flag_update_required` BOOL NOT NULL, "
-    "  `ccpu_version` VARCHAR(45) "
+    "  `ccpu_version` VARCHAR(45), "
+    "  `hardware_version` VARCHAR(45) "
     "); "
     "CREATE TABLE IF NOT EXISTS `module_config`( "
     "  `preloaded_pt` BOOL NOT NULL, "
@@ -1076,10 +1077,16 @@ const std::string kSaveModuleMeta =
     "`pt_exchanged_x_days_after_epoch` = ?, "
     "`ignition_cycles_since_last_exchange` = ? ";
 
-const std::string kSelectModuleMeta = "SELECT* FROM `module_meta`";
+const std::string kSelectModuleMeta =
+    "SELECT `ccpu_version`, `hardware_version`, `pt_exchanged_at_odometer_x`, "
+    "`pt_exchanged_x_days_after_epoch`, `ignition_cycles_since_last_exchange` "
+    "FROM `module_meta`";
 
 const std::string kUpdateMetaParams =
     "UPDATE `module_meta` SET "
     "`ccpu_version` = ? ";
+
+const std::string kUpdateMetaHardwareVersion =
+    "UPDATE `module_meta` SET `hardware_version` = ? ";
 }  // namespace sql_pt
 }  // namespace policy

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -472,10 +472,11 @@ void SQLPTRepresentation::GatherModuleMeta(
   SDL_LOG_INFO("Gather Module Meta Info");
   utils::dbms::SQLQuery query(db());
   if (query.Prepare(sql_pt::kSelectModuleMeta) && query.Next()) {
-    *meta->pt_exchanged_at_odometer_x = query.GetInteger(0);
-    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(1);
-    *meta->ignition_cycles_since_last_exchange = query.GetInteger(2);
-    *meta->ccpu_version = query.GetString(4);
+    *meta->ccpu_version = query.GetString(0);
+    *meta->hardware_version = query.GetString(1);
+    *meta->pt_exchanged_at_odometer_x = query.GetInteger(2);
+    *meta->pt_exchanged_x_days_after_epoch = query.GetInteger(3);
+    *meta->ignition_cycles_since_last_exchange = query.GetInteger(4);
   }
 }
 
@@ -714,6 +715,22 @@ bool SQLPTRepresentation::SetMetaInfo(const std::string& ccpu_version) {
     return false;
   }
   return true;
+}
+
+void SQLPTRepresentation::SetHardwareVersion(
+    const std::string& hardware_version) {
+  SDL_LOG_AUTO_TRACE();
+  utils::dbms::SQLQuery query(db());
+  if (!query.Prepare(sql_pt::kUpdateMetaHardwareVersion)) {
+    SDL_LOG_WARN("Incorrect statement for insert to module meta.");
+    return;
+  }
+
+  query.Bind(0, hardware_version);
+
+  if (!query.Exec()) {
+    SDL_LOG_WARN("Incorrect insert to module meta.");
+  }
 }
 
 bool SQLPTRepresentation::GatherApplicationPoliciesSection(

--- a/src/components/policy/policy_regular/test/cache_manager_test.cc
+++ b/src/components/policy/policy_regular/test/cache_manager_test.cc
@@ -1235,6 +1235,18 @@ TEST_F(CacheManagerTest, IsApplicationRepresented_DeviceApp_ReturnTrue) {
   EXPECT_TRUE(cache_manager_->IsApplicationRepresented(kDeviceId));
 }
 
+TEST_F(CacheManagerTest, GetHardwareVersion_ValueWasSetBefore_ReturnValue) {
+  std::string hardware_version = "1.1.1.1";
+  cache_manager_->SetHardwareVersion(hardware_version);
+  EXPECT_EQ(hardware_version, cache_manager_->GetHardwareVersionFromPT());
+}
+
+TEST_F(CacheManagerTest,
+       GetHardwareVersion_ValueNotSettedBefore_ReturnEmptyString) {
+  std::string empty_string = "";
+  EXPECT_EQ(empty_string, cache_manager_->GetHardwareVersionFromPT());
+}
+
 }  // namespace policy_test
 }  // namespace components
 }  // namespace test

--- a/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
+++ b/src/components/policy/policy_regular/test/policy_manager_impl_test.cc
@@ -599,20 +599,6 @@ TEST_F(PolicyManagerImplTest, GetHMITypes_ValidHmiTypes_ReturnTrue) {
   EXPECT_TRUE(policy_manager_->GetHMITypes(kValidAppId, &app_types));
 }
 
-TEST_F(PolicyManagerImplTest, SetMetaInfo_SetCCPUVersion_SUCCESS) {
-  const std::string ccpu_version = "ccpu_version";
-  const std::string wers_country_code = "wersCountryCode";
-  const std::string language = "language";
-
-  EXPECT_CALL(*mock_cache_manager_,
-              SetMetaInfo(ccpu_version, wers_country_code, language));
-  policy_manager_->SetSystemInfo(ccpu_version, wers_country_code, language);
-
-  EXPECT_CALL(*mock_cache_manager_, GetCCPUVersionFromPT())
-      .WillOnce(Return(ccpu_version));
-  EXPECT_EQ(ccpu_version, policy_manager_->GetCCPUVersionFromPT());
-}
-
 }  // namespace policy_test
 }  // namespace components
 }  // namespace test

--- a/src/components/utils/test/policy.sql
+++ b/src/components/utils/test/policy.sql
@@ -22,6 +22,7 @@ BEGIN TRANSACTION;
     `ccpu_version` VARCHAR(45), 
     `language` VARCHAR(45), 
     `wers_country_code` VARCHAR(45), 
+    `hardware_version` VARCHAR(45),
     `pt_exchanged_at_odometer_x` INTEGER NOT NULL DEFAULT 0, 
     `pt_exchanged_x_days_after_epoch` INTEGER NOT NULL DEFAULT 0, 
     `ignition_cycles_since_last_exchange` INTEGER NOT NULL DEFAULT 0, 


### PR DESCRIPTION
Fixes [FORDTCN-11076](https://adc.luxoft.com/jira/browse/FORDTCN-11076)

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Covered by ATF test scripts

### Summary
1. Handle new new hardware version parameter in GetSystemInfo response
2. Support sending new hardware version parameter to mobile via RAI
3. Support processing new hardware version parameter in SQL database
4. Add new hardware version parameter to snapshot under External policy flow

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
