### PR TITLE
[SDL 0192] Unify approach to result codes processing

### DIFF
--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -69,6 +69,23 @@ struct CommandParametersPermissions {
 };
 
 namespace commands {
+
+/**
+ * @brief Checks Mobile result code for single RPC
+ * @param result_code contains result code from response to Mobile
+ * @return true if result code complies to successful result codes,
+ * false otherwise.
+ */
+bool IsMobileResultSuccess(const mobile_apis::Result::eType result_code);
+
+/**
+ * @brief Checks HMI result code for single RPC
+ * @param result_code contains result code from HMI response
+ * @return true if result code complies to successful result codes,
+ * false otherwise.
+ */
+bool IsHMIResultSuccess(const hmi_apis::Common_Result::eType result_code);
+
 /**
  * @brief Class is intended to encapsulate RPC as an object
  **/
@@ -182,6 +199,16 @@ class CommandImpl : public Command {
    * @return true if success otherwise return false
    */
   bool CheckSyntax(const std::string& str, bool allow_empty_line = false) const;
+
+  /**
+   * @brief Checks HMI result code for single RPC
+   * @param result_code contains result code from HMI response
+   * @param interface to check availability
+   * @return true if result code complies to successful result codes,
+   * false otherwise.
+   */
+  bool IsHMIResultSuccess(hmi_apis::Common_Result::eType result_code,
+                          HmiInterfaces::InterfaceID interface) const;
 
   // members
   static const int32_t hmi_protocol_type_;

--- a/src/components/application_manager/include/application_manager/commands/command_request_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_request_impl.h
@@ -206,24 +206,6 @@ class CommandRequestImpl : public CommandImpl,
   mobile_apis::Result::eType GetMobileResultCode(
       const hmi_apis::Common_Result::eType& hmi_code) const;
 
-  /**
-   * @brief Checks Mobile result code for single RPC
-   * @param result_code contains result code from response to Mobile
-   * @return true if result code complies to successful result codes,
-   * false otherwise.
-   */
-  static bool IsMobileResultSuccess(
-      const mobile_apis::Result::eType result_code);
-
-  /**
-   * @brief Checks HMI result code for single RPC
-   * @param result_code contains result code from HMI response
-   * @return true if result code complies to successful result codes,
-   * false otherwise.
-   */
-  static bool IsHMIResultSuccess(
-      const hmi_apis::Common_Result::eType result_code);
-
  protected:
   /**
    * @brief Checks message permissions and parameters according to policy table

--- a/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
+++ b/src/components/application_manager/include/application_manager/commands/request_from_hmi.h
@@ -106,12 +106,6 @@ class RequestFromHMI : public CommandImpl, public event_engine::EventObserver {
       const uint32_t hmi_correlation_id,
       const hmi_apis::FunctionID::eType& function_id);
 
- protected:
-  bool IsMobileResultSuccess(mobile_apis::Result::eType result_code) const;
-
-  bool IsHMIResultSuccess(hmi_apis::Common_Result::eType result_code,
-                          HmiInterfaces::InterfaceID interface) const;
-
  private:
   /**
    * @brief Fills common parameters for SO

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_get_app_service_data_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_get_app_service_data_request_from_hmi.cc
@@ -240,8 +240,8 @@ void ASGetAppServiceDataRequestFromHMI::on_event(
   hmi_apis::Common_Result::eType result =
       static_cast<hmi_apis::Common_Result::eType>(
           event_message[strings::params][hmi_response::code].asInt());
-  bool success =
-      IsHMIResultSuccess(result, HmiInterfaces::HMI_INTERFACE_AppService);
+  bool success = CommandImpl::IsHMIResultSuccess(
+      result, HmiInterfaces::HMI_INTERFACE_AppService);
   if (ValidateResponse(msg_params)) {
     SendResponse(success,
                  correlation_id(),
@@ -263,7 +263,8 @@ void ASGetAppServiceDataRequestFromHMI::on_event(
           msg_params[strings::result_code].asInt());
   hmi_apis::Common_Result::eType result =
       MessageHelper::MobileToHMIResult(mobile_result);
-  bool success = IsMobileResultSuccess(mobile_result);
+  bool success =
+      application_manager::commands::IsMobileResultSuccess(mobile_result);
 
   if (ValidateResponse(msg_params)) {
     SendResponse(success,

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/hmi/as_perform_app_service_interaction_request_from_hmi.cc
@@ -140,7 +140,8 @@ void ASPerformAppServiceInteractionRequestFromHMI::on_event(
           msg_params[strings::result_code].asInt());
   hmi_apis::Common_Result::eType result =
       MessageHelper::MobileToHMIResult(mobile_result);
-  bool success = IsMobileResultSuccess(mobile_result);
+  bool success =
+      application_manager::commands::IsMobileResultSuccess(mobile_result);
   SendResponse(success,
                correlation_id(),
                hmi_apis::FunctionID::AppService_PerformAppServiceInteraction,

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/get_app_service_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/get_app_service_data_request.cc
@@ -96,7 +96,7 @@ void GetAppServiceDataRequest::on_event(
 
   mobile_apis::Result::eType result = static_cast<mobile_apis::Result::eType>(
       msg_params[strings::result_code].asInt());
-  bool success = IsMobileResultSuccess(result);
+  bool success = application_manager::commands::IsMobileResultSuccess(result);
   if (success) {
     HandleSubscribe();
   }

--- a/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/app_service_rpc_plugin/src/commands/mobile/perform_app_service_interaction_request.cc
@@ -181,7 +181,7 @@ void PerformAppServiceInteractionRequest::on_event(
                          : NULL;
   mobile_apis::Result::eType result = static_cast<mobile_apis::Result::eType>(
       msg_params[strings::result_code].asInt());
-  bool success = IsMobileResultSuccess(result);
+  bool success = application_manager::commands::IsMobileResultSuccess(result);
 
   SendResponse(success, result, info, &msg_params);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/subscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/subscribe_button_request.cc
@@ -144,8 +144,8 @@ void SubscribeButtonRequest::on_event(const event_engine::Event& event) {
       static_cast<mobile_apis::ButtonName::eType>(
           (*message_)[strings::msg_params][strings::button_name].asInt());
 
-  if ((hmi_apis::Common_Result::SUCCESS == hmi_result ||
-       hmi_apis::Common_Result::WARNINGS == hmi_result) &&
+  if (CommandImpl::IsHMIResultSuccess(hmi_result,
+                                      HmiInterfaces::HMI_INTERFACE_Buttons) &&
       is_pending) {
     app->SubscribeToButton(static_cast<mobile_apis::ButtonName::eType>(btn_id));
     app->RemovePendingSubscriptionButton(correlation_id());

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/unsubscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/unsubscribe_button_request.cc
@@ -132,8 +132,8 @@ void UnsubscribeButtonRequest::on_event(const event_engine::Event& event) {
       static_cast<hmi_apis::Common_Result::eType>(
           message[strings::params][hmi_response::code].asInt());
 
-  if ((hmi_apis::Common_Result::SUCCESS == hmi_result ||
-       hmi_apis::Common_Result::WARNINGS == hmi_result) &&
+  if (CommandImpl::IsHMIResultSuccess(hmi_result,
+                                      HmiInterfaces::HMI_INTERFACE_Buttons) &&
       is_pending) {
     const mobile_apis::ButtonName::eType btn_id =
         static_cast<mobile_apis::ButtonName::eType>(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/create_window_request.cc
@@ -218,7 +218,8 @@ void CreateWindowRequest::on_event(const event_engine::Event& event) {
       static_cast<hmi_apis::Common_Result::eType>(
           response_message[strings::params][hmi_response::code].asInt()));
 
-  const bool is_success = IsMobileResultSuccess(result_code);
+  const bool is_success =
+      app_mngr::commands::IsMobileResultSuccess(result_code);
   std::string response_info;
   GetInfo(response_message, response_info);
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_interaction_choice_set_request.cc
@@ -204,7 +204,7 @@ void DeleteInteractionChoiceSetRequest::
       continue;
     }
 
-    if (!IsHMIResultSuccess(code)) {
+    if (!application_manager::commands::IsHMIResultSuccess(code)) {
       result_code = code;
     }
   }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_window_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_window_request.cc
@@ -134,7 +134,8 @@ void DeleteWindowRequest::on_event(const event_engine::Event& event) {
       static_cast<hmi_apis::Common_Result::eType>(
           response_message[strings::params][hmi_response::code].asInt()));
 
-  const bool is_success = IsMobileResultSuccess(result_code);
+  const bool is_success =
+      app_mngr::commands::IsMobileResultSuccess(result_code);
   std::string response_info;
   GetInfo(response_message, response_info);
 

--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -567,25 +567,14 @@ bool CommandImpl::IsHMIResultSuccess(
     hmi_apis::Common_Result::eType result_code,
     HmiInterfaces::InterfaceID interface) const {
   SDL_LOG_AUTO_TRACE();
-  using namespace helpers;
-  if (Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
-          result_code,
-          hmi_apis::Common_Result::SUCCESS,
-          hmi_apis::Common_Result::WARNINGS,
-          hmi_apis::Common_Result::WRONG_LANGUAGE,
-          hmi_apis::Common_Result::RETRY,
-          hmi_apis::Common_Result::SAVED,
-          hmi_apis::Common_Result::TRUNCATED_DATA)) {
+  if (application_manager::commands::IsHMIResultSuccess(result_code)) {
     return true;
   }
 
   const HmiInterfaces::InterfaceState state =
       application_manager_.hmi_interfaces().GetInterfaceState(interface);
-  if ((hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code) &&
-      (HmiInterfaces::STATE_NOT_AVAILABLE != state)) {
-    return true;
-  }
-  return false;
+  return hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code &&
+         HmiInterfaces::STATE_NOT_AVAILABLE != state;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -71,6 +71,30 @@ namespace commands {
 
 SDL_CREATE_LOG_VARIABLE("Commands")
 
+bool IsMobileResultSuccess(const mobile_apis::Result::eType result_code) {
+  using namespace helpers;
+  return Compare<mobile_apis::Result::eType, EQ, ONE>(
+      result_code,
+      mobile_apis::Result::SUCCESS,
+      mobile_apis::Result::WARNINGS,
+      mobile_apis::Result::WRONG_LANGUAGE,
+      mobile_apis::Result::RETRY,
+      mobile_apis::Result::SAVED,
+      mobile_apis::Result::TRUNCATED_DATA);
+}
+
+bool IsHMIResultSuccess(const hmi_apis::Common_Result::eType result_code) {
+  using namespace helpers;
+  return Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+      result_code,
+      hmi_apis::Common_Result::SUCCESS,
+      hmi_apis::Common_Result::WARNINGS,
+      hmi_apis::Common_Result::WRONG_LANGUAGE,
+      hmi_apis::Common_Result::RETRY,
+      hmi_apis::Common_Result::SAVED,
+      hmi_apis::Common_Result::TRUNCATED_DATA);
+}
+
 const int32_t CommandImpl::hmi_protocol_type_ = 1;
 const int32_t CommandImpl::mobile_protocol_type_ = 0;
 const int32_t CommandImpl::protocol_version_ = 3;
@@ -537,6 +561,31 @@ bool CommandImpl::CheckSyntax(const std::string& str,
     }
   }
   return true;
+}
+
+bool CommandImpl::IsHMIResultSuccess(
+    hmi_apis::Common_Result::eType result_code,
+    HmiInterfaces::InterfaceID interface) const {
+  SDL_LOG_AUTO_TRACE();
+  using namespace helpers;
+  if (Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+          result_code,
+          hmi_apis::Common_Result::SUCCESS,
+          hmi_apis::Common_Result::WARNINGS,
+          hmi_apis::Common_Result::WRONG_LANGUAGE,
+          hmi_apis::Common_Result::RETRY,
+          hmi_apis::Common_Result::SAVED,
+          hmi_apis::Common_Result::TRUNCATED_DATA)) {
+    return true;
+  }
+
+  const HmiInterfaces::InterfaceState state =
+      application_manager_.hmi_interfaces().GetInterfaceState(interface);
+  if ((hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code) &&
+      (HmiInterfaces::STATE_NOT_AVAILABLE != state)) {
+    return true;
+  }
+  return false;
 }
 
 }  // namespace commands

--- a/src/components/application_manager/src/commands/command_request_impl.cc
+++ b/src/components/application_manager/src/commands/command_request_impl.cc
@@ -160,7 +160,7 @@ ResponseInfo::ResponseInfo(const hmi_apis::Common_Result::eType result,
   interface_state =
       application_manager.hmi_interfaces().GetInterfaceState(hmi_interface);
 
-  is_ok = CommandRequestImpl::IsHMIResultSuccess(result_code);
+  is_ok = IsHMIResultSuccess(result_code);
 
   is_not_used = hmi_apis::Common_Result::INVALID_ENUM == result_code;
 
@@ -695,49 +695,11 @@ bool CommandRequestImpl::HasDisallowedParams() const {
           (!removed_parameters_permissions_.undefined_params.empty()));
 }
 
-bool CommandRequestImpl::IsMobileResultSuccess(
-    const mobile_apis::Result::eType result_code) {
-  SDL_LOG_AUTO_TRACE();
-  using namespace helpers;
-  return Compare<mobile_apis::Result::eType, EQ, ONE>(
-      result_code,
-      mobile_apis::Result::SUCCESS,
-      mobile_apis::Result::WARNINGS,
-      mobile_apis::Result::WRONG_LANGUAGE,
-      mobile_apis::Result::RETRY,
-      mobile_apis::Result::SAVED,
-      mobile_apis::Result::TRUNCATED_DATA);
-}
-
-bool CommandRequestImpl::IsHMIResultSuccess(
-    const hmi_apis::Common_Result::eType result_code) {
-  SDL_LOG_AUTO_TRACE();
-  using namespace helpers;
-  return Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
-      result_code,
-      hmi_apis::Common_Result::SUCCESS,
-      hmi_apis::Common_Result::WARNINGS,
-      hmi_apis::Common_Result::WRONG_LANGUAGE,
-      hmi_apis::Common_Result::RETRY,
-      hmi_apis::Common_Result::SAVED,
-      hmi_apis::Common_Result::TRUNCATED_DATA);
-}
-
 bool CommandRequestImpl::PrepareResultForMobileResponse(
     hmi_apis::Common_Result::eType result_code,
     HmiInterfaces::InterfaceID interface) const {
   SDL_LOG_AUTO_TRACE();
-  if (IsHMIResultSuccess(result_code)) {
-    return true;
-  }
-
-  const HmiInterfaces::InterfaceState state =
-      application_manager_.hmi_interfaces().GetInterfaceState(interface);
-  if ((hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code) &&
-      (HmiInterfaces::STATE_NOT_AVAILABLE != state)) {
-    return true;
-  }
-  return false;
+  return IsHMIResultSuccess(result_code, interface);
 }
 
 bool CommandRequestImpl::PrepareResultForMobileResponse(

--- a/src/components/application_manager/src/commands/request_from_hmi.cc
+++ b/src/components/application_manager/src/commands/request_from_hmi.cc
@@ -143,43 +143,6 @@ void RequestFromHMI::FillCommonParametersOfSO(
   (message)[strings::params][strings::correlation_id] = correlation_id;
 }
 
-bool RequestFromHMI::IsMobileResultSuccess(
-    mobile_apis::Result::eType result_code) const {
-  SDL_LOG_AUTO_TRACE();
-  using namespace helpers;
-  return Compare<mobile_apis::Result::eType, EQ, ONE>(
-      result_code,
-      mobile_apis::Result::SUCCESS,
-      mobile_apis::Result::WARNINGS,
-      mobile_apis::Result::WRONG_LANGUAGE,
-      mobile_apis::Result::RETRY,
-      mobile_apis::Result::SAVED);
-}
-
-bool RequestFromHMI::IsHMIResultSuccess(
-    hmi_apis::Common_Result::eType result_code,
-    HmiInterfaces::InterfaceID interface) const {
-  SDL_LOG_AUTO_TRACE();
-  using namespace helpers;
-  if (Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
-          result_code,
-          hmi_apis::Common_Result::SUCCESS,
-          hmi_apis::Common_Result::WARNINGS,
-          hmi_apis::Common_Result::WRONG_LANGUAGE,
-          hmi_apis::Common_Result::RETRY,
-          hmi_apis::Common_Result::SAVED)) {
-    return true;
-  }
-
-  const HmiInterfaces::InterfaceState state =
-      application_manager_.hmi_interfaces().GetInterfaceState(interface);
-  if ((hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code) &&
-      (HmiInterfaces::STATE_NOT_AVAILABLE != state)) {
-    return true;
-  }
-  return false;
-}
-
 void RequestFromHMI::SendProviderRequest(
     const mobile_apis::FunctionID::eType& mobile_function_id,
     const hmi_apis::FunctionID::eType& hmi_function_id,

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -1007,7 +1007,7 @@ bool IsResponseSuccessful(const smart_objects::SmartObject& response) {
       response[strings::params][application_manager::hmi_response::code]
           .asInt());
 
-  return commands::CommandRequestImpl::IsHMIResultSuccess(result_code) ||
+  return commands::IsHMIResultSuccess(result_code) ||
          hmi_apis::Common_Result::UNSUPPORTED_RESOURCE == result_code;
 }
 


### PR DESCRIPTION
Fixes [FORDTCN-12270](https://adc.luxoft.com/jira/browse/FORDTCN-12270)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF test scripts

### Summary
Unify approach to result codes processing
For now we have 6 successful result codes:
SUCCESS,
WARNINGS,
WRONG_LANGUAGE,
RETRY,
SAVED,
TRUNCATED_DATA

Also I didn't change existing logic for UNSUPPORTED_RESOURCE code processing, so only refactoring is there.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
