### PR TITLE
Fix sub menues deletion wrong order

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
@@ -82,9 +82,9 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
   bool Init() FINAL;
 
  private:
-  /*
-   * @brief Creates and queues up delete requests for a submenues that have a
-   * parentID that matches the parentID parameter
+  /**
+   * @brief Creates and queues up delete requests for a submenus that have a
+   * parent ID which matches the parentID parameter
    *
    * @param app_id Application ID
    * @param parentID Parent ID of a nested submenu
@@ -93,9 +93,9 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
                             const uint32_t parentID,
                             const app_mngr::SubMenuMap& subMenus);
 
-  /*
-   * @brief Creates and queues up delete requests for a VR commands from SDL for
-   * corresponding submenu ID
+  /**
+   * @brief Creates and queues up delete requests for each VR command tied to
+   * the given submenu ID
    *
    * @param app_id Application ID
    * @param parentID Parent ID of a nested submenu
@@ -103,9 +103,9 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
   void DeleteSubMenuVRCommands(app_mngr::ApplicationConstSharedPtr app,
                                const uint32_t parentID);
 
-  /*
-   * @brief Creates and queues up the delete requests for a UI commands from SDL
-   * for corresponding submenu ID
+  /**
+   * @brief Creates and queues up delete requests for each UI command tied to
+   * the given submenu ID
    *
    * @param app_id Application ID
    * @param parentID Parent ID of a nested submenu

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
@@ -83,8 +83,8 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
 
  private:
   /*
-   * @brief Deletes submenus that have a parentID that matches the parentID
-   * parameter
+   * @brief Creates and queues up delete requests for a submenues that have a
+   * parentID that matches the parentID parameter
    *
    * @param app_id Application ID
    * @param parentID Parent ID of a nested submenu
@@ -94,7 +94,8 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
                             const app_mngr::SubMenuMap& subMenus);
 
   /*
-   * @brief Deletes VR commands from SDL for corresponding submenu ID
+   * @brief Creates and queues up delete requests for a VR commands from SDL for
+   * corresponding submenu ID
    *
    * @param app_id Application ID
    * @param parentID Parent ID of a nested submenu
@@ -103,7 +104,8 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
                                const uint32_t parentID);
 
   /*
-   * @brief Deletes UI commands from SDL for corresponding submenu ID
+   * @brief Creates and queues up the delete requests for a UI commands from SDL
+   * for corresponding submenu ID
    *
    * @param app_id Application ID
    * @param parentID Parent ID of a nested submenu
@@ -111,6 +113,9 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
   void DeleteSubMenuUICommands(app_mngr::ApplicationSharedPtr const app,
                                const uint32_t parentID);
 
+  /**
+   * @brief Takes the next request in the queue and sends it to HMI
+   */
   void SendNextRequest();
 
   typedef std::list<smart_objects::SmartObject> RequestsList;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/delete_sub_menu_request.h
@@ -90,7 +90,7 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
    * @param parentID Parent ID of a nested submenu
    */
   void DeleteNestedSubMenus(app_mngr::ApplicationSharedPtr const app,
-                            uint32_t parentID,
+                            const uint32_t parentID,
                             const app_mngr::SubMenuMap& subMenus);
 
   /*
@@ -100,7 +100,7 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
    * @param parentID Parent ID of a nested submenu
    */
   void DeleteSubMenuVRCommands(app_mngr::ApplicationConstSharedPtr app,
-                               uint32_t parentID);
+                               const uint32_t parentID);
 
   /*
    * @brief Deletes UI commands from SDL for corresponding submenu ID
@@ -109,7 +109,13 @@ class DeleteSubMenuRequest : public app_mngr::commands::CommandRequestImpl {
    * @param parentID Parent ID of a nested submenu
    */
   void DeleteSubMenuUICommands(app_mngr::ApplicationSharedPtr const app,
-                               uint32_t parentID);
+                               const uint32_t parentID);
+
+  void SendNextRequest();
+
+  typedef std::list<smart_objects::SmartObject> RequestsList;
+  RequestsList requests_list_;
+  uint32_t pending_request_corr_id_;
 
   DISALLOW_COPY_AND_ASSIGN(DeleteSubMenuRequest);
 };

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
@@ -133,7 +133,7 @@ void DeleteSubMenuRequest::DeleteNestedSubMenus(ApplicationSharedPtr const app,
     }
 
     if (parentID == (*it->second)[strings::parent_id].asUInt()) {
-      uint32_t menuID = (*it->second)[strings::menu_id].asUInt();
+      const uint32_t menuID = (*it->second)[strings::menu_id].asUInt();
       DeleteNestedSubMenus(app, menuID, subMenus);
 
       smart_objects::SmartObject msg_params =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
@@ -224,8 +224,7 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
         const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
             message[strings::params][hmi_response::code].asInt());
 
