### PR TITLE
fix/sdl_does_not_stop_after_ignition_off_in_case_mobile_connected_via_usb

### DIFF
--- a/src/components/transport_manager/src/usb/libusb/usb_connection.cc
+++ b/src/components/transport_manager/src/usb/libusb/usb_connection.cc
@@ -81,7 +81,6 @@ UsbConnection::UsbConnection(const DeviceUID& device_uid,
 UsbConnection::~UsbConnection() {
   SDL_LOG_TRACE("enter with this" << this);
   Finalise();
-  libusb_free_transfer(in_transfer_);
   delete[] in_buffer_;
   SDL_LOG_TRACE("exit");
 }
@@ -129,34 +128,41 @@ std::string hex_data(const unsigned char* const buffer,
 
 void UsbConnection::OnInTransfer(libusb_transfer* transfer) {
   SDL_LOG_AUTO_TRACE();
-  if (transfer->status == LIBUSB_TRANSFER_CANCELLED) {
-    SDL_LOG_DEBUG("Free already canceled transfer.");
-    libusb_free_transfer(transfer);
+  SDL_LOG_TRACE("enter with Libusb_transfer*: " << transfer);
+  switch (transfer->status) {
+    case LIBUSB_TRANSFER_COMPLETED: {
+      SDL_LOG_DEBUG("USB incoming transfer, size:"
+                    << transfer->actual_length << ", data:"
+                    << hex_data(transfer->buffer, transfer->actual_length));
+      ::protocol_handler::RawMessagePtr data(new protocol_handler::RawMessage(
+          0, 0, in_buffer_, transfer->actual_length, false));
+      controller_->DataReceiveDone(device_uid_, app_handle_, data);
+      break;
+    }
+
+    case LIBUSB_TRANSFER_CANCELLED: {
+      SDL_LOG_DEBUG("Free already canceled transfer.");
+      break;
+    }
+
+    default: {
+      SDL_LOG_ERROR("USB incoming transfer failed: "
+                    << libusb_error_name(transfer->status));
+      controller_->DataReceiveFailed(
+          device_uid_, app_handle_, DataReceiveError());
+    }
+  }
+
+  if (disconnecting_) {
+    libusb_free_transfer(in_transfer_);
+    waiting_in_transfer_cancel_ = false;
     return;
   }
 
-  SDL_LOG_TRACE("enter with Libusb_transfer*: " << transfer);
-  if (transfer->status == LIBUSB_TRANSFER_COMPLETED) {
-    SDL_LOG_DEBUG("USB incoming transfer, size:"
-                  << transfer->actual_length << ", data:"
-                  << hex_data(transfer->buffer, transfer->actual_length));
-    ::protocol_handler::RawMessagePtr data(new protocol_handler::RawMessage(
-        0, 0, in_buffer_, transfer->actual_length, false));
-    controller_->DataReceiveDone(device_uid_, app_handle_, data);
-  } else {
-    SDL_LOG_ERROR("USB incoming transfer failed: "
-                  << libusb_error_name(transfer->status));
-    controller_->DataReceiveFailed(
-        device_uid_, app_handle_, DataReceiveError());
-  }
-  if (disconnecting_) {
-    waiting_in_transfer_cancel_ = false;
-  } else {
-    if (!PostInTransfer()) {
-      SDL_LOG_ERROR("USB incoming transfer failed with "
-                    << "LIBUSB_TRANSFER_NO_DEVICE. Abort connection.");
-      AbortConnection();
-    }
+  if (!PostInTransfer()) {
+    SDL_LOG_ERROR("USB incoming transfer failed with "
+                  << "LIBUSB_TRANSFER_NO_DEVICE. Abort connection.");
+    AbortConnection();
   }
   SDL_LOG_TRACE("exit");
 }
@@ -208,44 +214,48 @@ TransportAdapter::Error UsbConnection::PostOutTransfer() {
 
 void UsbConnection::OnOutTransfer(libusb_transfer* transfer) {
   SDL_LOG_AUTO_TRACE();
-  if (transfer->status == LIBUSB_TRANSFER_CANCELLED) {
-    SDL_LOG_DEBUG("Free already canceled transfer.");
-    libusb_free_transfer(transfer);
-    return;
-  }
-
   SDL_LOG_TRACE("enter with  Libusb_transfer*: " << transfer);
   auto error_code = TransportAdapter::OK;
   {
     sync_primitives::AutoLock locker(out_messages_mutex_);
-    if (LIBUSB_TRANSFER_COMPLETED == transfer->status) {
-      bytes_sent_ += transfer->actual_length;
-      if (current_out_message_->data_size() == bytes_sent_) {
-        SDL_LOG_DEBUG(
-            "USB out transfer, data sent: " << current_out_message_.get());
-        controller_->DataSendDone(
-            device_uid_, app_handle_, current_out_message_);
+    switch (transfer->status) {
+      case LIBUSB_TRANSFER_COMPLETED: {
+        bytes_sent_ += transfer->actual_length;
+        if (current_out_message_->data_size() == bytes_sent_) {
+          SDL_LOG_DEBUG(
+              "USB out transfer, data sent: " << current_out_message_.get());
+          controller_->DataSendDone(
+              device_uid_, app_handle_, current_out_message_);
+          error_code = PopOutMessage();
+        }
+        break;
+      }
+
+      case LIBUSB_TRANSFER_CANCELLED: {
+        SDL_LOG_DEBUG("Free already canceled transfer.");
+        break;
+      }
+
+      default: {
+        SDL_LOG_ERROR(
+            "USB out transfer failed: " << libusb_error_name(transfer->status));
+        controller_->DataSendFailed(
+            device_uid_, app_handle_, current_out_message_, DataSendError());
         error_code = PopOutMessage();
       }
-    } else {
-      SDL_LOG_ERROR(
-          "USB out transfer failed: " << libusb_error_name(transfer->status));
-      controller_->DataSendFailed(
-          device_uid_, app_handle_, current_out_message_, DataSendError());
-      error_code = PopOutMessage();
     }
-    if (current_out_message_.use_count() == 0) {
+
+    if (waiting_out_transfer_cancel_ || current_out_message_.use_count() == 0) {
       libusb_free_transfer(transfer);
       out_transfer_ = nullptr;
       waiting_out_transfer_cancel_ = false;
+      return;
     }
   }
 
   if (TransportAdapter::FAIL == error_code) {
     AbortConnection();
   }
-
-  SDL_LOG_TRACE("exit");
 }
 
 TransportAdapter::Error UsbConnection::SendData(


### PR DESCRIPTION
Fixes #[12547](https://adc.luxoft.com/jira/browse/FORDTCN-12547)

This PR is ready for review.

Risk
This PR makes no API changes.

Summary
After the ignition is switched off, the core does not switch off. Hangs on disconnecting the USB connection.
The shutdown was interrupted by the part of the code that I deleted and the waiting_in_transfer_cancel_ variable did not change to false. Because of this, in the Finalize function loop did not stop working. Removed the unit that interrupted the sequence of closing the connection to the device via usb in function OnInTransfer.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
