### PR TITLE
Fix applying functional group consent for all applications

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -720,7 +720,7 @@ void PolicyHandler::OnAppPermissionConsentInternal(
       policy_manager->SetUserConsentForApp(out_permissions);
 #endif
     }
-  } else if (!app_to_device_link_.empty()) {
+  } else {
     const ApplicationSet& accessor =
         application_manager_.applications().GetData();
     for (const auto& app : accessor) {
@@ -759,10 +759,6 @@ void PolicyHandler::OnAppPermissionConsentInternal(
       policy_manager->SetUserConsentForApp(out_permissions);
 #endif
     }
-  } else {
-    SDL_LOG_WARN(
-        "There are no applications previously stored for "
-        "setting common permissions.");
   }
 #ifdef EXTERNAL_PROPRIETARY_MODE
   if (!policy_manager->SetExternalConsentStatus(external_consent_status)) {


### PR DESCRIPTION
Fixes #[22420](https://adc.luxoft.com/jira/browse/FORDTCN-12420)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
[ATF Scripts](https://github.com/LuxoftSDL/sdl_atf_test_scripts/commit/6d7c96997aba05e09726ff084e2820af4f6a1729)

### Summary
Deleted useless if statement. 
SDL has to apply permissions provided in `SDL.OnAppPermissionConsent` notification regardless of `SDL.GetListOfPermissions`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