-        auto app = application_manager_.application(
-            msg_params[strings::app_id].asUInt());
+        auto app = application_manager_.application(connection_key());
         if (!app) {
           SDL_LOG_ERROR("Application not found");
           return;
@@ -251,10 +250,7 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
           message[strings::params][strings::correlation_id].asUInt();
 
       if (corr_id == pending_request_corr_id_) {
-        auto msg_params = requests_list_.front();
-
-        auto app = application_manager_.application(
-            msg_params[strings::app_id].asUInt());
+        auto app = application_manager_.application(connection_key());
         if (!app) {
           SDL_LOG_ERROR("Application not found");
           return;
@@ -277,8 +273,7 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
         const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
             message[strings::params][hmi_response::code].asInt());
 
-        auto app = application_manager_.application(
-            msg_params[strings::app_id].asUInt());
+        auto app = application_manager_.application(connection_key());
         if (!app) {
           SDL_LOG_ERROR("Application not found");
           return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
@@ -224,18 +224,18 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
         const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
             message[strings::params][hmi_response::code].asInt());
 
-        if (IsHMIResultSuccess(result_code)) {
-          auto app = application_manager_.application(
-              msg_params[strings::app_id].asUInt());
+        auto app = application_manager_.application(
+            msg_params[strings::app_id].asUInt());
+        if (!app) {
+          SDL_LOG_ERROR("Application not found");
+          return;
+        }
 
-          if (app) {
-            const auto cmd_id = msg_params[strings::cmd_id].asUInt();
-            SDL_LOG_DEBUG("Removing UI Command: " << cmd_id);
-            app->RemoveCommand(cmd_id);
-            app->help_prompt_manager().OnVrCommandDeleted(cmd_id, false);
-          } else {
-            SDL_LOG_ERROR("Application not found");
-          }
+        if (IsHMIResultSuccess(result_code)) {
+          const auto cmd_id = msg_params[strings::cmd_id].asUInt();
+          SDL_LOG_DEBUG("Removing UI Command: " << cmd_id);
+          app->RemoveCommand(cmd_id);
+          app->help_prompt_manager().OnVrCommandDeleted(cmd_id, false);
         }
 
         requests_list_.pop_front();
@@ -251,6 +251,15 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
           message[strings::params][strings::correlation_id].asUInt();
 
       if (corr_id == pending_request_corr_id_) {
+        auto msg_params = requests_list_.front();
+
+        auto app = application_manager_.application(
+            msg_params[strings::app_id].asUInt());
+        if (!app) {
+          SDL_LOG_ERROR("Application not found");
+          return;
+        }
+
         requests_list_.pop_front();
       }
 
@@ -268,17 +277,17 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
         const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
             message[strings::params][hmi_response::code].asInt());
 
-        if (IsHMIResultSuccess(result_code)) {
-          auto app = application_manager_.application(
-              msg_params[strings::app_id].asUInt());
+        auto app = application_manager_.application(
+            msg_params[strings::app_id].asUInt());
+        if (!app) {
+          SDL_LOG_ERROR("Application not found");
+          return;
+        }
 
-          if (app) {
-            const auto menu_id = msg_params[strings::menu_id].asUInt();
-            SDL_LOG_DEBUG("Removing submenuID: " << menu_id);
-            app->RemoveSubMenu(menu_id);
-          } else {
-            SDL_LOG_ERROR("Application not found");
-          }
+        if (IsHMIResultSuccess(result_code)) {
+          const auto menu_id = msg_params[strings::menu_id].asUInt();
+          SDL_LOG_DEBUG("Removing submenuID: " << menu_id);
+          app->RemoveSubMenu(menu_id);
         }
 
         requests_list_.pop_front();

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
@@ -193,12 +193,6 @@ void DeleteSubMenuRequest::DeleteSubMenuUICommands(
       continue;
     }
 
-    if ((*it->second).keyExists(strings::vr_commands)) {
-      SDL_LOG_ERROR("Skipping VR command");
-      ++it;
-      continue;
-    }
-
     if (parentID ==
         (*it->second)[strings::menu_params][hmi_request::parent_id].asUInt()) {
       smart_objects::SmartObject msg_params =

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/delete_sub_menu_request.cc
@@ -56,7 +56,9 @@ DeleteSubMenuRequest::DeleteSubMenuRequest(
                          application_manager,
                          rpc_service,
                          hmi_capabilities,
-                         policy_handler) {}
+                         policy_handler)
+    , requests_list_()
+    , pending_request_corr_id_(0) {}
 
 DeleteSubMenuRequest::~DeleteSubMenuRequest() {}
 
@@ -82,19 +84,42 @@ void DeleteSubMenuRequest::Run() {
     return;
   }
 
+  {
+    const DataAccessor<SubMenuMap> accessor = app->sub_menu_map();
+    const SubMenuMap& sub_menus = accessor.GetData();
+    DeleteNestedSubMenus(app, menu_id, sub_menus);
+  }
+
   smart_objects::SmartObject msg_params =
       smart_objects::SmartObject(smart_objects::SmartType_Map);
-
   msg_params[strings::menu_id] =
       (*message_)[strings::msg_params][strings::menu_id];
   msg_params[strings::app_id] = app->app_id();
-  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+  requests_list_.push_back(msg_params);
 
-  SendHMIRequest(hmi_apis::FunctionID::UI_DeleteSubMenu, &msg_params, true);
+  StartAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+  SendNextRequest();
+}
+
+void DeleteSubMenuRequest::SendNextRequest() {
+  SDL_LOG_AUTO_TRACE();
+
+  const auto request_params = requests_list_.front();
+  auto function_id = hmi_apis::FunctionID::UI_DeleteSubMenu;
+
+  if (request_params.keyExists(strings::cmd_id)) {
+    function_id = request_params.keyExists(strings::grammar_id)
+                      ? hmi_apis::FunctionID::VR_DeleteCommand
+                      : hmi_apis::FunctionID::UI_DeleteCommand;
+  }
+
+  pending_request_corr_id_ = SendHMIRequest(function_id, &request_params, true);
+  SDL_LOG_DEBUG(
+      "Waiting for response for corr_id = " << pending_request_corr_id_);
 }
 
 void DeleteSubMenuRequest::DeleteNestedSubMenus(ApplicationSharedPtr const app,
-                                                uint32_t parentID,
+                                                const uint32_t parentID,
                                                 const SubMenuMap& subMenus) {
   SDL_LOG_AUTO_TRACE();
 
@@ -110,24 +135,24 @@ void DeleteSubMenuRequest::DeleteNestedSubMenus(ApplicationSharedPtr const app,
     if (parentID == (*it->second)[strings::parent_id].asUInt()) {
       uint32_t menuID = (*it->second)[strings::menu_id].asUInt();
       DeleteNestedSubMenus(app, menuID, subMenus);
-      DeleteSubMenuVRCommands(app, menuID);
-      DeleteSubMenuUICommands(app, menuID);
+
       smart_objects::SmartObject msg_params =
           smart_objects::SmartObject(smart_objects::SmartType_Map);
       msg_params[strings::menu_id] = menuID;
       msg_params[strings::app_id] = app->app_id();
-      SendHMIRequest(hmi_apis::FunctionID::UI_DeleteSubMenu, &msg_params);
-      ++it;
-      SDL_LOG_DEBUG("Removing submenuID: " << menuID);
-      app->RemoveSubMenu(menuID);
-    } else {
-      ++it;
+      requests_list_.push_back(msg_params);
     }
+
+    ++it;
   }
+
+  SDL_LOG_DEBUG("Delete commands with Parent ID: " << parentID);
+  DeleteSubMenuVRCommands(app, parentID);
+  DeleteSubMenuUICommands(app, parentID);
 }
 
 void DeleteSubMenuRequest::DeleteSubMenuVRCommands(
-    ApplicationConstSharedPtr app, uint32_t parentID) {
+    ApplicationConstSharedPtr app, const uint32_t parentID) {
   SDL_LOG_AUTO_TRACE();
 
   const DataAccessor<CommandsMap> accessor = app->commands_map();
@@ -148,7 +173,7 @@ void DeleteSubMenuRequest::DeleteSubMenuVRCommands(
       msg_params[strings::grammar_id] = app->get_grammar_id();
       msg_params[strings::type] = hmi_apis::Common_VRCommandType::Command;
 
-      SendHMIRequest(hmi_apis::FunctionID::VR_DeleteCommand, &msg_params);
+      requests_list_.push_back(msg_params);
     }
   }
 }
@@ -168,6 +193,12 @@ void DeleteSubMenuRequest::DeleteSubMenuUICommands(
       continue;
     }
 
+    if ((*it->second).keyExists(strings::vr_commands)) {
+      SDL_LOG_ERROR("Skipping VR command");
+      ++it;
+      continue;
+    }
+
     if (parentID ==
         (*it->second)[strings::menu_params][hmi_request::parent_id].asUInt()) {
       smart_objects::SmartObject msg_params =
@@ -175,16 +206,11 @@ void DeleteSubMenuRequest::DeleteSubMenuUICommands(
       const uint32_t cmd_id = (*it->second)[strings::cmd_id].asUInt();
       msg_params[strings::app_id] = app->app_id();
       msg_params[strings::cmd_id] = cmd_id;
-      SDL_LOG_DEBUG("Removing UI Command: " << cmd_id);
-      app->RemoveCommand(cmd_id);
-      app->help_prompt_manager().OnVrCommandDeleted(cmd_id, false);
-      it = commands.begin();  // Can not relay on
-                              // iterators after erase was called
 
-      SendHMIRequest(hmi_apis::FunctionID::UI_DeleteCommand, &msg_params);
-    } else {
-      ++it;
+      requests_list_.push_back(msg_params);
     }
+
+    ++it;
   }
 }
 
