### PR TITLE
Separate subscription processing logic for mobile requests and resumption

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
@@ -367,6 +367,17 @@ class ResumptionDataProcessorImpl
       const smart_objects::SmartObject& request,
       const smart_objects::SmartObject& response) const;
 
+  /**
+   * @brief Checks whether SubscribeButton response successful or not and
+   * subscribes application if successful
+   * @param app_id application id
+   * @param request reference to request SO
+   * @param response reference to response SO
+   */
+  void ProcessSubscribeButtonResponse(
+      const uint32_t app_id,
+      const smart_objects::SmartObject& request,
+      const smart_objects::SmartObject& response);
   app_mngr::ApplicationManager& application_manager_;
 
   /**

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/subscribe_button_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/subscribe_button_request.h
@@ -45,7 +45,8 @@ namespace hmi {
 /**
  * @brief SubscribeButtonRequest command class
  **/
-class SubscribeButtonRequest : public app_mngr::commands::RequestToHMI {
+class SubscribeButtonRequest : public app_mngr::commands::RequestToHMI,
+                               public app_mngr::event_engine::EventObserver {
  public:
   /**
    * @brief SubscribeButtonRequest class constructor
@@ -68,6 +69,8 @@ class SubscribeButtonRequest : public app_mngr::commands::RequestToHMI {
   void Run() OVERRIDE;
 
   void onTimeOut() OVERRIDE;
+
+  void on_event(const application_manager::event_engine::Event& event) OVERRIDE;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(SubscribeButtonRequest);

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/subscribe_button_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/subscribe_button_request.h
@@ -45,8 +45,7 @@ namespace hmi {
 /**
  * @brief SubscribeButtonRequest command class
  **/
-class SubscribeButtonRequest : public app_mngr::commands::RequestToHMI,
-                               public app_mngr::event_engine::EventObserver {
+class SubscribeButtonRequest : public app_mngr::commands::RequestToHMI {
  public:
   /**
    * @brief SubscribeButtonRequest class constructor
@@ -70,21 +69,8 @@ class SubscribeButtonRequest : public app_mngr::commands::RequestToHMI,
 
   void onTimeOut() OVERRIDE;
 
-  void on_event(const application_manager::event_engine::Event& event) OVERRIDE;
-
  private:
   DISALLOW_COPY_AND_ASSIGN(SubscribeButtonRequest);
-
-  /**
-   * @brief Determines whether internal unsubscription must be performed
-   * and HMI UnsubscribeButton request should be sent
-   * @param hmi_result - result code received from HMI
-   * @param app - reference to application instance
-   * @return bool - true if app should unsubscribe internally
-   **/
-  bool ShouldUnsubscribeIntertally(
-      const hmi_apis::Common_Result::eType hmi_result,
-      const app_mngr::Application& app) const;
 
   hmi_apis::Common_ButtonName::eType button_name_;
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/subscribe_button_request.cc
@@ -143,6 +143,11 @@ void SubscribeButtonRequest::on_event(const event_engine::Event& event) {
   const bool result = PrepareResultForMobileResponse(
       hmi_result, HmiInterfaces::HMI_INTERFACE_Buttons);
 
+  if (result) {
+    const auto btn_id = static_cast<mobile_apis::ButtonName::eType>(
+        (*message_)[str::msg_params][str::button_name].asInt());
+    app->SubscribeToButton(btn_id);
+  }
   mobile_apis::Result::eType result_code =
       MessageHelper::HMIToMobileResult(hmi_result);
 

--- a/src/components/application_manager/test/resumption/resume_ctrl_test.cc
+++ b/src/components/application_manager/test/resumption/resume_ctrl_test.cc
@@ -611,12 +611,6 @@ TEST_F(ResumeCtrlTest, StartResumption_AppWithSubscribeOnButtons) {
 
   EXPECT_CALL(*mock_app_, set_grammar_id(kTestGrammarId_));
 
-  for (uint32_t i = 0; i < count_of_buttons; ++i) {
-    EXPECT_CALL(
-        *mock_app_,
-        SubscribeToButton(static_cast<mobile_apis::ButtonName::eType>(i)));
-  }
-
   std::list<application_manager::AppExtensionPtr> extensions;
   extensions.insert(extensions.begin(), mock_app_extension_);
 


### PR DESCRIPTION
Fixes [FORDTCN-12277](https://adc.luxoft.com/jira/browse/FORDTCN-12277)

This PR is **ready** for review.

### Risk
This PR makes **no ** API changes.

### Testing Plan
ATF test scripts

### Summary
Separate subscription processing logic for mobile requests and resumption:
* Delete on_event() method and parent event_observer from hmi::SubscribeButtonRequest class
* Move logic with application subscription to on_event() method of mobile::SubscribeButtonRequest class during mobile request processing
* Move logic with application subscription to ResumptionDataProcessor during Resumption to avoid race conditions with already deleted on_event() method from hmi::SubscribeButtonRequest class

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
