### PR TITLE
Fix CUSTOM_BUTTON subscription logic

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_button_notification_commands_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/on_button_notification_commands_test.cc
@@ -197,6 +197,9 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
   typename TestFixture::MockAppPtr mock_app = this->CreateMockApp();
   EXPECT_CALL(this->app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
 
+  EXPECT_CALL(*mock_app,
+              IsSubscribedToButton(mobile_apis::ButtonName::CUSTOM_BUTTON))
+      .WillOnce(Return(true));
   EXPECT_CALL(*mock_app, IsSubscribedToSoftButton(kCustomButtonId))
       .WillOnce(Return(false));
 
@@ -228,6 +231,9 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_CustomButton_SUCCESS) {
   ON_CALL(*mock_app, hmi_level(kDefaultWindowId))
       .WillByDefault(Return(mobile_apis::HMILevel::HMI_FULL));
   EXPECT_CALL(this->app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app,
+              IsSubscribedToButton(mobile_apis::ButtonName::CUSTOM_BUTTON))
+      .WillOnce(Return(true));
   EXPECT_CALL(*mock_app, IsSubscribedToSoftButton(kCustomButtonId))
       .WillOnce(Return(true));
   EXPECT_CALL(this->mock_rpc_service_,
@@ -268,6 +274,10 @@ TYPED_TEST(OnButtonNotificationCommandsTest,
       .WillOnce(Return(mobile_apis::HMILevel::HMI_BACKGROUND));
 
   EXPECT_CALL(this->app_mngr_, application(kAppId)).WillOnce(Return(mock_app));
+
+  EXPECT_CALL(*mock_app,
+              IsSubscribedToButton(mobile_apis::ButtonName::CUSTOM_BUTTON))
+      .WillOnce(Return(true));
   EXPECT_CALL(*mock_app, IsSubscribedToSoftButton(kCustomButtonId))
       .WillOnce(Return(true));
 
@@ -357,23 +367,21 @@ TYPED_TEST(OnButtonNotificationCommandsTest, Run_SUCCESS) {
   std::shared_ptr<Notification> command(
       this->template CreateCommand<Notification>(notification_msg));
 
-  typename TestFixture::MockAppPtr mock_app = this->CreateMockApp();
-  std::vector<ApplicationSharedPtr> subscribed_apps_list;
-  subscribed_apps_list.push_back(mock_app);
   auto mock_message_helper = am::MockMessageHelper::message_helper_mock();
   smart_objects::SmartObjectSPtr msg =
       std::make_shared<smart_objects::SmartObject>();
   EXPECT_CALL(*mock_message_helper, CreateButtonNotificationToMobile(_, _))
       .WillRepeatedly(Return(msg));
 
+  typename TestFixture::MockAppPtr mock_app = this->CreateMockApp();
+  EXPECT_CALL(*mock_app, IsSubscribedToButton(kButtonName))
+      .WillOnce(Return(true));
   EXPECT_CALL(*mock_app, hmi_level(kDefaultWindowId))
       .WillRepeatedly(Return(mobile_apis::HMILevel::HMI_FULL));
 
   ON_CALL(*mock_app, IsFullscreen()).WillByDefault(Return(true));
   ON_CALL(this->app_mngr_, application(kAppId)).WillByDefault(Return(mock_app));
 
-  EXPECT_CALL(this->app_mngr_, applications_by_button(kButtonName))
-      .WillOnce(Return(subscribed_apps_list));
   EXPECT_CALL(this->mock_rpc_service_,
               SendMessageToMobile(
                   CheckNotificationMessage(TestFixture::kFunctionId), _));

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -159,8 +159,7 @@ ApplicationImpl::ApplicationImpl(
   set_name(app_name);
 
   MarkUnregistered();
-  // subscribe application to custom button by default
-  SubscribeToButton(mobile_apis::ButtonName::CUSTOM_BUTTON);
+
   // load persistent files
   LoadPersistentFiles();
 

--- a/src/components/application_manager/test/application_impl_test.cc
+++ b/src/components/application_manager/test/application_impl_test.cc
@@ -560,9 +560,9 @@ TEST_F(ApplicationImplTest, SubscribeToButton_UnsubscribeFromButton) {
   EXPECT_FALSE(app_impl->IsSubscribedToButton(ButtonName::PRESET_0));
 }
 
-TEST_F(ApplicationImplTest, SubscribeToDefaultButton_UnsubscribeFromButton) {
-  EXPECT_TRUE(app_impl->IsSubscribedToButton(ButtonName::CUSTOM_BUTTON));
-  EXPECT_FALSE(app_impl->SubscribeToButton(ButtonName::CUSTOM_BUTTON));
+TEST_F(ApplicationImplTest, NotSubscribedToDefaultButton_SubscribeToButton) {
+  EXPECT_FALSE(app_impl->IsSubscribedToButton(ButtonName::CUSTOM_BUTTON));
+  EXPECT_TRUE(app_impl->SubscribeToButton(ButtonName::CUSTOM_BUTTON));
 }
 
 TEST_F(ApplicationImplTest, SubscribeToSoftButton_UnsubscribeFromSoftButton) {


### PR DESCRIPTION
Was removed subscription to the custom button by default.
Also, added check if the app is actually subscribed to CUSTOM_BUTTON like for all other buttons.
