### PR TITLE
fix respond on SDL.GetListOfPermission request

### DIFF
--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -876,19 +876,21 @@ class PolicyHandler : public PolicyHandlerInterface,
   /**
    * @brief Collects permissions for all currently registered applications on
    * all devices
-   * @return consolidated permissions list or empty list if no
-   * applications/devices currently present
+   * @param outPermissions output ref on list of application permissions
+   * @return true if app connection information is valid, otherwise - false
    */
-  std::vector<FunctionalGroupPermission> CollectRegisteredAppsPermissions();
+  bool CollectRegisteredAppsPermissions(
+      std::vector<FunctionalGroupPermission>& outPermissions);
 
   /**
    * @brief Collects permissions for application with certain connection key
    * @param connection_key Connection key of application to look for
-   * @return list of application permissions or empty list if no such
-   * application found
+   * @param outPermissions output ref on list of application permissions
+   * @return true if app connection information is valid, otherwise - false
    */
-  std::vector<FunctionalGroupPermission> CollectAppPermissions(
-      const uint32_t connection_key);
+  bool CollectAppPermissions(
+      const uint32_t connection_key,
+      std::vector<policy::FunctionalGroupPermission>& outPermissions);
 
  private:
   static const std::string kLibrary;

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -866,12 +866,11 @@ void PolicyHandler::ExchangePolicyManager(
   atomic_policy_manager_.swap(policy_manager);
 }
 
-std::vector<policy::FunctionalGroupPermission>
-PolicyHandler::CollectRegisteredAppsPermissions() {
+bool PolicyHandler::CollectRegisteredAppsPermissions(
+    std::vector<FunctionalGroupPermission>& outPermissions) {
   SDL_LOG_AUTO_TRACE();
   const auto policy_manager = LoadPolicyManager();
-  POLICY_LIB_CHECK_OR_RETURN(policy_manager,
-                             std::vector<policy::FunctionalGroupPermission>());
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
   // If no specific app was passed, get permissions for all currently registered
   // applications
   sync_primitives::AutoLock lock(app_to_device_link_lock_);
@@ -887,14 +886,17 @@ PolicyHandler::CollectRegisteredAppsPermissions() {
         it->first, it->second, group_permissions);
     consolidator.Consolidate(group_permissions);
   }
-  return consolidator.GetConsolidatedPermissions();
+
+  outPermissions = consolidator.GetConsolidatedPermissions();
+  return true;
 }
 
