### PR TITLE
Fix OnResetTimeout for Alerts with soft buttons

### DIFF
--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -399,6 +399,9 @@ void RequestControllerImpl::UpdateRequestTimeout(const uint32_t app_id,
       waiting_for_response_.Find(app_id, correlation_id);
   if (request_info) {
     if (0 == request_info->timeout_msec()) {
+      SDL_LOG_INFO(
+          "Request with zero timeout is not updating, "
+          "manual control is assumed");
       return;
     }
 

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -388,13 +388,20 @@ void RequestControllerImpl::UpdateRequestTimeout(const uint32_t app_id,
   SDL_LOG_DEBUG("app_id : " << app_id
                             << " mobile_correlation_id : " << correlation_id
                             << " new_timeout : " << new_timeout);
-  SDL_LOG_DEBUG(
-      "New_timeout is NULL. RequestCtrl will "
-      "not manage this request any more");
+
+  if (new_timeout == 0) {
+    SDL_LOG_DEBUG(
+        "New_timeout is NULL. RequestCtrl will "
+        "not manage this request any more");
+  }
 
   RequestInfoPtr request_info =
       waiting_for_response_.Find(app_id, correlation_id);
   if (request_info) {
+    if (0 == request_info->timeout_msec()) {
+      return;
+    }
+
     waiting_for_response_.RemoveRequest(request_info);
     request_info->updateTimeOut(new_timeout);
     waiting_for_response_.Add(request_info);


### PR DESCRIPTION
Fixes #[FORDTCN-12163]

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
ATF, manual

### Summary
This PR provide change logic for handling HMI requests with soft buttons.
If request to HMI contains some soft buttons request_controller should wait until user make interaction
and do not apply onTimeout() method for this request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
