### PR TITLE
[SDL-0189] fix crash sdl_core on close

### DIFF
--- a/src/components/application_manager/include/application_manager/request_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/request_controller_impl.h
@@ -68,6 +68,8 @@ class RequestControllerImpl : public RequestController {
 
   ~RequestControllerImpl();
 
+  void Stop() OVERRIDE;
+
   void InitializeThreadpool() OVERRIDE;
 
   void DestroyThreadpool() OVERRIDE;

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2606,7 +2606,7 @@ bool ApplicationManagerImpl::Stop() {
   } catch (...) {
     SDL_LOG_ERROR("An error occurred during unregistering applications.");
   }
-  request_ctrl_->DestroyThreadpool();
+  request_ctrl_->Stop();
 
   // for PASA customer policy backup should happen :AllApp(SUSPEND)
   SDL_LOG_DEBUG("Unloading policy library.");

--- a/src/components/include/application_manager/request_controller.h
+++ b/src/components/include/application_manager/request_controller.h
@@ -73,6 +73,11 @@ class RequestController {
   virtual ~RequestController() {}
 
   /**
+   * @brief Stop request controller internal activities
+   */
+  virtual void Stop() = 0;
+
+  /**
    * @brief Initialize thread pool
    */
   virtual void InitializeThreadpool() = 0;

--- a/src/components/include/test/application_manager/mock_request_controller.h
+++ b/src/components/include/test/application_manager/mock_request_controller.h
@@ -42,6 +42,7 @@ namespace application_manager_test {
 class MockRequestController
     : public application_manager::request_controller::RequestController {
  public:
+  MOCK_METHOD0(Stop, void());
   MOCK_METHOD0(InitializeThreadpool, void());
   MOCK_METHOD0(DestroyThreadpool, void());
   MOCK_METHOD2(


### PR DESCRIPTION
Fixes #[FORDTCN-12131]

This PR is **[ready ]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF test scripts

### Summary
During ATF testing, it was noticed that the SDL crashes after the tests are completed.
This happened due to the incorrect termination of the requests_controller.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