-std::vector<FunctionalGroupPermission> PolicyHandler::CollectAppPermissions(
-    const uint32_t connection_key) {
+bool PolicyHandler::CollectAppPermissions(
+    const uint32_t connection_key,
+    std::vector<policy::FunctionalGroupPermission>& outPermissions) {
   std::vector<FunctionalGroupPermission> group_permissions;
   const auto policy_manager = LoadPolicyManager();
-  POLICY_LIB_CHECK_OR_RETURN(policy_manager, group_permissions);
+  POLICY_LIB_CHECK_OR_RETURN(policy_manager, false);
 
   // Single app only
   ApplicationSharedPtr app = application_manager_.application(connection_key);
@@ -905,7 +907,7 @@ std::vector<FunctionalGroupPermission> PolicyHandler::CollectAppPermissions(
                  << "' "
                     "not found within registered applications.");
 
-    return group_permissions;
+    return false;
   }
 
   DeviceParams device_params = GetDeviceParams(
@@ -914,14 +916,13 @@ std::vector<FunctionalGroupPermission> PolicyHandler::CollectAppPermissions(
 
   if (device_params.device_mac_address.empty()) {
     SDL_LOG_WARN("Couldn't find device, which hosts application.");
-    return group_permissions;
+    return false;
   }
 
-  policy_manager->GetUserConsentForApp(device_params.device_mac_address,
-                                       app->policy_app_id(),
-                                       group_permissions);
+  policy_manager->GetUserConsentForApp(
+      device_params.device_mac_address, app->policy_app_id(), outPermissions);
 
-  return group_permissions;
+  return true;
 }
 
 void PolicyHandler::OnGetListOfPermissions(const uint32_t connection_key,
@@ -935,23 +936,26 @@ void PolicyHandler::OnGetListOfPermissions(const uint32_t connection_key,
   const bool is_app_registered = NULL != app.get();
   const bool is_connection_key_valid = is_app_registered && connection_key;
 
-  const std::vector<policy::FunctionalGroupPermission> permissions =
-      is_connection_key_valid ? CollectAppPermissions(connection_key)
-                              : CollectRegisteredAppsPermissions();
+  std::vector<policy::FunctionalGroupPermission> permissions;
 
-  if (permissions.empty() && is_connection_key_valid) {
-    SDL_LOG_ERROR("No permissions found for application with connection key:"
-                  << connection_key);
-    return;
-  }
+  const bool collect_result =
+      is_connection_key_valid
+          ? CollectAppPermissions(connection_key, permissions)
+          : CollectRegisteredAppsPermissions(permissions);
 
-  MessageHelper::SendGetListOfPermissionsResponse(
-      permissions,
+  if (collect_result) {
+    MessageHelper::SendGetListOfPermissionsResponse(
+        permissions,
 #ifdef EXTERNAL_PROPRIETARY_MODE
-      policy_manager->GetExternalConsentStatus(),
+        policy_manager->GetExternalConsentStatus(),
 #endif  // EXTERNAL_PROPRIETARY_MODE
-      correlation_id,
-      application_manager_);
+        correlation_id,
+        application_manager_);
+  } else {
+    SDL_LOG_ERROR(
+        "Permissions collection failed for application with connection key:"
+        << connection_key);
+  }
 }
 
 void PolicyHandler::LinkAppsToDevice() {

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1612,6 +1612,22 @@ TEST_F(PolicyHandlerTest, OnGetListOfPermissions) {
   policy_handler_.OnGetListOfPermissions(app_id, corr_id);
 }
 
+TEST_F(PolicyHandlerTest, OnGetListOfPermissions_CollectResult_false) {
+  // Arrange
+  EnablePolicyAndPolicyManagerMock();
+
+  const uint32_t app_id = 10u;
+  const uint32_t corr_id = 1u;
+  test_app.insert(mock_app_);
+
+  // Expectations
+  EXPECT_CALL(app_manager_, application(app_id))
+      .WillOnce(Return(mock_app_))
+      .WillOnce(Return(nullptr));
+
+  policy_handler_.OnGetListOfPermissions(app_id, corr_id);
+}
+
 TEST_F(PolicyHandlerTest, OnGetListOfPermissions_WithoutConnectionKey) {
   // Arrange
   EnablePolicyAndPolicyManagerMock();

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -292,6 +292,10 @@ class PolicyHandlerTest : public ::testing::Test {
   }
 };
 
+ACTION_P(SetDeviceParamsMacAdress, mac_adress) {
+  *arg3 = mac_adress;
+}
+
 TEST_F(PolicyHandlerTest, LoadPolicyLibrary_Method_ExpectLibraryLoaded) {
   // Check before policy enabled from ini file
   EXPECT_CALL(policy_settings_, enable_policy()).WillRepeatedly(Return(false));
@@ -1620,10 +1624,29 @@ TEST_F(PolicyHandlerTest, OnGetListOfPermissions_CollectResult_false) {
   const uint32_t corr_id = 1u;
   test_app.insert(mock_app_);
 
-  // Expectations
   EXPECT_CALL(app_manager_, application(app_id))
-      .WillOnce(Return(mock_app_))
-      .WillOnce(Return(nullptr));
+      .WillRepeatedly(Return(mock_app_));
+  EXPECT_CALL(conn_handler, get_session_observer())
+      .WillOnce(ReturnRef(mock_session_observer));
+  EXPECT_CALL(*mock_app_, device()).WillOnce(Return(0));
+  EXPECT_CALL(mock_session_observer,
+              GetDataOnDeviceID(
+                  testing::An<transport_manager::DeviceHandle>(), _, _, _, _))
+      .WillRepeatedly(
+          DoAll(SetDeviceParamsMacAdress(std::string()), (Return(1u))));
+
+#ifdef EXTERNAL_PROPRIETARY_MODE
+  policy::ExternalConsentStatus external_consent_status =
+      policy::ExternalConsentStatus();
+  EXPECT_CALL(
+      mock_message_helper_,
+      SendGetListOfPermissionsResponse(_, external_consent_status, corr_id, _))
+      .Times(0);
+#else
+  EXPECT_CALL(mock_message_helper_,
+              SendGetListOfPermissionsResponse(_, corr_id, _))
+      .Times(0);
+#endif  // #ifdef EXTERNAL_PROPRIETARY_MODE
 
   policy_handler_.OnGetListOfPermissions(app_id, corr_id);
 }
@@ -2358,10 +2381,6 @@ TEST_F(PolicyHandlerTest,
 #endif
 
   EXPECT_FALSE(waiter->WaitFor(kCallsCount_, kTimeout_));
-}
-
-ACTION_P(SetDeviceParamsMacAdress, mac_adress) {
-  *arg3 = mac_adress;
 }
 
 TEST_F(PolicyHandlerTest,

--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -1596,6 +1596,19 @@ TEST_F(PolicyHandlerTest, OnGetListOfPermissions) {
               GetDataOnDeviceID(
                   testing::An<transport_manager::DeviceHandle>(), _, _, _, _));
 
+#ifdef EXTERNAL_PROPRIETARY_MODE
+  policy::ExternalConsentStatus external_consent_status =
+      policy::ExternalConsentStatus();
+  EXPECT_CALL(
+      mock_message_helper_,
+      SendGetListOfPermissionsResponse(_, external_consent_status, corr_id, _));
+  EXPECT_CALL(*mock_policy_manager_, GetExternalConsentStatus())
+      .WillOnce(Return(external_consent_status));
+#else
+  EXPECT_CALL(mock_message_helper_,
+              SendGetListOfPermissionsResponse(_, corr_id, _));
+#endif  // #ifdef EXTERNAL_PROPRIETARY_MODE
+
   policy_handler_.OnGetListOfPermissions(app_id, corr_id);
 }
 

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1589,7 +1589,6 @@ void PolicyManagerImpl::GetPermissionsForApp(
     FillFunctionalGroupPermissions(
         all_disallowed, group_names, kGroupDisallowed, permissions);
   }
-  return;
 }
 
 std::string& PolicyManagerImpl::GetCurrentDeviceId(


### PR DESCRIPTION
This PR fixes respond to SDL.GetListOfPermission in case there are no specific permissions for the app.

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Will be tested manually

### Summary
There was noticed an incorrect behavior in PolicyHandler::OnGetListOfPermissions method. 
No response was sent if the list of permission was empty.
In this fix we check if we went through all the methods for filling the List Of Permissions and didn't cause an error, then we send an empty list.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
