### PR TITLE
Fix/cmake warning under external flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 2.8.11)
+cmake_policy(SET CMP0054 NEW)
 
 set (PROJECT smartDeviceLinkCore)
 project (${PROJECT})
@@ -510,7 +511,11 @@ add_subdirectory(./src/appMain)
 add_subdirectory(./src/plugins)
 
 add_dependencies(${PROJECT} Policy)
-add_dependencies(${PROJECT} copy_policy_library)
+if(EXTENDED_POLICY STREQUAL "EXTERNAL_PROPRIETARY")
+  add_dependencies(${PROJECT} copy_library_Policy)
+else()
+  add_dependencies(${PROJECT} copy_policy_library)
+endif()
 
 # Building documentation
 


### PR DESCRIPTION
**Fixes** #[12153](https://adc.luxoft.com/jira/browse/FORDTCN-12153)

This PR is ready for review.

**Risk**
This PR makes no API changes.

**Summary**
When cmake is called ../sdl_core -DEXTENDED_POLICY = EXTERNAL_PROPRIETARY we get a warning. Сmake did not find an added dependency. Different dependencies need to be added for different policies. EXTERNAL_PROPRIETARY has dependecy "copy_library_Policy" and PROPRIETARY has copy_policy_library. So I added a policy check to establish the correct dependencies.
There was also an error with the lack of a new version of the CMP0054 policy. Added a new version of this policy.