@@ -193,48 +219,106 @@ void DeleteSubMenuRequest::on_event(const event_engine::Event& event) {
   const smart_objects::SmartObject& message = event.smart_object();
 
   switch (event.id()) {
-    case hmi_apis::FunctionID::UI_DeleteSubMenu: {
-      EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
-      hmi_apis::Common_Result::eType result_code =
-          static_cast<hmi_apis::Common_Result::eType>(
-              message[strings::params][hmi_response::code].asInt());
-      std::string response_info;
-      GetInfo(message, response_info);
-      const bool result = PrepareResultForMobileResponse(
-          result_code, HmiInterfaces::HMI_INTERFACE_UI);
+    case hmi_apis::FunctionID::UI_DeleteCommand: {
+      SDL_LOG_DEBUG("Received UI_DeleteCommand response");
 
-      ApplicationSharedPtr application =
-          application_manager_.application(connection_key());
+      const auto corr_id =
+          message[strings::params][strings::correlation_id].asUInt();
+      if (pending_request_corr_id_ == corr_id) {
+        auto msg_params = requests_list_.front();
 
-      if (!application) {
-        SDL_LOG_ERROR("NULL pointer");
-        return;
+        const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+            message[strings::params][hmi_response::code].asInt());
+
+        if (IsHMIResultSuccess(result_code)) {
+          auto app = application_manager_.application(
+              msg_params[strings::app_id].asUInt());
+
+          if (app) {
+            const auto cmd_id = msg_params[strings::cmd_id].asUInt();
+            SDL_LOG_DEBUG("Removing UI Command: " << cmd_id);
+            app->RemoveCommand(cmd_id);
+            app->help_prompt_manager().OnVrCommandDeleted(cmd_id, false);
+          } else {
+            SDL_LOG_ERROR("Application not found");
+          }
+        }
+
+        requests_list_.pop_front();
       }
 
-      if (result) {
-        // delete sub menu items from SDL and HMI
-        uint32_t parentID =
-            (*message_)[strings::msg_params][strings::menu_id].asUInt();
-        const DataAccessor<SubMenuMap> accessor = application->sub_menu_map();
-        const SubMenuMap& subMenus = accessor.GetData();
-        DeleteNestedSubMenus(application, parentID, subMenus);
-        DeleteSubMenuVRCommands(application, parentID);
-        DeleteSubMenuUICommands(application, parentID);
-        application->RemoveSubMenu(
-            (*message_)[strings::msg_params][strings::menu_id].asInt());
-      }
-
-      SendResponse(result,
-                   MessageHelper::HMIToMobileResult(result_code),
-                   response_info.empty() ? NULL : response_info.c_str(),
-                   &(message[strings::msg_params]));
       break;
     }
+
+    case hmi_apis::FunctionID::VR_DeleteCommand: {
+      SDL_LOG_DEBUG("Received VR_DeleteCommand response");
+
+      const auto corr_id =
+          message[strings::params][strings::correlation_id].asUInt();
+
+      if (corr_id == pending_request_corr_id_) {
+        requests_list_.pop_front();
+      }
+
+      break;
+    }
+
+    case hmi_apis::FunctionID::UI_DeleteSubMenu: {
+      SDL_LOG_DEBUG("Received UI_DeleteSubMenu response");
+
+      const auto corr_id =
+          message[strings::params][strings::correlation_id].asUInt();
+      if (corr_id == pending_request_corr_id_) {
+        auto msg_params = requests_list_.front();
+
+        const auto result_code = static_cast<hmi_apis::Common_Result::eType>(
+            message[strings::params][hmi_response::code].asInt());
+
+        if (IsHMIResultSuccess(result_code)) {
+          auto app = application_manager_.application(
+              msg_params[strings::app_id].asUInt());
+
+          if (app) {
+            const auto menu_id = msg_params[strings::menu_id].asUInt();
+            SDL_LOG_DEBUG("Removing submenuID: " << menu_id);
+            app->RemoveSubMenu(menu_id);
+          } else {
+            SDL_LOG_ERROR("Application not found");
+          }
+        }
+
+        requests_list_.pop_front();
+      }
+
+      break;
+    }
+
     default: {
       SDL_LOG_ERROR("Received unknown event" << event.id());
       return;
     }
   }
+
+  if (!requests_list_.empty()) {
+    SDL_LOG_DEBUG("Still waiting for another requests");
+    SendNextRequest();
+    return;
+  }
+
+  EndAwaitForInterface(HmiInterfaces::HMI_INTERFACE_UI);
+
+  hmi_apis::Common_Result::eType result_code =
+      static_cast<hmi_apis::Common_Result::eType>(
+          message[strings::params][hmi_response::code].asInt());
+  std::string response_info;
+  GetInfo(message, response_info);
+  const bool result = PrepareResultForMobileResponse(
+      result_code, HmiInterfaces::HMI_INTERFACE_UI);
+
+  SendResponse(result,
+               MessageHelper::HMIToMobileResult(result_code),
+               response_info.empty() ? NULL : response_info.c_str(),
+               &(message[strings::msg_params]));
 }
 
 bool DeleteSubMenuRequest::Init() {


### PR DESCRIPTION
Fixes `https://github.com/smartdevicelink/sdl_core/issues/3747`

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Can be reproduced manually:

##### Reproduction Steps
1. SDL and HMI are started
2. Mobile device connected
3. Mobile app is registered and activated
4. SubMenu item is added
AddSubMenu("menuID":1, "menuName":"Submenu Name 1")`
5. Nested submenu items are added (each submenu is nested in the previous submenu)
    Send AddSubMenu(parentID=1, "menuID":2, "menuName":"Submenu Name 2")
    Send AddSubMenu(parentID=2, "menuID":3, "menuName":"Submenu Name 3")
    Send AddSubMenu(parentID=3, "menuID":4, "menuName":"Submenu Name 4")
6. AddCommand item is added to nested SubMenu
    Send AddCommand("menuParams: { "parentID:4, "menuName":"Item to Add 1", "position":0)
7. Delete submenu item (item is menu-tree branch)
    Send DeleteSubMenu("menuID":1)

### Summary
The issue which was observed is that SDL sends `DeleteSubMenu` request to HMI for a "parent node" submenu and then sends
subsequent `DeleteSubMenu` requests recursively for all child nodes starting from the bottom one. Such an order confuses HMI because deletion of parent node may automatically trigger deletion of all its child nodes on the HMI side so subsequent requests from SDL for a child node might be rejected.
To make sure that HMI removes all the hierarchy properly, SDL should start deletion sequence from the bottom nodes and delete the parent node in the end. To resolve that issue, `DeleteSubMenu` request logic was updated. Currently, SDL recursively iterates through the submenu and command nodes and collects them in a queue.
Once the queue is ready, SDL sends requests one by one, waiting for an HMI response for each sent request before sending the
subsequent. Once the responses to all requests are received, SDL sends the final response to the mobile app and finalizes the
command.
Also updated DeleteSubMenu unit tests to cover new logic.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
