### PR TITLE
Added methods get and set the menuLayout and added to the request on …

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -203,6 +203,7 @@ class DynamicApplicationData {
   virtual const smart_objects::SmartObject* keyboard_props() const = 0;
   virtual const smart_objects::SmartObject* menu_title() const = 0;
   virtual const smart_objects::SmartObject* menu_icon() const = 0;
+  virtual const smart_objects::SmartObject* menu_layout() const = 0;
   virtual smart_objects::SmartObject day_color_scheme() const = 0;
   virtual smart_objects::SmartObject night_color_scheme() const = 0;
   virtual std::string display_layout() const = 0;
@@ -242,6 +243,8 @@ class DynamicApplicationData {
       const smart_objects::SmartObject& keyboard_props) = 0;
   virtual void set_menu_title(const smart_objects::SmartObject& menu_title) = 0;
   virtual void set_menu_icon(const smart_objects::SmartObject& menu_icon) = 0;
+  virtual void set_menu_layout(
+      const smart_objects::SmartObject& menu_layout) = 0;
 
   virtual uint32_t audio_stream_retry_number() const = 0;
 

--- a/src/components/application_manager/include/application_manager/application_data_impl.h
+++ b/src/components/application_manager/include/application_manager/application_data_impl.h
@@ -102,6 +102,7 @@ class DynamicApplicationDataImpl : public virtual Application {
   const smart_objects::SmartObject* keyboard_props() const;
   const smart_objects::SmartObject* menu_title() const;
   const smart_objects::SmartObject* menu_icon() const;
+  const smart_objects::SmartObject* menu_layout() const;
 
   smart_objects::SmartObject day_color_scheme() const OVERRIDE;
   smart_objects::SmartObject night_color_scheme() const OVERRIDE;
@@ -141,6 +142,7 @@ class DynamicApplicationDataImpl : public virtual Application {
   void set_keyboard_props(const smart_objects::SmartObject& keyboard_props);
   void set_menu_title(const smart_objects::SmartObject& menu_title);
   void set_menu_icon(const smart_objects::SmartObject& menu_icon);
+  void set_menu_layout(const smart_objects::SmartObject& menu_layout);
   void set_day_color_scheme(const smart_objects::SmartObject& color_scheme);
   void set_night_color_scheme(const smart_objects::SmartObject& color_scheme);
   void set_display_layout(const std::string& layout);
@@ -323,6 +325,7 @@ class DynamicApplicationDataImpl : public virtual Application {
   smart_objects::SmartObject* keyboard_props_;
   smart_objects::SmartObject* menu_title_;
   smart_objects::SmartObject* menu_icon_;
+  smart_objects::SmartObject* menu_layout_;
   smart_objects::SmartObject* tbt_show_command_;
   smart_objects::SmartObjectSPtr display_capabilities_;
   AppWindowsTemplates window_templates_;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/set_global_properties_request.cc
@@ -186,6 +186,7 @@ void SetGlobalPropertiesRequest::Run() {
         msg_params[strings::menu_layout].asUInt());
     if (app->menu_layout_supported(menu_layout)) {
       params[strings::menu_layout] = msg_params[strings::menu_layout];
+      app->set_menu_layout(msg_params[strings::menu_layout]);
     } else {
       is_menu_layout_available_ = false;
     }

--- a/src/components/application_manager/src/application_data_impl.cc
+++ b/src/components/application_manager/src/application_data_impl.cc
@@ -201,6 +201,7 @@ DynamicApplicationDataImpl::DynamicApplicationDataImpl()
     , keyboard_props_(nullptr)
     , menu_title_(nullptr)
     , menu_icon_(nullptr)
+    , menu_layout_(nullptr)
     , tbt_show_command_(nullptr)
     , commands_()
     , commands_lock_ptr_(std::make_shared<sync_primitives::RecursiveLock>())
@@ -349,6 +350,11 @@ const smart_objects::SmartObject* DynamicApplicationDataImpl::menu_icon()
   return menu_icon_;
 }
 
+const smart_objects::SmartObject* DynamicApplicationDataImpl::menu_layout()
+    const {
+  return menu_layout_;
+}
+
 smart_objects::SmartObject DynamicApplicationDataImpl::day_color_scheme()
     const {
   using namespace mobile_apis::PredefinedWindows;
@@ -467,6 +473,8 @@ void DynamicApplicationDataImpl::load_global_properties(
 
   SetGlobalProperties(properties_so.getElement(strings::menu_icon),
                       &DynamicApplicationData::set_menu_icon);
+  SetGlobalProperties(properties_so.getElement(strings::menu_layout),
+                      &DynamicApplicationData::set_menu_layout);
 }
 
 void DynamicApplicationDataImpl::set_help_prompt(
@@ -558,6 +566,14 @@ void DynamicApplicationDataImpl::set_menu_icon(
     delete menu_icon_;
   }
   menu_icon_ = new smart_objects::SmartObject(menu_icon);
+}
+
+void DynamicApplicationDataImpl::set_menu_layout(
+    const smart_objects::SmartObject& menu_layout) {
+  if (menu_layout_) {
+    delete menu_layout_;
+  }
+  menu_layout_ = new smart_objects::SmartObject(menu_layout);
 }
 
 void DynamicApplicationDataImpl::set_day_color_scheme(

--- a/src/components/application_manager/src/helpers/application_helper.cc
+++ b/src/components/application_manager/src/helpers/application_helper.cc
@@ -87,6 +87,7 @@ void DeleteGlobalProperties(ApplicationSharedPtr app,
   app->set_keyboard_props(empty_so);
   app->set_menu_icon(empty_so);
   app->set_menu_title(empty_so);
+  app->set_menu_layout(empty_so);
 
   MessageHelper::SendResetPropertiesRequest(app, app_manager);
 }

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1313,6 +1313,9 @@ MessageHelper::CreateGlobalPropertiesRequestsToHMI(
       if (app->menu_icon()) {
         ui_msg_params[strings::menu_icon] = (*app->menu_icon());
       }
+      if (app->menu_layout()) {
+        ui_msg_params[strings::menu_layout] = (*app->menu_layout());
+      }
       ui_msg_params[strings::app_id] = app->app_id();
 
       (*ui_global_properties)[strings::msg_params] = ui_msg_params;
@@ -1994,6 +1997,9 @@ smart_objects::SmartObjectList MessageHelper::CreateAddSubMenuRequestsToHMI(
     if ((*i->second).keyExists(strings::parent_id)) {
       msg_params[strings::menu_params][strings::parent_id] =
           (*i->second)[strings::parent_id];
+    }
+    if ((*i->second).keyExists(strings::menu_layout)) {
+      msg_params[strings::menu_layout] = (*i->second)[strings::menu_layout];
     }
     msg_params[strings::app_id] = app->app_id();
     (*ui_sub_menu)[strings::msg_params] = msg_params;

--- a/src/components/application_manager/src/resumption/resumption_data.cc
+++ b/src/components/application_manager/src/resumption/resumption_data.cc
@@ -132,6 +132,8 @@ smart_objects::SmartObject ResumptionData::GetApplicationGlobalProperties(
       PointerToSmartObj(application->menu_title());
   global_properties[strings::menu_icon] =
       PointerToSmartObj(application->menu_icon());
+  global_properties[strings::menu_layout] =
+      PointerToSmartObj(application->menu_layout());
   return global_properties;
 }
 

--- a/src/components/application_manager/test/application_helper_test.cc
+++ b/src/components/application_manager/test/application_helper_test.cc
@@ -176,6 +176,7 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectAppDataReset) {
   app_impl_->set_keyboard_props(dummy_data);
   app_impl_->set_menu_title(dummy_data);
   app_impl_->set_menu_icon(dummy_data);
+  app_impl_->set_menu_layout(dummy_data);
 
   const bool persistent = false;
   const bool downloaded = true;
@@ -205,6 +206,8 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectAppDataReset) {
   EXPECT_TRUE(menu_title->asString() == some_string);
   auto menu_icon = app_impl_->menu_icon();
   EXPECT_TRUE(menu_icon->asString() == some_string);
+  auto menu_layout = app_impl_->menu_layout();
+  EXPECT_TRUE(menu_layout->asString() == some_string);
   auto file_ptr = app_impl_->GetFile(filename);
   EXPECT_TRUE(NULL != file_ptr);
   EXPECT_TRUE(file_ptr->file_name == filename);
@@ -239,6 +242,8 @@ TEST_F(ApplicationHelperTest, RecallApplicationData_ExpectAppDataReset) {
   EXPECT_FALSE(menu_title->asString() == some_string);
   menu_icon = app_impl_->menu_icon();
   EXPECT_FALSE(menu_icon->asString() == some_string);
+  menu_layout = app_impl_->menu_layout();
+  EXPECT_FALSE(menu_layout->asString() == some_string);
   file_ptr = app_impl_->GetFile(filename);
   EXPECT_TRUE(NULL == file_ptr);
 }

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -253,6 +253,7 @@ class MockApplication : public ::application_manager::Application {
   MOCK_CONST_METHOD0(keyboard_props, const smart_objects::SmartObject*());
   MOCK_CONST_METHOD0(menu_title, const smart_objects::SmartObject*());
   MOCK_CONST_METHOD0(menu_icon, const smart_objects::SmartObject*());
+  MOCK_CONST_METHOD0(menu_layout, const smart_objects::SmartObject*());
   MOCK_CONST_METHOD0(day_color_scheme, smart_objects::SmartObject());
   MOCK_CONST_METHOD0(night_color_scheme, smart_objects::SmartObject());
   MOCK_CONST_METHOD0(display_layout, std::string());
@@ -305,6 +306,8 @@ class MockApplication : public ::application_manager::Application {
                void(const smart_objects::SmartObject& menu_title));
   MOCK_METHOD1(set_menu_icon,
                void(const smart_objects::SmartObject& menu_icon));
+  MOCK_METHOD1(set_menu_layout,
+               void(const smart_objects::SmartObject& menu_layout));
   MOCK_METHOD1(set_day_color_scheme,
                void(const smart_objects::SmartObject& color_scheme));
   MOCK_METHOD1(set_night_color_scheme,


### PR DESCRIPTION
### Fixes #[10407](https://adc.luxoft.com/jira/browse/FORDTCN-10407)

This PR is ready for review.

### Risk
This PR makes no API changes.


### Summary
We never saved the menu layer, so when restoring the device, we did not add it to the request GlobalProperty. And for the sub menu, we did not correctly add it to the request.
I added set and get methods for menuLayout to the application interface. As well as a menu layer field. In the command to restore global properties and submenus added a menu layer to the request. I corrected the tests that failed the test.
