### PR TITLE
Remove default timeout adjustments from core

### DIFF
--- a/src/components/application_manager/include/application_manager/request_controller_impl.h
+++ b/src/components/application_manager/include/application_manager/request_controller_impl.h
@@ -106,11 +106,6 @@ class RequestControllerImpl : public RequestController {
                             const uint32_t mobile_correlation_id,
                             const uint32_t new_timeout) OVERRIDE;
 
-  bool IsRequestTimeoutUpdateRequired(
-      const uint32_t app_id,
-      const uint32_t correlation_id,
-      const uint32_t new_timeout) const OVERRIDE;
-
   void OnLowVoltage() OVERRIDE;
 
   void OnWakeUp() OVERRIDE;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/button_press_request.h
@@ -46,11 +46,6 @@ class ButtonPressRequest : public RCCommandRequest {
       const RCCommandParams& params);
 
   /**
-   * @brief Init command command
-   */
-  bool Init() FINAL;
-
-  /**
    * @brief Execute command
    * send HMI request if message contains appropriate
    * button name and module type

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_request.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/mobile/set_interior_vehicle_data_request.h
@@ -47,11 +47,6 @@ class SetInteriorVehicleDataRequest : public RCCommandRequest {
       const RCCommandParams& params);
 
   /**
-   * @brief Init command
-   */
-  bool Init() FINAL;
-
-  /**
    * @brief Execute command
    */
   void Execute() FINAL;

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/hmi/rc_get_interior_vehicle_data_consent_request.cc
@@ -45,10 +45,7 @@ RCGetInteriorVehicleDataConsentRequest::RCGetInteriorVehicleDataConsentRequest(
                                                   params.application_manager_,
                                                   params.rpc_service_,
                                                   params.hmi_capabilities_,
-                                                  params.policy_handler_) {
-  // Increase default timeout for user interaction.
-  default_timeout_ = default_timeout_ * 2;
-}
+                                                  params.policy_handler_) {}
 
 RCGetInteriorVehicleDataConsentRequest::
     ~RCGetInteriorVehicleDataConsentRequest() {}

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/button_press_request.cc
@@ -54,21 +54,6 @@ ButtonPressRequest::ButtonPressRequest(
 
 ButtonPressRequest::~ButtonPressRequest() {}
 
-bool ButtonPressRequest::Init() {
-  SDL_LOG_AUTO_TRACE();
-  // If driver permission is required, the SDL should increase the default
-  // timeout value by 2 times
-  auto access_mode = resource_allocation_manager_.GetAccessMode();
-
-  if (hmi_apis::Common_RCAccessMode::ASK_DRIVER == access_mode &&
-      resource_allocation_manager_.IsResourceAllocated(
-          ModuleType(), ModuleId(), connection_key())) {
-    const uint32_t increase_value = 2;
-    default_timeout_ *= increase_value;
-  }
-  return true;
-}
-
 std::string ButtonPressRequest::GetButtonName() const {
   mobile_apis::ButtonName::eType button_name =
       static_cast<mobile_apis::ButtonName::eType>(

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -54,22 +54,6 @@ SetInteriorVehicleDataRequest::SetInteriorVehicleDataRequest(
 
 SetInteriorVehicleDataRequest::~SetInteriorVehicleDataRequest() {}
 
-bool SetInteriorVehicleDataRequest::Init() {
-  SDL_LOG_AUTO_TRACE();
-  // If driver permission is required, the SDL should increase the default
-  // timeout value by 2 times
-  auto access_mode = resource_allocation_manager_.GetAccessMode();
-
-  if (hmi_apis::Common_RCAccessMode::ASK_DRIVER == access_mode &&
-      resource_allocation_manager_.IsResourceAllocated(
-          ModuleType(), ModuleId(), connection_key())) {
-    const uint32_t increase_value = 2;
-    default_timeout_ *= increase_value;
-  }
-
-  return true;
-}
-
 /**
  * @brief Clears unrelated module data parameters
  * @param module type in request

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -166,23 +166,6 @@ bool RequestControllerImpl::CheckPendingRequestsAmount(
   return true;
 }
 
-bool RequestControllerImpl::IsRequestTimeoutUpdateRequired(
-    const uint32_t app_id,
-    const uint32_t correlation_id,
-    const uint32_t new_timeout) const {
-  SDL_LOG_AUTO_TRACE();
-  auto request_info = waiting_for_response_.Find(app_id, correlation_id);
-  if (request_info) {
-    date_time::TimeDuration current_time = date_time::getCurrentTime();
-    const date_time::TimeDuration end_time = request_info->end_time();
-    date_time::AddMilliseconds(current_time, new_timeout);
-    if (date_time::getmSecs(current_time) > date_time::getmSecs(end_time)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 RequestController::TResult RequestControllerImpl::AddMobileRequest(
     const RequestPtr request, const mobile_apis::HMILevel::eType& hmi_level) {
   SDL_LOG_AUTO_TRACE();

--- a/src/components/application_manager/src/request_timeout_handler_impl.cc
+++ b/src/components/application_manager/src/request_timeout_handler_impl.cc
@@ -66,23 +66,18 @@ bool RequestTimeoutHandlerImpl::IsTimeoutUpdateRequired(
     const Request& request,
     const uint32_t timeout,
     const hmi_apis::FunctionID::eType method_name) {
-  if (static_cast<hmi_apis::FunctionID::eType>(request.hmi_function_id_) ==
-      method_name) {
-    if (application_manager_.get_request_controller()
-            .IsRequestTimeoutUpdateRequired(request.connection_key_,
-                                            request.mob_correlation_id_,
-                                            timeout)) {
-      return true;
-    }
-
-    SDL_LOG_WARN(
-        "New timeout value is less than the time remaining from "
-        "the current timeout. OnResetTimeout will be ignored");
+  if (0 == timeout) {
+    SDL_LOG_WARN("Zero timeout ignored");
     return false;
   }
 
-  SDL_LOG_WARN("Method name does not match the hmi function id");
-  return false;
+  if (static_cast<hmi_apis::FunctionID::eType>(request.hmi_function_id_) !=
+      method_name) {
+    SDL_LOG_WARN("Method name does not match the hmi function id");
+    return false;
+  }
+
+  return true;
 }
 
 void RequestTimeoutHandlerImpl::on_event(const event_engine::Event& event) {

--- a/src/components/application_manager/test/request_timeout_handler_test.cc
+++ b/src/components/application_manager/test/request_timeout_handler_test.cc
@@ -157,10 +157,6 @@ TEST_F(RequestTimeoutHandlerTest, OnEvent_OnResetTimeout_SUCCESS) {
   EXPECT_CALL(app_mngr_, get_request_timeout_handler())
       .WillOnce(ReturnRef(*request_timeout_handler_));
 
-  EXPECT_CALL(mock_request_controller_,
-              IsRequestTimeoutUpdateRequired(
-                  mock_app->app_id(), command->correlation_id(), kTimeout))
-      .WillOnce(Return(true));
   EXPECT_CALL(app_mngr_,
               UpdateRequestTimeout(
                   mock_app->app_id(), command->correlation_id(), kTimeout));
@@ -204,11 +200,6 @@ TEST_F(RequestTimeoutHandlerTest, OnEvent_OnResetTimeout_MissedResetPeriod) {
   EXPECT_CALL(app_mngr_, get_request_timeout_handler())
       .WillOnce(ReturnRef(*request_timeout_handler_));
   EXPECT_CALL(
-      mock_request_controller_,
-      IsRequestTimeoutUpdateRequired(
-          mock_app->app_id(), command->correlation_id(), kDefaultTimeout))
-      .WillOnce(Return(true));
-  EXPECT_CALL(
       app_mngr_,
       UpdateRequestTimeout(
           mock_app->app_id(), command->correlation_id(), kDefaultTimeout));
@@ -251,8 +242,6 @@ TEST_F(RequestTimeoutHandlerTest, OnEvent_OnResetTimeout_InvalidRequestId) {
 
   EXPECT_CALL(app_mngr_, get_request_timeout_handler())
       .WillOnce(ReturnRef(*request_timeout_handler_));
-  EXPECT_CALL(mock_request_controller_, IsRequestTimeoutUpdateRequired(_, _, _))
-      .Times(0);
   EXPECT_CALL(app_mngr_, UpdateRequestTimeout(_, _, _)).Times(0);
 
   ASSERT_TRUE(command->Init());
@@ -290,8 +279,6 @@ TEST_F(RequestTimeoutHandlerTest, OnEvent_OnResetTimeout_InvalidMethodName) {
 
   EXPECT_CALL(app_mngr_, get_request_timeout_handler())
       .WillOnce(ReturnRef(*request_timeout_handler_));
-  EXPECT_CALL(mock_request_controller_, IsRequestTimeoutUpdateRequired(_, _, _))
-      .Times(0);
   EXPECT_CALL(app_mngr_, UpdateRequestTimeout(_, _, _)).Times(0);
 
   ASSERT_TRUE(command->Init());

--- a/src/components/include/application_manager/request_controller.h
+++ b/src/components/include/application_manager/request_controller.h
@@ -172,20 +172,6 @@ class RequestController {
   virtual void UpdateRequestTimeout(const uint32_t app_id,
                                     const uint32_t mobile_correlation_id,
                                     const uint32_t new_timeout) = 0;
-
-  /**
-   * @brief IsRequestTimeoutUpdateRequired check is update timeout required.
-   * @param app_id Connection key of application
-   * @param correlation_id Correlation ID of the mobile request
-   * @param new_timeout New timeout value which should be compared with the
-   * remaining time of specified request
-   * @return true if the new timeout value is greater than the time remaining
-   * from the current timeout, otherwise - false
-   */
-  virtual bool IsRequestTimeoutUpdateRequired(
-      const uint32_t app_id,
-      const uint32_t correlation_id,
-      const uint32_t new_timeout) const = 0;
   /**
    * @brief Function Should be called when Low Voltage is occured
    */

--- a/src/components/include/test/application_manager/mock_request_controller.h
+++ b/src/components/include/test/application_manager/mock_request_controller.h
@@ -76,10 +76,6 @@ class MockRequestController
                void(const uint32_t app_id,
                     const uint32_t mobile_correlation_id,
                     const uint32_t new_timeout));
-  MOCK_CONST_METHOD3(IsRequestTimeoutUpdateRequired,
-                     bool(const uint32_t app_id,
-                          const uint32_t correlation_id,
-                          const uint32_t new_timeout));
   MOCK_METHOD0(OnLowVoltage, void());
   MOCK_METHOD0(OnWakeUp, void());
   MOCK_METHOD0(IsLowVoltage, bool());


### PR DESCRIPTION
### Summary
Remove default timeout adjustments from core:

RC plugin:
- ButtonPress request
- SetIVD request
- RC.GetIVD consent


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
