### PR TITLE
use files from the rps_spec folder without copying to the sdl_core

### DIFF
--- a/src/components/interfaces/CMakeLists.txt
+++ b/src/components/interfaces/CMakeLists.txt
@@ -29,14 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Copy RPC spec submodule files to interfaces directory
-if(EXISTS ${CMAKE_SOURCE_DIR}/tools/rpc_spec/)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml
-                  ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xml)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                  ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xsd
-                  ${CMAKE_CURRENT_SOURCE_DIR}/MOBILE_API.xsd)
-else ()
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/tools/rpc_spec/)
   message( FATAL_ERROR "Missing the RPC Spec submodule" )
   message( FATAL_ERROR "Please run `git submodule update --init` in the SDL Core source directory" )
 endif ()

--- a/src/components/policy/policy_external/CMakeLists.txt
+++ b/src/components/policy/policy_external/CMakeLists.txt
@@ -76,7 +76,7 @@ set(GENERATED_MOBILE_POLICY_TYPES
   ${GENERATED_MOBILE_POLICY_TYPES_CPP})
 
 generate_policy_types("${GENERATED_MOBILE_POLICY_TYPES}"
-                      "${COMPONENTS_DIR}/interfaces/MOBILE_API.xml"
+                      "${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml"
                       "rpc::policy_table_interface_base"
                       "mobile-policy-types")
 

--- a/src/components/policy/policy_regular/CMakeLists.txt
+++ b/src/components/policy/policy_regular/CMakeLists.txt
@@ -61,7 +61,7 @@ set(GENERATED_MOBILE_POLICY_TYPES
   ${GENERATED_MOBILE_POLICY_TYPES_CPP})
 
 generate_policy_types("${GENERATED_MOBILE_POLICY_TYPES}"
-                      "${COMPONENTS_DIR}/interfaces/MOBILE_API.xml"
+                      "${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml"
                       "rpc::policy_table_interface_base"
                       "mobile-policy-types")
 

--- a/src/components/utils/test/test_generator/CMakeLists.txt
+++ b/src/components/utils/test/test_generator/CMakeLists.txt
@@ -39,7 +39,7 @@ include_directories (
   ${GMOCK_INCLUDE_DIRECTORY}
 )
 
-set(XML_NAME ${CMAKE_SOURCE_DIR}/src/components/interfaces/MOBILE_API.xml)
+set(XML_NAME ${CMAKE_SOURCE_DIR}/tools/rpc_spec/MOBILE_API.xml)
 add_custom_target(generate_version
   COMMAND ${INTEFRACE_GENERATOR_CMD} "--source-xml" "${XML_NAME}" "--namespace" "mobile_apis"
   "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}" "--parser-type" "sdlrpcv2" "-y"

--- a/tools/cmake/helpers/generators.cmake
+++ b/tools/cmake/helpers/generators.cmake
@@ -63,7 +63,11 @@ macro(generate_interface ARG_XML_NAME ARG_NAMESPACE PARSER_TYPE)
   )
 
   set(CPP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}_schema.cc")
-  set(FULL_XML_NAME "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_XML_NAME}")
+  if("${ARG_XML_NAME}" STREQUAL "MOBILE_API.xml")
+	set(FULL_XML_NAME "${CMAKE_SOURCE_DIR}/tools/rpc_spec/${ARG_XML_NAME}")
+  else()
+    set(FULL_XML_NAME "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_XML_NAME}")
+endif()
 
   add_custom_command(
     OUTPUT ${HPP_FILE} ${CPP_FILE}


### PR DESCRIPTION
### Fixes #[4742](https://adc.luxoft.com/jira/browse/FORDTCN-4742)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
We copied files from rpc_spec to  sdl_core/src/components/interfaces. Now we use MOBILE_API.xml from submodule rpc_spec instead of copied for classes generation

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
