### PR TITLE
Add new parameter enable_seek and OnSeekMediaClockTimer notification

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/smartdevicelink/jsoncpp.git
 [submodule "tools/rpc_spec"]
 	path = tools/rpc_spec
-	url = https://github.com/smartdevicelink/rpc_spec.git
+	url = https://github.com/LuxoftSDL/rpc_spec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/smartdevicelink/jsoncpp.git
 [submodule "tools/rpc_spec"]
 	path = tools/rpc_spec
-	url = https://github.com/LuxoftSDL/rpc_spec.git
+	url = https://github.com/smartdevicelink/rpc_spec.git

--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -443,7 +443,11 @@
                             "LIMITED",
                             "BACKGROUND"
                         ]
+                    },
+                    "OnSeekMediaClockTimer": {
+                        "hmi_levels": ["FULL"]
                     }
+
                 }
             },
             "Location-1": {

--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -634,6 +634,18 @@ class Application : public virtual InitialApplicationData,
   virtual void set_audio_streaming_allowed(bool state) = 0;
 
   /**
+   * @brief set_seek_enabled Set seek enabled for application
+   * @param seek_enabled
+   */
+  virtual void set_seek_enabled(bool seek_enabled) = 0;
+
+  /**
+   * @brief seek_enabled
+   * @return true if seek enabled
+   */
+  virtual bool seek_enabled() const = 0;
+
+  /**
    * @brief Sends SetVideoConfig request to HMI to configure streaming
    * @param service_type Type of streaming service, should be kMobileNav
    * @param params parameters of video streaming in key-value format

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -136,16 +136,7 @@ class ApplicationImpl : public virtual Application,
   bool audio_streaming_allowed() const;
   void set_audio_streaming_allowed(bool state);
 
-  /**
-   * @brief set_seek_enabled Set seek enabled for application
-   * @param seek_enabled
-   */
   void set_seek_enabled(bool seek_enabled) OVERRIDE;
-
-  /**
-   * @brief seek_enabled
-   * @return true if seek enabled
-   */
   bool seek_enabled() const OVERRIDE;
 
   bool SetVideoConfig(protocol_handler::ServiceType service_type,

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -136,6 +136,18 @@ class ApplicationImpl : public virtual Application,
   bool audio_streaming_allowed() const;
   void set_audio_streaming_allowed(bool state);
 
+  /**
+   * @brief set_seek_enabled Set seek enabled for application
+   * @param seek_enabled
+   */
+  void set_seek_enabled(bool seek_enabled) OVERRIDE;
+
+  /**
+   * @brief seek_enabled
+   * @return true if seek enabled
+   */
+  bool seek_enabled() const OVERRIDE;
+
   bool SetVideoConfig(protocol_handler::ServiceType service_type,
                       const smart_objects::SmartObject& params);
   void StartStreaming(protocol_handler::ServiceType service_type);
@@ -570,6 +582,7 @@ class ApplicationImpl : public virtual Application,
   bool is_remote_control_supported_;
   bool mobile_projection_enabled_;
   bool webengine_projection_enabled_;
+  bool seek_enabled_;
 
   bool video_streaming_approved_;
   bool audio_streaming_approved_;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -232,7 +232,6 @@ extern const char* displays;
 extern const char* seat_location;
 extern const char* app_capability;
 extern const char* app_capability_type;
-extern const char* seekTime;
 extern const char* enable_seek;
 
 // PutFile

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -232,6 +232,8 @@ extern const char* displays;
 extern const char* seat_location;
 extern const char* app_capability;
 extern const char* app_capability_type;
+extern const char* seekTime;
+extern const char* enable_seek;
 
 // PutFile
 extern const char* sync_file_name;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_seek_media_clock_timer_notification.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_seek_media_clock_timer_notification.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+
+#include "application_manager/application_manager.h"
+#include "application_manager/commands/notification_from_hmi.h"
+namespace sdl_rpc_plugin {
+
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+namespace hmi {
+/**
+ * @brief OnSeekMediaClockTimerNotification command class
+ **/
+class OnSeekMediaClockTimerNotification
+    : public app_mngr::commands::NotificationFromHMI {
+ public:
+  /**
+   * @brief OnSeekMediaClockTimerNotification class constructor
+   * @param message Incoming SmartObject message
+   * @param application_manager reference to ApplicationManager instance
+   * @param rpc_service reference to RPCService instance
+   * @param hmi_capabilities reference to HMICapabilities instance
+   * @param policy_handle reference to PolicyHandler instance
+   **/
+  OnSeekMediaClockTimerNotification(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  /**
+   * @brief OnSeekMediaClockTimerNotification class destructor
+   **/
+  virtual ~OnSeekMediaClockTimerNotification();
+
+  /**
+   * @brief Execute command
+   **/
+  void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnSeekMediaClockTimerNotification);
+};
+
+}  // namespace hmi
+
+}  // namespace commands
+
+}  // namespace sdl_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/on_seek_media_clock_timer_notification.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/on_seek_media_clock_timer_notification.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_
+
+#include "application_manager/commands/command_notification_impl.h"
+#include "utils/macro.h"
+
+namespace sdl_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+namespace mobile {
+
+/**
+ * @brief OnSeekMediaClockTimerNotification class
+ **/
+class OnSeekMediaClockTimerNotification
+    : public app_mngr::commands::CommandNotificationImpl {
+ public:
+  /**
+   * @brief OnSeekMediaClockTimerNotification class constructor
+   * @param message Incoming SmartObject message
+   * @param application_manager reference to ApplicationManager instance
+   * @param rpc_service reference to RPCService instance
+   * @param hmi_capabilities reference to HMICapabilities instance
+   * @param policy_handle reference to PolicyHandler instance
+   **/
+  OnSeekMediaClockTimerNotification(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handler);
+
+  /**
+   * @brief OnSeekMediaClockTimerNotification class destructor
+   **/
+  virtual ~OnSeekMediaClockTimerNotification();
+  /**
+   * @brief Execute command
+   **/
+  void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnSeekMediaClockTimerNotification);
+};
+
+}  // namespace mobile
+
+}  // namespace commands
+
+}  // namespace sdl_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_ON_SEEK_MEDIA_CLOCK_TIMER_NOTIFICATION_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_seek_media_clock_timer_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_seek_media_clock_timer_notification.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "sdl_rpc_plugin/commands/hmi/on_seek_media_clock_timer_notification.h"
+
+namespace sdl_rpc_plugin {
+using namespace application_manager;
+
+namespace commands {
+
+namespace hmi {
+
+SDL_CREATE_LOG_VARIABLE("Commands")
+
+OnSeekMediaClockTimerNotification::OnSeekMediaClockTimerNotification(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    rpc_service::RPCService& rpc_service,
+    HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handle)
+    : NotificationFromHMI(message,
+                          application_manager,
+                          rpc_service,
+                          hmi_capabilities,
+                          policy_handle) {}
+
+OnSeekMediaClockTimerNotification::~OnSeekMediaClockTimerNotification() {}
+void OnSeekMediaClockTimerNotification::Run() {
+  SDL_LOG_AUTO_TRACE();
+
+  (*message_)[strings::params][strings::function_id] =
+      static_cast<int32_t>(mobile_apis::FunctionID::OnSeekMediaClockTimerID);
+
+  SendNotificationToMobile(message_);
+}
+
+}  // namespace hmi
+
+}  // namespace commands
+
+}  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_seek_media_clock_timer_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_seek_media_clock_timer_notification.cc
@@ -72,7 +72,7 @@ void OnSeekMediaClockTimerNotification::Run() {
     return;
   }
 
