### PR TITLE
[SDL-0189] Fix timeout for requests with consent

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_request.h
@@ -46,6 +46,11 @@ class ButtonPressRequest : public RCCommandRequest {
       const RCCommandParams& params);
 
   /**
+   * @brief Init command command
+   */
+  bool Init() FINAL;
+
+  /**
    * @brief Execute command
    * send HMI request if message contains appropriate
    * button name and module type

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_request.h
@@ -47,6 +47,11 @@ class SetInteriorVehicleDataRequest : public RCCommandRequest {
       const RCCommandParams& params);
 
   /**
+   * @brief Init command
+   */
+  bool Init() FINAL;
+
+  /**
    * @brief Execute command
    */
   void Execute() FINAL;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
@@ -130,6 +130,19 @@ class ResourceAllocationManager {
                               const std::string& module_id) const = 0;
 
   /**
+   * @brief IsResourceAllocated check if module is allocated by certain
+   * application
+   * @param module_type module to be checked
+   * @param module_id uuid of a resource to be checked
+   * @param app_id app to be checked
+   * @return true if module_type is allocated by application with provided
+   * app_id
+   */
+  virtual bool IsResourceAllocated(const std::string& module_type,
+                                   const std::string& module_id,
+                                   const uint32_t app_id) = 0;
+
+  /**
    * @brief AcquireResource forces acquiring resource by application
    * @param module_type resource to acquire
    * @param module_id uuid of a resource

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager_impl.h
@@ -94,6 +94,10 @@ class ResourceAllocationManagerImpl : public ResourceAllocationManager {
   bool IsResourceFree(const std::string& module_type,
                       const std::string& module_id) const FINAL;
 
+  bool IsResourceAllocated(const std::string& module_type,
+                           const std::string& module_id,
+                           const uint32_t app_id) FINAL;
+
   void SetAccessMode(
       const hmi_apis::Common_RCAccessMode::eType access_mode) FINAL;
 

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_request.cc
@@ -45,7 +45,10 @@ RCGetInteriorVehicleDataConsentRequest::RCGetInteriorVehicleDataConsentRequest(
                                                   params.application_manager_,
                                                   params.rpc_service_,
                                                   params.hmi_capabilities_,
-                                                  params.policy_handler_) {}
+                                                  params.policy_handler_) {
+  // Increase default timeout for user interaction.
+  default_timeout_ = default_timeout_ * 2;
+}
 
 RCGetInteriorVehicleDataConsentRequest::
     ~RCGetInteriorVehicleDataConsentRequest() {}

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
@@ -54,6 +54,21 @@ ButtonPressRequest::ButtonPressRequest(
 
 ButtonPressRequest::~ButtonPressRequest() {}
 
+bool ButtonPressRequest::Init() {
+  SDL_LOG_AUTO_TRACE();
+  // If driver permission is required, the SDL should increase the default
+  // timeout value by 2 times
+  auto access_mode = resource_allocation_manager_.GetAccessMode();
+
+  if (hmi_apis::Common_RCAccessMode::ASK_DRIVER == access_mode &&
+      resource_allocation_manager_.IsResourceAllocated(
+          ModuleType(), ModuleId(), connection_key())) {
+    const uint32_t increase_value = 2;
+    default_timeout_ *= increase_value;
+  }
+  return true;
+}
+
 std::string ButtonPressRequest::GetButtonName() const {
   mobile_apis::ButtonName::eType button_name =
       static_cast<mobile_apis::ButtonName::eType>(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -220,10 +220,6 @@ void SetInteriorVehicleDataRequest::Execute() {
       }
     }
 
-    const auto default_timeout =
-        application_manager_.get_settings().default_timeout();
-    application_manager_.UpdateRequestTimeout(
-        connection_key(), correlation_id(), default_timeout);
     (*message_)[app_mngr::strings::msg_params][message_params::kModuleData]
                [message_params::kModuleId] = module_id;
     SendHMIRequest(hmi_apis::FunctionID::RC_SetInteriorVehicleData,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/rc_command_request.cc
@@ -278,7 +278,12 @@ void RCCommandRequest::ProcessConsentResult(const bool is_allowed,
   SDL_LOG_AUTO_TRACE();
   if (is_allowed) {
     SetResourceState(module_type, ResourceState::BUSY);
+    const auto default_timeout =
+        application_manager_.get_settings().default_timeout();
+    application_manager_.UpdateRequestTimeout(
+        connection_key(), correlation_id(), default_timeout);
     Execute();  // run child's logic
+
   } else {
     resource_allocation_manager_.OnDriverDisallowed(
         module_type, module_id, app_id);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/resource_allocation_manager_impl.cc
@@ -486,6 +486,28 @@ bool ResourceAllocationManagerImpl::IsResourceFree(
   return ResourceState::FREE == resource->second;
 }
 
+bool ResourceAllocationManagerImpl::IsResourceAllocated(
+    const std::string& module_type,
+    const std::string& module_id,
+    const uint32_t app_id) {
+  ModuleUid module(module_type, module_id);
+  sync_primitives::AutoLock lock(allocated_resources_lock_);
+  const auto allocation = allocated_resources_.find(module);
+  if (allocated_resources_.end() == allocation) {
+    SDL_LOG_DEBUG("Resource " << module_type << " is not allocated.");
+    return false;
+  }
+
+  if (app_id != allocation->second) {
+    SDL_LOG_DEBUG("Resource " << module_type
+                              << " is allocated by different application "
+                              << allocation->second);
+    return true;
+  }
+
+  return false;
+}
+
 void ResourceAllocationManagerImpl::SetAccessMode(
     const hmi_apis::Common_RCAccessMode::eType access_mode) {
   if (hmi_apis::Common_RCAccessMode::ASK_DRIVER != access_mode) {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/button_press_request_test.cc
@@ -105,6 +105,8 @@ class ButtonPressRequestTest
         .WillByDefault(Return(true));
     ON_CALL(mock_allocation_manager_, is_rc_enabled())
         .WillByDefault(Return(true));
+    ON_CALL(mock_allocation_manager_, GetAccessMode())
+        .WillByDefault(Return(hmi_apis::Common_RCAccessMode::AUTO_ALLOW));
     ON_CALL(mock_rc_capabilities_manager_, CheckButtonName(_, _))
         .WillByDefault(Return(true));
     ON_CALL(mock_rc_capabilities_manager_, CheckIfModuleExistsInCapabilities(_))

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/rc_get_interior_vehicle_data_consent_test.cc
@@ -239,6 +239,8 @@ TEST_F(RCGetInteriorVehicleDataConsentTest,
        Run_MobileSendButtonPressMessage_HMISendASKDRIVERModeToMobile) {
   // Arrange
   auto mobile_message = CreateBasicMessage();
+  ON_CALL(mock_allocation_manager_, GetAccessMode())
+      .WillByDefault(Return(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
 
   // Expectations
   EXPECT_CALL(mock_allocation_manager_, AcquireResource(_, _, _))
@@ -283,6 +285,9 @@ TEST_F(RCGetInteriorVehicleDataConsentTest,
       .WillOnce(ReturnRef(mock_command_factory));
 
   auto mobile_message = CreateBasicMessage();
+  ON_CALL(mock_allocation_manager_, GetAccessMode())
+      .WillByDefault(Return(hmi_apis::Common_RCAccessMode::AUTO_DENY));
+
   auto rc_consent_response =
       CreateRCCommand<commands::RCGetInteriorVehicleDataConsentResponse>(
           mobile_message);

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -112,6 +112,8 @@ class SetInteriorVehicleDataRequestTest
     ON_CALL(mock_rc_capabilities_manager_, GetModuleDataCapabilities(_, _))
         .WillByDefault(
             Return(std::make_pair("", capabilitiesStatus::kSuccess)));
+    ON_CALL(mock_allocation_manager_, GetAccessMode())
+        .WillByDefault(Return(hmi_apis::Common_RCAccessMode::AUTO_ALLOW));
   }
 
   MessageSharedPtr CreateBasicMessage() {

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/include/rc_rpc_plugin/mock/mock_resource_allocation_manager.h
@@ -70,6 +70,10 @@ class MockResourceAllocationManager
   MOCK_CONST_METHOD2(IsResourceFree,
                      bool(const std::string& module_type,
                           const std::string& module_id));
+  MOCK_METHOD3(IsResourceAllocated,
+               bool(const std::string& module_type,
+                    const std::string& module_id,
+                    const uint32_t app_id));
   MOCK_METHOD0(ResetAllAllocations, void());
   MOCK_METHOD2(SendOnRCStatusNotifications,
                void(rc_rpc_plugin::NotificationTrigger::eType,


### PR DESCRIPTION
Fixes [FORDTCN-2939](https://adc.luxoft.com/jira/browse/FORDTCN-2939) and [FORDTCN-12134](https://adc.luxoft.com/jira/browse/FORDTCN-12134)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test scripts, affected UTs are updated

### Summary
* SDL shall respond to a SetInteriorVehicleData request within 10 seconds after a request is received if SDL allows or denies the request without asking for the driver’s permission. If the driver’s permission pop up is needed, SDL shall respond to the request within 20 seconds.

* SDL shall respond to a ButtonPress request within 10 seconds after a request is received if SDL allows or denies the request without asking for the driver’s permission. If the driver’s permission pop up is needed, SDL shall respond to the request within 20 seconds.

* The HMI shall respond to a GetInteriorVehicleDataConsent request within 10 seconds after a request is received from SDL.

To satisfy these requirements default timeout was doubled for RCGetInteriorVehicleDataConsentRequest, SetInteriorVehicleDataRequest and ButtonPress request. Also timeout was changed/updated inside RCCommand request (this class is shared parent class for SetInteriorVehicleData request and ButtonPress request) before execution of child logic (logic specific to SetInteriorVehicleData request or ButtonPress request correspondingly) to increase time for internal processing of SetInteriorVehicleData/ButtonPress request after successful response to GetInteriorVehicleDataConsent request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
