### PR TITLE
[SDL-0189]  Fix onResetTimeout twice notification

### DIFF
--- a/src/components/application_manager/include/application_manager/request_info.h
+++ b/src/components/application_manager/include/application_manager/request_info.h
@@ -127,7 +127,7 @@ struct RequestInfo {
   }
   uint64_t hash();
   static uint64_t GenerateHash(uint32_t var1, uint32_t var2);
-  static uint32_t HmiConnectionKey;
+  static constexpr uint32_t HmiConnectionKey = 0;
 
  protected:
   RequestPtr request_;

--- a/src/components/application_manager/src/request_info.cc
+++ b/src/components/application_manager/src/request_info.cc
@@ -42,7 +42,7 @@ namespace request_controller {
 
 SDL_CREATE_LOG_VARIABLE("RequestController")
 
-uint32_t RequestInfo::HmiConnectionKey = 0;
+constexpr uint32_t RequestInfo::HmiConnectionKey;
 
 HMIRequestInfo::HMIRequestInfo(RequestPtr request, const uint64_t timeout_msec)
     : RequestInfo(request, HMIRequest, timeout_msec) {
@@ -132,13 +132,13 @@ bool RequestInfoSet::Add(RequestInfoPtr request_info) {
                                         << request_info->requestId());
   sync_primitives::AutoLock lock(pending_requests_lock_);
   CheckSetSizes();
-  const std::pair<HashSortedRequestInfoSet::iterator, bool>& insert_resilt =
+  const std::pair<HashSortedRequestInfoSet::iterator, bool>& insert_result =
       hash_sorted_pending_requests_.insert(request_info);
-  if (insert_resilt.second == true) {
-    const std::pair<TimeSortedRequestInfoSet::iterator, bool>& insert_resilt =
+  if (insert_result.second == true) {
+    const std::pair<TimeSortedRequestInfoSet::iterator, bool>& insert_result =
         time_sorted_pending_requests_.insert(request_info);
-    DCHECK(insert_resilt.second);
-    if (!insert_resilt.second) {
+    DCHECK(insert_result.second);
+    if (!insert_result.second) {
       return false;
     }
     CheckSetSizes();

--- a/src/components/application_manager/src/request_timeout_handler_impl.cc
+++ b/src/components/application_manager/src/request_timeout_handler_impl.cc
@@ -32,6 +32,7 @@
 
 #include "application_manager/request_timeout_handler_impl.h"
 #include "application_manager/message_helper.h"
+#include "application_manager/request_info.h"
 #include "utils/logger.h"
 
 SDL_CREATE_LOG_VARIABLE("RequestTimeoutHandler")
@@ -112,6 +113,8 @@ void RequestTimeoutHandlerImpl::on_event(const event_engine::Event& event) {
       if (IsTimeoutUpdateRequired(request, timeout, method_name)) {
         application_manager_.UpdateRequestTimeout(
             request.connection_key_, request.mob_correlation_id_, timeout);
+        application_manager_.UpdateRequestTimeout(
+            RequestInfo::HmiConnectionKey, hmi_corr_id, timeout);
       }
     } else {
       SDL_LOG_WARN("Timeout reset failed by " << hmi_corr_id

--- a/src/components/application_manager/test/request_timeout_handler_test.cc
+++ b/src/components/application_manager/test/request_timeout_handler_test.cc
@@ -44,6 +44,7 @@
 #include "application_manager/mock_message_helper.h"
 #include "application_manager/mock_request_controller.h"
 #include "application_manager/policies/mock_policy_handler_interface.h"
+#include "application_manager/request_info.h"
 #include "sdl_rpc_plugin/commands/hmi/on_reset_timeout_notification.h"
 #include "sdl_rpc_plugin/commands/mobile/subscribe_way_points_request.h"
 #include "sdl_rpc_plugin/commands/mobile/unsubscribe_way_points_request.h"
@@ -163,6 +164,9 @@ TEST_F(RequestTimeoutHandlerTest, OnEvent_OnResetTimeout_SUCCESS) {
   EXPECT_CALL(app_mngr_,
               UpdateRequestTimeout(
                   mock_app->app_id(), command->correlation_id(), kTimeout));
+  EXPECT_CALL(app_mngr_,
+              UpdateRequestTimeout(
+                  RequestInfo::HmiConnectionKey, kRequestId, kTimeout));
 
   ASSERT_TRUE(command->Init());
   command->Run();
@@ -208,6 +212,9 @@ TEST_F(RequestTimeoutHandlerTest, OnEvent_OnResetTimeout_MissedResetPeriod) {
       app_mngr_,
       UpdateRequestTimeout(
           mock_app->app_id(), command->correlation_id(), kDefaultTimeout));
+  EXPECT_CALL(app_mngr_,
+              UpdateRequestTimeout(
+                  RequestInfo::HmiConnectionKey, kRequestId, kDefaultTimeout));
 
   ASSERT_TRUE(command->Init());
   command->Run();


### PR DESCRIPTION
Fixes #[FORDTCN-2944]

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF test scripts

### Summary
In case we changed the ResetTimeout for more than 10 seconds, we were unable to change it to a different value.
To fix this problem, we can update the ResetTimeout to the request with the corresponding hmi_correlation_id in RequestTimeoutHandlerImpl::on_event() method.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
