### PR TITLE
Prevent resumption of default keyboard properties after reset

### DIFF
--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -408,6 +408,8 @@ MessageHelper::CreateUIResetGlobalPropertiesRequest(
     key_board_properties[strings::auto_complete_text] = "";
     (*ui_reset_global_prop_request)[hmi_request::keyboard_properties] =
         key_board_properties;
+    application->set_keyboard_props(
+        smart_objects::SmartObject(smart_objects::SmartType_Null));
   }
 
   (*ui_reset_global_prop_request)[strings::app_id] = application->app_id();


### PR DESCRIPTION
Fixes [FORDTCN-11043](https://adc.luxoft.com/jira/browse/FORDTCN-11043)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by ATF test script

### Summary
There is an issue when after reset of keyboard properties previously saved values are still resumed instead of default ones. Root cause of this situation is ignoring of keyboard properties cache during reset of keyboard properties. Previously this cache wasn't emptied during reset, so it continued to store outdated application defined data. This cache is also used as data source for resumption, that's why we need to empty this cache after reset, because we don't need to re-send requests with default keyboard properties.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
