### PR TITLE
Fix unstable policy handler unit tests

### DIFF
--- a/src/components/application_manager/test/policy_handler_test.cc
+++ b/src/components/application_manager/test/policy_handler_test.cc
@@ -127,7 +127,7 @@ class PolicyHandlerTest : public ::testing::Test {
       , kGroupNameAllowed_("name_allowed")
       , kGroupNameDisallowed_("name_disallowed")
       , kCallsCount_(1u)
-      , kTimeout_(1000u)
+      , kTimeout_(2000u)
       , mock_message_helper_(*MockMessageHelper::message_helper_mock()) {
     Mock::VerifyAndClearExpectations(&mock_message_helper_);
   }


### PR DESCRIPTION
Fixes #[issue number]

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Covered by unit tests

### Summary
Looks like there was a missing async waiter in some unit tests so the Async thread is still working when the unit test is already finalized. That causes core crashes and random unit-test failures.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
