### PR TITLE
Fix wrong behavior of RCOnRemoteControlSettingsNotification

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_on_remote_control_settings_notification.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/commands/hmi/rc_on_remote_control_settings_notification.h
@@ -76,6 +76,18 @@ class RCOnRemoteControlSettingsNotification
    * notifications
    */
   void DisallowRCFunctionality();
+
+  /**
+   * @brief Performs the set of actions depending on access mode param received
+   * in the message
+   */
+  void ProcessAccessModeParam();
+
+  /**
+   * @brief Performs the set of actions depending on allowed param received in
+   * the message
+   */
+  void ProcessAllowedParam();
 };
 }  // namespace commands
 }  // namespace rc_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/resource_allocation_manager.h
@@ -209,8 +209,16 @@ class ResourceAllocationManager {
       NotificationTrigger::eType event,
       application_manager::ApplicationSharedPtr application) = 0;
 
+  /**
+   * @brief Returns current state of RC functionality
+   * @return current state of RC functionality
+   */
   virtual bool is_rc_enabled() const = 0;
 
+  /**
+   * @brief Sets current state of RC functionality to a new one
+   * @param value new RC functionality state
+   */
   virtual void set_rc_enabled(const bool value) = 0;
 
   /**

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
@@ -117,18 +117,61 @@ class RCOnRemoteControlSettingsNotificationTest
 };
 
 TEST_F(RCOnRemoteControlSettingsNotificationTest,
-       Run_Allowed_SetAccessMode) {  // Arrange
+       Run_Allowed_MissedAccessMode) {  // Arrange
   MessageSharedPtr mobile_message = CreateBasicMessage();
   (*mobile_message)[application_manager::strings::msg_params]
                    [message_params::kAllowed] = true;
 
   // Expectations
+  EXPECT_CALL(mock_allocation_manager_, SetAccessMode(_)).Times(0);
+  EXPECT_CALL(mock_allocation_manager_, set_rc_enabled(true));
 
-  ON_CALL(mock_allocation_manager_, GetAccessMode())
-      .WillByDefault(Return(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
+  // Act
+  std::shared_ptr<
+      rc_rpc_plugin::commands::RCOnRemoteControlSettingsNotification>
+      command = CreateRCCommand<
+          rc_rpc_plugin::commands::RCOnRemoteControlSettingsNotification>(
+          mobile_message);
 
+  command->Run();
+}
+
+TEST_F(RCOnRemoteControlSettingsNotificationTest,
+       Run_AccessMode_MissedAllowed) {  // Arrange
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kAllowed] = true;
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kAccessMode] =
+                       hmi_apis::Common_RCAccessMode::ASK_DRIVER;
+
+  // Expectations
+  EXPECT_CALL(mock_allocation_manager_, set_rc_enabled(true));
   EXPECT_CALL(mock_allocation_manager_,
               SetAccessMode(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
+
+  // Act
+  std::shared_ptr<
+      rc_rpc_plugin::commands::RCOnRemoteControlSettingsNotification>
+      command = CreateRCCommand<
+          rc_rpc_plugin::commands::RCOnRemoteControlSettingsNotification>(
+          mobile_message);
+
+  command->Run();
+}
+
+TEST_F(RCOnRemoteControlSettingsNotificationTest,
+       Run_AccessModeAndAllowed_BothPresent) {  // Arrange
+  MessageSharedPtr mobile_message = CreateBasicMessage();
+  (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kAccessMode] =
+                       hmi_apis::Common_RCAccessMode::ASK_DRIVER;
+
+  // Expectations
+  EXPECT_CALL(mock_allocation_manager_, set_rc_enabled(_)).Times(0);
+  EXPECT_CALL(mock_allocation_manager_,
+              SetAccessMode(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
+
   // Act
   std::shared_ptr<
       rc_rpc_plugin::commands::RCOnRemoteControlSettingsNotification>

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/on_remote_control_settings_test.cc
@@ -140,13 +140,11 @@ TEST_F(RCOnRemoteControlSettingsNotificationTest,
        Run_AccessMode_MissedAllowed) {  // Arrange
   MessageSharedPtr mobile_message = CreateBasicMessage();
   (*mobile_message)[application_manager::strings::msg_params]
-                   [message_params::kAllowed] = true;
-  (*mobile_message)[application_manager::strings::msg_params]
                    [message_params::kAccessMode] =
                        hmi_apis::Common_RCAccessMode::ASK_DRIVER;
 
   // Expectations
-  EXPECT_CALL(mock_allocation_manager_, set_rc_enabled(true));
+  EXPECT_CALL(mock_allocation_manager_, set_rc_enabled(_)).Times(0);
   EXPECT_CALL(mock_allocation_manager_,
               SetAccessMode(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
 
@@ -164,11 +162,13 @@ TEST_F(RCOnRemoteControlSettingsNotificationTest,
        Run_AccessModeAndAllowed_BothPresent) {  // Arrange
   MessageSharedPtr mobile_message = CreateBasicMessage();
   (*mobile_message)[application_manager::strings::msg_params]
+                   [message_params::kAllowed] = true;
+  (*mobile_message)[application_manager::strings::msg_params]
                    [message_params::kAccessMode] =
                        hmi_apis::Common_RCAccessMode::ASK_DRIVER;
 
   // Expectations
-  EXPECT_CALL(mock_allocation_manager_, set_rc_enabled(_)).Times(0);
+  EXPECT_CALL(mock_allocation_manager_, set_rc_enabled(true));
   EXPECT_CALL(mock_allocation_manager_,
               SetAccessMode(hmi_apis::Common_RCAccessMode::ASK_DRIVER));
 


### PR DESCRIPTION
Fixes #[12680](https://adc.luxoft.com/jira/browse/FORDTCN-12680)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Steps:
1. Two RC apps are registered
2. RC functionality is allowed both apps by policy
3. RC functionality is enabled from HMI via OnRemoteControlSettings without setting of access mode OnRemoteControlSettings [allowed = true]
4. Set <mode> access mode without allowed parameter via OnRemoteControlSettings OnRemoteControlSettings [accessMode = <mode>] where <mode> is one of {"AUTO_DENY", "ASK_DRIVER", "AUTO_ALLOW"}

**Expected result::**
SDL applys received <mode> accessMode and does not enable/disable of RC functionality and change its behavior according applied accessMode

### Summary
Looks like `kAllowed` parameter was switching on/off the RC functionality even if it was not present and the previous value should be taken. Processing of `kAllowed` and `kAccessMode` was split into two separate and independent functions make it really isolated.
Processing of both parameters was aligned, so now core does not perform extra actions if one of the parameters is missing.
Also added more unit tests to cover that functionality.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