-  (*message_)[strings::params][strings::connection_key] = app->app_id();
+  (*message_)[strings::params][strings::connection_key] = app_id;
   SendNotification();
 }
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_seek_media_clock_timer_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/on_seek_media_clock_timer_notification.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "sdl_rpc_plugin/commands/mobile/on_seek_media_clock_timer_notification.h"
+#include "application_manager/application_impl.h"
+
+namespace sdl_rpc_plugin {
+using namespace application_manager;
+
+namespace commands {
+
+namespace mobile {
+
+SDL_CREATE_LOG_VARIABLE("Commands")
+
+OnSeekMediaClockTimerNotification::OnSeekMediaClockTimerNotification(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    app_mngr::rpc_service::RPCService& rpc_service,
+    app_mngr::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : CommandNotificationImpl(message,
+                              application_manager,
+                              rpc_service,
+                              hmi_capabilities,
+                              policy_handler) {}
+
+OnSeekMediaClockTimerNotification::~OnSeekMediaClockTimerNotification() {}
+
+void OnSeekMediaClockTimerNotification::Run() {
+  SDL_LOG_AUTO_TRACE();
+
+  const int32_t app_id =
+      (*message_)[strings::msg_params][strings::app_id].asInt();
+  auto app = application_manager_.application(app_id);
+
+  if (!app) {
+    SDL_LOG_ERROR("No application associated with session key");
+    return;
+  }
+
+  if (!app->seek_enabled()) {
+    SDL_LOG_WARN("Enable seek parameter was set to false");
+    return;
+  }
+
+  (*message_)[strings::params][strings::connection_key] = app->app_id();
+  SendNotification();
+}
+
+}  // namespace mobile
+
+}  // namespace commands
+
+}  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_media_clock_timer_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_media_clock_timer_request.cc
@@ -84,6 +84,11 @@ void SetMediaClockRequest::Run() {
     msg_params[strings::app_id] = app->app_id();
     StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
 
+    if (msg_params.keyExists(strings::enable_seek)) {
+      auto enable_seek = msg_params[strings::enable_seek].asBool();
+      app->set_seek_enabled(enable_seek);
+    }
+
     SendHMIRequest(
         hmi_apis::FunctionID::UI_SetMediaClockTimer, &msg_params, true);
   } else {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/hmi_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/hmi_command_factory.cc
@@ -62,6 +62,7 @@
 #include "sdl_rpc_plugin/commands/hmi/on_put_file_notification.h"
 #include "sdl_rpc_plugin/commands/hmi/on_resume_audio_source_notification.h"
 #include "sdl_rpc_plugin/commands/hmi/on_sdl_consent_needed_notification.h"
+#include "sdl_rpc_plugin/commands/hmi/on_seek_media_clock_timer_notification.h"
 #include "sdl_rpc_plugin/commands/hmi/on_start_device_discovery.h"
 #include "sdl_rpc_plugin/commands/hmi/on_status_update_notification.h"
 #include "sdl_rpc_plugin/commands/hmi/on_system_info_changed_notification.h"
@@ -687,6 +688,10 @@ CommandCreator& HMICommandFactory::get_creator_factory(
     }
     case hmi_apis::FunctionID::SDL_OnSDLConsentNeeded: {
       return factory.GetCreator<commands::OnSDLConsentNeededNotification>();
+    }
+    case hmi_apis::FunctionID::UI_OnSeekMediaClockTimer: {
+      return factory
+          .GetCreator<commands::hmi::OnSeekMediaClockTimerNotification>();
     }
     case hmi_apis::FunctionID::SDL_UpdateSDL: {
       return hmi_apis::messageType::request == message_type

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
@@ -89,6 +89,7 @@
 #include "sdl_rpc_plugin/commands/mobile/on_keyboard_input_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_language_change_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_permissions_change_notification.h"
+#include "sdl_rpc_plugin/commands/mobile/on_seek_media_clock_timer_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_subtle_alert_pressed_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_system_capability_updated_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/on_system_request_notification.h"
@@ -470,6 +471,10 @@ CommandCreator& MobileCommandFactory::get_notification_creator(
     }
     case mobile_apis::FunctionID::OnWayPointChangeID: {
       return factory.GetCreator<commands::OnWayPointChangeNotification>();
+    }
+    case mobile_apis::FunctionID::OnSeekMediaClockTimerID: {
+      return factory
+          .GetCreator<commands::mobile::OnSeekMediaClockTimerNotification>();
     }
     case mobile_apis::FunctionID::OnUpdateFileID: {
       return factory.GetCreator<commands::OnUpdateFileNotification>();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_seek_media_clock_timer_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_seek_media_clock_timer_notification_test.cc
@@ -84,11 +84,11 @@ class OnSeekMediaClockTimerNotificationTest
  private:
   void CreateBasicMessage() {
     commands_msg = CreateMessage(smart_objects::SmartType_Map);
-    (*commands_msg)[am::strings::msg_params][am::strings::seekTime]
+    (*commands_msg)[am::strings::msg_params][am::strings::seek_time]
                    [am::strings::hours] = kHours;
-    (*commands_msg)[am::strings::msg_params][am::strings::seekTime]
+    (*commands_msg)[am::strings::msg_params][am::strings::seek_time]
                    [am::strings::minutes] = kMinutes;
-    (*commands_msg)[am::strings::msg_params][am::strings::seekTime]
+    (*commands_msg)[am::strings::msg_params][am::strings::seek_time]
                    [am::strings::seconds] = kSeconds;
     (*commands_msg)[am::strings::msg_params][am::strings::app_id] = kAppID;
   }
@@ -103,6 +103,32 @@ TEST_F(OnSeekMediaClockTimerNotificationTest,
   ON_CALL(*mock_app, seek_enabled()).WillByDefault(Return(true));
 
   EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(commands_msg, _));
+
+  command->Run();
+}
+
+TEST_F(OnSeekMediaClockTimerNotificationTest,
+       Run_SendNotificationToMobile_SeekDisabled) {
+  NotificationPtr command(
+      CreateCommand<OnSeekMediaClockTimerNotification>(commands_msg));
+
+  ON_CALL(app_mngr_, application(kAppID)).WillByDefault(Return(mock_app));
+  ON_CALL(*mock_app, seek_enabled()).WillByDefault(Return(false));
+
+  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(commands_msg, _)).Times(0);
+
+  command->Run();
+}
+
+TEST_F(OnSeekMediaClockTimerNotificationTest,
+       Run_SendNotificationToMobile_AppDoesntExist) {
+  NotificationPtr command(
+      CreateCommand<OnSeekMediaClockTimerNotification>(commands_msg));
+
+  ON_CALL(app_mngr_, application(kAppID)).WillByDefault(Return(nullptr));
+  ON_CALL(*mock_app, seek_enabled()).WillByDefault(Return(true));
+
+  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(commands_msg, _)).Times(0);
 
   command->Run();
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_seek_media_clock_timer_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_seek_media_clock_timer_notification_test.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string>
+
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/policies/mock_policy_handler_interface.h"
+#include "application_manager/smart_object_keys.h"
+#include "gtest/gtest.h"
+#include "interfaces/MOBILE_API.h"
+#include "mobile/on_seek_media_clock_timer_notification.h"
+#include "smart_objects/smart_object.h"
+#include "utils/data_accessor.h"
+#include "utils/lock.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace on_seek_media_clock_timer_notification {
+
+using ::testing::_;
+using ::testing::Eq;
+using ::testing::Return;
+namespace am = ::application_manager;
+using am::commands::MessageSharedPtr;
+using sdl_rpc_plugin::commands::mobile::OnSeekMediaClockTimerNotification;
+
+using namespace am::commands;
+
+const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 2u;
+const uint32_t kAppID = 2u;
+const uint32_t kHours = 2u;
+const uint32_t kMinutes = 26u;
+const uint32_t kSeconds = 1u;
+
+typedef std::shared_ptr<OnSeekMediaClockTimerNotification> NotificationPtr;
+
+class OnSeekMediaClockTimerNotificationTest
+    : public CommandsTest<CommandsTestMocks::kIsNice> {
+ public:
+  OnSeekMediaClockTimerNotificationTest() {
+    CreateBasicMessage();
+    mock_app = CreateMockApp();
+  }
+
+ public:
+  MessageSharedPtr commands_msg;
+  MockAppPtr mock_app;
+
+ private:
+  void CreateBasicMessage() {
+    commands_msg = CreateMessage(smart_objects::SmartType_Map);
+    (*commands_msg)[am::strings::msg_params][am::strings::seekTime]
+                   [am::strings::hours] = kHours;
+    (*commands_msg)[am::strings::msg_params][am::strings::seekTime]
+                   [am::strings::minutes] = kMinutes;
+    (*commands_msg)[am::strings::msg_params][am::strings::seekTime]
+                   [am::strings::seconds] = kSeconds;
+    (*commands_msg)[am::strings::msg_params][am::strings::app_id] = kAppID;
+  }
+};
+
+TEST_F(OnSeekMediaClockTimerNotificationTest,
+       Run_SendNotificationToMobile_SUCCESS) {
+  NotificationPtr command(
+      CreateCommand<OnSeekMediaClockTimerNotification>(commands_msg));
+
+  ON_CALL(app_mngr_, application(kAppID)).WillByDefault(Return(mock_app));
+  ON_CALL(*mock_app, seek_enabled()).WillByDefault(Return(true));
+
+  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(commands_msg, _));
+
+  command->Run();
+}
+
+}  // namespace on_seek_media_clock_timer_notification
+}  // namespace mobile_commands_test
+}  // namespace commands_test
+}  // namespace components
+}  // namespace test

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -107,6 +107,7 @@ ApplicationImpl::ApplicationImpl(
     , is_remote_control_supported_(false)
     , mobile_projection_enabled_(false)
     , webengine_projection_enabled_(false)
+    , seek_enabled_(false)
     , video_streaming_approved_(false)
     , audio_streaming_approved_(false)
     , video_streaming_allowed_(false)
@@ -307,6 +308,14 @@ void ApplicationImpl::set_webengine_projection_enabled(const bool option) {
 
 bool ApplicationImpl::webengine_projection_enabled() const {
   return webengine_projection_enabled_;
+}
+
+void ApplicationImpl::set_seek_enabled(bool seek_enabled) {
+  seek_enabled_ = seek_enabled;
+}
+
+bool ApplicationImpl::seek_enabled() const {
+  return seek_enabled_;
 }
 
 struct StateIDComparator {

--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -166,6 +166,7 @@ generate_function_to_interface_convert_map() {
   convert_map[UI_IsReady] = HmiInterfaces::HMI_INTERFACE_UI;
   convert_map[UI_ClosePopUp] = HmiInterfaces::HMI_INTERFACE_UI;
   convert_map[UI_OnResetTimeout] = HmiInterfaces::HMI_INTERFACE_UI;
+  convert_map[UI_OnSeekMediaClockTimer] = HmiInterfaces::HMI_INTERFACE_UI;
   convert_map[UI_SendHapticData] = HmiInterfaces::HMI_INTERFACE_UI;
   convert_map[Navigation_IsReady] = HmiInterfaces::HMI_INTERFACE_Navigation;
   convert_map[Navigation_SendLocation] =

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -200,7 +200,6 @@ const char* seat_location = "seatLocation";
 const char* app_capability = "appCapability";
 const char* app_capability_type = "appCapabilityType";
 const char* enable_seek = "enableSeek";
-const char* seekTime = "seekTime";
 
 // PutFile
 const char* sync_file_name = "syncFileName";

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -199,6 +199,8 @@ const char* displays = "displays";
 const char* seat_location = "seatLocation";
 const char* app_capability = "appCapability";
 const char* app_capability_type = "appCapabilityType";
+const char* enable_seek = "enableSeek";
+const char* seekTime = "seekTime";
 
 // PutFile
 const char* sync_file_name = "syncFileName";

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -436,6 +436,8 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD1(set_user_location,
                void(const smart_objects::SmartObject& user_location));
   MOCK_CONST_METHOD0(get_user_location, const smart_objects::SmartObject&());
+  MOCK_CONST_METHOD0(seek_enabled, bool());
+  MOCK_METHOD1(set_seek_enabled, void(bool seek_enabled));
 };
 
 }  // namespace application_manager_test

--- a/src/components/hmi_message_handler/src/messagebroker_adapter.cc
+++ b/src/components/hmi_message_handler/src/messagebroker_adapter.cc
@@ -147,6 +147,7 @@ void MessageBrokerAdapter::SubscribeTo() {
       "BasicCommunication.OnSystemCapabilityUpdated");
   MessageBrokerController::subscribeTo("UI.OnUpdateFile");
   MessageBrokerController::subscribeTo("UI.OnUpdateSubMenu");
+  MessageBrokerController::subscribeTo("UI.OnSeekMediaClockTimer");
 
   SDL_LOG_INFO("Subscribed to notifications.");
 }

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -5754,6 +5754,11 @@
     <param name="appID" type="Integer" mandatory="true">
       <description>ID of application that requested this RPC.</description>
     </param>
+        <param name="enableSeek" type="Boolean" mandatory="false">
+     <description>
+       Defines if seek media clock timer functionality will be available. If omitted, the value is set to false. The value is retained until the next SetMediaClockTimer is sent.
+     </description>
+    </param>
   </function>
   <function name="SetMediaClockTimer" messagetype="response">
   </function>
@@ -5793,6 +5798,14 @@
       <description>ID of application that is related to this RPC.</description>
     </param>
   </function>
+  <function name="OnSeekMediaClockTimer" messagetype="notification">
+    <param name="seekTime" type="Common.TimeFormat" mandatory="true">
+      <description>See TimeFormat.</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+      <description>The ID of application that relates to this media clock status change.</description>
+    </param>
+  </function>  
   <function name="OnSystemContext" messagetype="notification">
     <description>
       Notification must be initiated by HMI when the user changes the context of application: goes to menu (in-application menu or system menu);


### PR DESCRIPTION
Implements 1735

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
 ATF test scripts
 Manual testing
 Unit tests

### Summary
1. OnSeekMediaClockTime notification that will send the new start time to the app was implemented.
2. New parameter named "enableSeek" was added to SetMediaClockTimer request for enabling progress bar seek feature.
3. Related changes were added to HMI API.

Link to PR with changes in RPC Spec: **********

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
