### PR TITLE
Fix unstable unit test

### DIFF
--- a/src/components/transport_manager/test/websocket_connection_test.cc
+++ b/src/components/transport_manager/test/websocket_connection_test.cc
@@ -141,6 +141,10 @@ TEST_F(WebsocketNotSecureSessionConnectionTest, SUCCESS_SendData) {
   auto error = websocket_connection_->SendData(message);
 
   ASSERT_EQ(TransportAdapter::Error::OK, error);
+
+  auto disconnect_error = websocket_connection_->Disconnect();
+
+  ASSERT_EQ(TransportAdapter::Error::OK, disconnect_error);
 }
 
 TEST_F(WebsocketNotSecureSessionConnectionTest, UNSUCCESS_SendData_BAD_STATE) {


### PR DESCRIPTION
Fixes #[issue number]

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by unit tests

### Summary
Looks like we have to properly shut down the message queue in the unit test `WebsocketNotSecureSessionConnectionTest.SUCCESS_SendData` which emulates data sending over the secured WebSocket session. Otherwise, the unit test might be terminated earlier and data sending will be failed which causes a core crash.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
