### PR TITLE
Core dump on ignition off during registering 20 apps

### DIFF
--- a/src/components/application_manager/include/application_manager/application.h
+++ b/src/components/application_manager/include/application_manager/application.h
@@ -1181,7 +1181,8 @@ class Application : public virtual InitialApplicationData,
    * @brief Get list of available application extensions
    * @return application extensions
    */
-  virtual const std::list<AppExtensionPtr>& Extensions() const = 0;
+  virtual const DataAccessor<std::list<AppExtensionPtr> > Extensions()
+      const = 0;
 
   /**
    * @brief Get cloud app endpoint for websocket connection

--- a/src/components/application_manager/include/application_manager/application_impl.h
+++ b/src/components/application_manager/include/application_manager/application_impl.h
@@ -555,7 +555,7 @@ class ApplicationImpl : public virtual Application,
    */
   bool RemoveExtension(AppExtensionUID uid) OVERRIDE;
 
-  const std::list<AppExtensionPtr>& Extensions() const OVERRIDE;
+  const DataAccessor<std::list<AppExtensionPtr> > Extensions() const OVERRIDE;
 
   std::string hash_val_;
   uint32_t grammar_id_;
@@ -617,6 +617,7 @@ class ApplicationImpl : public virtual Application,
   Timer audio_stream_suspend_timer_;
 
   std::list<AppExtensionPtr> extensions_;
+  mutable std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
 
   // Cloud app properties
   std::string endpoint_;
@@ -644,7 +645,6 @@ class ApplicationImpl : public virtual Application,
   CommandSoftButtonID cmd_softbuttonid_;
   // Lock for command soft button id
   sync_primitives::Lock cmd_softbuttonid_lock_;
-  mutable std::shared_ptr<sync_primitives::Lock> vi_lock_ptr_;
   mutable std::shared_ptr<sync_primitives::Lock> button_lock_ptr_;
   std::string folder_name_;
   ApplicationManager& application_manager_;

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -1023,8 +1023,6 @@ class ApplicationManagerImpl
     rpc_service_ = std::move(rpc_service);
   }
 
-  bool is_stopping() const OVERRIDE;
-
   bool is_audio_pass_thru_active() const OVERRIDE;
   /*
    * @brief Function Should be called when Low Voltage is occured

--- a/src/components/application_manager/include/application_manager/commands/command.h
+++ b/src/components/application_manager/include/application_manager/commands/command.h
@@ -137,6 +137,8 @@ class Command {
    */
   virtual void SetAllowedToTerminate(const bool allowed) = 0;
 
+  virtual const ApplicationManager& GetApplicationManager() const = 0;
+
   enum CommandSource {
     SOURCE_SDL,
     SOURCE_MOBILE,

--- a/src/components/application_manager/include/application_manager/commands/command_impl.h
+++ b/src/components/application_manager/include/application_manager/commands/command_impl.h
@@ -182,6 +182,8 @@ class CommandImpl : public Command {
    */
   void SetAllowedToTerminate(const bool allowed) OVERRIDE;
 
+  const ApplicationManager& GetApplicationManager() const OVERRIDE;
+
   void OnUpdateTimeOut() OVERRIDE;
 
   /**

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -148,8 +148,8 @@ ApplicationImpl::ApplicationImpl(
           "AudioStreamSuspend",
           new ::timer::TimerTaskImpl<ApplicationImpl>(
               this, &ApplicationImpl::OnAudioStreamSuspend))
+    , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>())
     , hybrid_app_preference_(mobile_api::HybridAppPreference::INVALID_ENUM)
-    , vi_lock_ptr_(std::make_shared<sync_primitives::Lock>())
     , button_lock_ptr_(std::make_shared<sync_primitives::Lock>())
     , application_manager_(application_manager) {
   cmd_number_to_time_limits_[mobile_apis::FunctionID::ReadDIDID] = {
@@ -177,13 +177,27 @@ ApplicationImpl::~ApplicationImpl() {
     delete active_message_;
     active_message_ = NULL;
   }
-
+  button_lock_ptr_->Acquire();
   subscribed_buttons_.clear();
+  button_lock_ptr_->Release();
+  {
+    sync_primitives::AutoLock lock(cmd_softbuttonid_lock_);
+    cmd_softbuttonid_.clear();
+  }
+  cmd_number_to_time_limits_.clear();
+
   if (is_perform_interaction_active()) {
     set_perform_interaction_active(0);
     set_perform_interaction_mode(-1);
   }
   CleanupFiles();
+  sync_primitives::AutoLock lock(mobile_message_lock_);
+  mobile_message_queue_.clear();
+  {
+    extensions_lock_->Acquire();
+    extensions_.clear();
+    extensions_lock_->Release();
+  }
 }
 
 void ApplicationImpl::CloseActiveMessage() {
@@ -1301,12 +1315,15 @@ void ApplicationImpl::set_hmi_level(
 }
 
 AppExtensionPtr ApplicationImpl::QueryInterface(AppExtensionUID uid) {
+  extensions_lock_->Acquire();
   std::list<AppExtensionPtr>::const_iterator it = extensions_.begin();
   for (; it != extensions_.end(); ++it) {
     if ((*it)->uid() == uid) {
+      extensions_lock_->Release();
       return (*it);
     }
   }
+  extensions_lock_->Release();
   return AppExtensionPtr();
 }
 
@@ -1315,7 +1332,9 @@ bool ApplicationImpl::AddExtension(AppExtensionPtr extension) {
   if (!QueryInterface(extension->uid())) {
     SDL_LOG_TRACE("Add extenstion to add id" << app_id() << " with uid "
                                              << extension->uid());
+    extensions_lock_->Acquire();
     extensions_.push_back(extension);
+    extensions_lock_->Release();
     return true;
   }
   return false;
@@ -1323,6 +1342,7 @@ bool ApplicationImpl::AddExtension(AppExtensionPtr extension) {
 
 bool ApplicationImpl::RemoveExtension(AppExtensionUID uid) {
   SDL_LOG_AUTO_TRACE();
+  extensions_lock_->Acquire();
   auto it = std::find_if(
       extensions_.begin(), extensions_.end(), [uid](AppExtensionPtr extension) {
         return extension->uid() == uid;
@@ -1330,14 +1350,20 @@ bool ApplicationImpl::RemoveExtension(AppExtensionUID uid) {
 
   if (extensions_.end() != it) {
     extensions_.erase(it);
+    extensions_lock_->Release();
     return true;
   }
-
+  extensions_lock_->Release();
   return false;
 }
 
-const std::list<AppExtensionPtr>& ApplicationImpl::Extensions() const {
-  return extensions_;
+const DataAccessor<std::list<AppExtensionPtr> > ApplicationImpl::Extensions()
+    const {
+  extensions_lock_->Acquire();
+  DataAccessor<std::list<AppExtensionPtr> > accessor(extensions_,
+                                                     extensions_lock_);
+  extensions_lock_->Release();
+  return accessor;
 }
 
 const std::string& ApplicationImpl::cloud_app_endpoint() const {
@@ -1403,14 +1429,16 @@ const smart_objects::SmartObject& ApplicationImpl::get_user_location() const {
 
 void ApplicationImpl::PushMobileMessage(
     smart_objects::SmartObjectSPtr mobile_message) {
-  sync_primitives::AutoLock lock(mobile_message_lock_);
+  mobile_message_lock_.Acquire();
   mobile_message_queue_.push_back(mobile_message);
+  mobile_message_lock_.Release();
 }
 
 void ApplicationImpl::SwapMobileMessageQueue(
     MobileMessageQueue& mobile_messages) {
-  sync_primitives::AutoLock lock(mobile_message_lock_);
+  mobile_message_lock_.Acquire();
   mobile_messages.swap(mobile_message_queue_);
+  mobile_message_lock_.Release();
 }
 
 }  // namespace application_manager

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -256,8 +256,36 @@ ApplicationManagerImpl::~ApplicationManagerImpl() {
     streaming_timer_pool_.clear();
   }
 
+  {
+    sync_primitives::AutoLock lock(navi_service_status_lock_);
+    navi_service_status_.clear();
+  }
+
+  {
+    sync_primitives::AutoLock lock(tts_global_properties_app_list_lock_);
+    tts_global_properties_app_list_.clear();
+  }
+
+  {
+    sync_primitives::AutoLock lock(apps_to_register_list_lock_ptr_);
+    apps_to_register_.clear();
+  }
+
+  {
+    sync_primitives::AutoLock lock(reregister_wait_list_lock_ptr_);
+    reregister_wait_list_.erase(reregister_wait_list_.begin(),
+                                reregister_wait_list_.end());
+  }
+
+  {
+    sync_primitives::AutoLock lock(query_apps_devices_lock_);
+    query_apps_devices_.clear();
+  }
   clear_pool_timer_.Stop();
   secondary_transport_devices_cache_.clear();
+  applications_list_lock_ptr_->Acquire();
+  applications_.clear();
+  applications_list_lock_ptr_->Release();
 }
 
 DataAccessor<ApplicationSet> ApplicationManagerImpl::applications() const {
@@ -984,7 +1012,7 @@ void ApplicationManagerImpl::RefreshCloudAppInformation() {
   return;
 #else
   SDL_LOG_AUTO_TRACE();
-  if (is_stopping()) {
+  if (IsStopping()) {
     return;
   }
   std::vector<std::string> enabled_apps;
@@ -3502,10 +3530,6 @@ mobile_apis::Result::eType ApplicationManagerImpl::CheckPolicyPermissions(
   }
   SDL_LOG_DEBUG("Request is allowed by policies. " << log_msg);
   return mobile_api::Result::SUCCESS;
-}
-
-bool ApplicationManagerImpl::is_stopping() const {
-  return is_stopping_;
 }
 
 bool ApplicationManagerImpl::is_audio_pass_thru_active() const {

--- a/src/components/application_manager/src/commands/command_impl.cc
+++ b/src/components/application_manager/src/commands/command_impl.cc
@@ -174,6 +174,10 @@ void CommandImpl::SetAllowedToTerminate(const bool allowed) {
   allowed_to_terminate_ = allowed;
 }
 
+const ApplicationManager& CommandImpl::GetApplicationManager() const {
+  return application_manager_;
+}
+
 bool CommandImpl::CheckAllowedParameters(const Command::CommandSource source) {
   SDL_LOG_AUTO_TRACE();
 

--- a/src/components/application_manager/src/request_controller_impl.cc
+++ b/src/components/application_manager/src/request_controller_impl.cc
@@ -72,6 +72,27 @@ RequestControllerImpl::RequestControllerImpl(
 RequestControllerImpl::~RequestControllerImpl() {
   SDL_LOG_AUTO_TRACE();
   Stop();
+
+  retained_mobile_requests_.clear();
+
+  {
+    notification_list_lock_.Acquire();
+    notification_list_.clear();
+    notification_list_lock_.Release();
+  }
+
+  {
+    duplicate_message_count_lock_.Acquire();
+    duplicate_message_count_.clear();
+    duplicate_message_count_lock_.Release();
+  }
+
+  {
+    mobile_request_list_lock_.Acquire();
+    mobile_request_list_.clear();
+    waiting_for_response_.RemoveMobileRequests();
+    mobile_request_list_lock_.Release();
+  }
 }
 
 void RequestControllerImpl::Stop() {
@@ -111,7 +132,6 @@ void RequestControllerImpl::InitializeThreadpool() {
 void RequestControllerImpl::DestroyThreadpool() {
   SDL_LOG_AUTO_TRACE();
   {
-    AutoLock auto_lock(mobile_request_list_lock_);
     pool_state_ = TPoolState::STOPPED;
     SDL_LOG_DEBUG("Broadcasting STOP signal to all threads...");
     cond_var_.Broadcast();  // notify all threads we are shutting down
@@ -159,7 +179,9 @@ bool RequestControllerImpl::CheckPendingRequestsAmount(
   SDL_LOG_AUTO_TRACE();
 
   if (pending_requests_amount > 0) {
+    mobile_request_list_lock_.Acquire();
     const size_t pending_requests_size = mobile_request_list_.size();
+    mobile_request_list_lock_.Release();
     const bool available_to_add =
         pending_requests_amount > pending_requests_size;
     if (!available_to_add) {
@@ -181,11 +203,13 @@ RequestController::TResult RequestControllerImpl::AddMobileRequest(
     cond_var_.NotifyOne();
     return TResult::INVALID_DATA;
   }
+
   SDL_LOG_DEBUG("correlation_id : " << request->correlation_id()
                                     << "connection_key : "
                                     << request->connection_key());
   RequestController::TResult result = CheckPosibilitytoAdd(request, hmi_level);
-  if (TResult::SUCCESS == result) {
+
+  if (TResult::SUCCESS == result && pool_state_ != TPoolState::STOPPED) {
     AutoLock auto_lock_list(mobile_request_list_lock_);
     mobile_request_list_.push_back(request);
     SDL_LOG_DEBUG("Waiting for execution: " << mobile_request_list_.size());
@@ -431,12 +455,13 @@ void RequestControllerImpl::TerminateWaitingForResponseAppRequests(
 
 void RequestControllerImpl::TerminateAppRequests(const uint32_t app_id) {
   SDL_LOG_AUTO_TRACE();
+  mobile_request_list_lock_.Acquire();
   SDL_LOG_DEBUG("app_id : " << app_id
                             << "Requests waiting for execution count : "
                             << mobile_request_list_.size()
                             << "Requests waiting for response count : "
                             << waiting_for_response_.Size());
-
+  mobile_request_list_lock_.Release();
   TerminateWaitingForExecutionAppRequests(app_id);
   TerminateWaitingForResponseAppRequests(app_id);
   NotifyTimer();
@@ -451,10 +476,9 @@ void RequestControllerImpl::TerminateAllMobileRequests() {
   SDL_LOG_AUTO_TRACE();
 
   waiting_for_response_.RemoveMobileRequests();
-  SDL_LOG_DEBUG("Mobile Requests waiting for response cleared");
-  AutoLock waiting_execution_auto_lock(mobile_request_list_lock_);
+  mobile_request_list_lock_.Acquire();
   mobile_request_list_.clear();
-  SDL_LOG_DEBUG("Mobile Requests waiting for execution cleared");
+  mobile_request_list_lock_.Release();
   NotifyTimer();
 }
 
@@ -590,27 +614,32 @@ RequestControllerImpl::Worker::~Worker() {}
 
 void RequestControllerImpl::Worker::threadMain() {
   SDL_LOG_AUTO_TRACE();
-  AutoLock auto_lock(thread_lock_);
+  AutoLock auto_thread_lock_(thread_lock_);
   while (!stop_flag_) {
     // Try to pick a request
-    AutoLock auto_lock(request_controller_->mobile_request_list_lock_);
+    request_controller_->mobile_request_list_lock_.Acquire();
 
     while ((request_controller_->pool_state_ != TPoolState::STOPPED) &&
            (request_controller_->mobile_request_list_.empty())) {
       // Wait until there is a task in the queue
       // Unlock mutex while wait, then lock it back when signaled
       SDL_LOG_INFO("Unlocking and waiting");
-      request_controller_->cond_var_.Wait(auto_lock);
+      request_controller_->cond_var_.Wait(
+          request_controller_->mobile_request_list_lock_);
       SDL_LOG_INFO("Signaled and locking");
     }
 
     // If the thread was shutdown, return from here
     if (request_controller_->pool_state_ == TPoolState::STOPPED) {
+      SDL_LOG_WARN("TPoolState::STOPPED");
+      request_controller_->mobile_request_list_.clear();
+      request_controller_->mobile_request_list_lock_.Release();
       break;
     }
 
     if (request_controller_->mobile_request_list_.empty()) {
       SDL_LOG_WARN("Mobile request list is empty");
+      request_controller_->mobile_request_list_lock_.Release();
       break;
     }
 
@@ -640,6 +669,7 @@ void RequestControllerImpl::Worker::threadMain() {
         cmd_request->SendResponse(
             false, mobile_apis::Result::INVALID_ID, "Duplicate correlation_id");
       }
+      request_controller_->mobile_request_list_lock_.Release();
       continue;
     }
     SDL_LOG_DEBUG("timeout_in_mseconds " << timeout_in_mseconds);
@@ -653,7 +683,7 @@ void RequestControllerImpl::Worker::threadMain() {
           "of this request.");
     }
 
-    AutoUnlock unlock(auto_lock);
+    request_controller_->mobile_request_list_lock_.Release();
 
     // execute
     if ((false == request_controller_->IsLowVoltage()) &&
@@ -662,6 +692,12 @@ void RequestControllerImpl::Worker::threadMain() {
                     << request_info_ptr->requestId()
                     << " with timeout: " << timeout_in_mseconds);
       request_ptr->Run();
+    }
+    if (request_ptr->GetApplicationManager().IsStopping()) {
+      request_controller_->mobile_request_list_lock_.Acquire();
+      request_controller_->mobile_request_list_.clear();
+      request_controller_->waiting_for_response_.RemoveMobileRequests();
+      request_controller_->mobile_request_list_lock_.Release();
     }
   }
 }

--- a/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
+++ b/src/components/application_manager/src/resumption/resume_ctrl_impl.cc
@@ -252,6 +252,7 @@ bool ResumeCtrlImpl::SetupDefaultHMILevel(ApplicationSharedPtr application) {
 
 void ResumeCtrlImpl::ApplicationResumptiOnTimer() {
   SDL_LOG_AUTO_TRACE();
+  DataAccessor<ApplicationSet> apps = application_manager_.applications();
   sync_primitives::AutoLock auto_lock(queue_lock_);
   WaitingForTimerList::iterator it = waiting_for_timer_.begin();
 

--- a/src/components/application_manager/src/resumption/resumption_data.cc
+++ b/src/components/application_manager/src/resumption/resumption_data.cc
@@ -163,7 +163,8 @@ smart_objects::SmartObject ResumptionData::GetApplicationSubscriptions(
            subscriptions);
   }
 
-  for (auto extension : application->Extensions()) {
+  auto extensions = application->Extensions();
+  for (auto extension : extensions.GetData()) {
     extension->SaveResumptionData(subscriptions);
   }
 

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -890,7 +890,8 @@ void ResumptionDataProcessorImpl::AddPluginsSubscriptions(
     const smart_objects::SmartObject& saved_app) {
   SDL_LOG_AUTO_TRACE();
 
-  for (auto& extension : application->Extensions()) {
+  auto extensions = application->Extensions();
+  for (auto& extension : extensions.GetData()) {
     extension->ProcessResumption(saved_app);
   }
 }
@@ -995,7 +996,7 @@ void ResumptionDataProcessorImpl::DeletePluginsSubscriptions(
   resumption_status_lock_.Release();
 
   auto extensions = application->Extensions();
-  for (auto& extension : extensions) {
+  for (auto& extension : extensions.GetData()) {
     extension->RevertResumption(resumption_data_to_revert);
   }
 }

--- a/src/components/application_manager/src/rpc_handler_impl.cc
+++ b/src/components/application_manager/src/rpc_handler_impl.cc
@@ -212,7 +212,7 @@ void RPCHandlerImpl::Handle(const impl::MessageFromMobile message) {
     SDL_LOG_ERROR("Null-pointer message received.");
     return;
   }
-  if (app_manager_.is_stopping()) {
+  if (app_manager_.IsStopping()) {
     SDL_LOG_INFO("Application manager is stopping");
     return;
   }

--- a/src/components/application_manager/test/include/application_manager/mock_application.h
+++ b/src/components/application_manager/test/include/application_manager/mock_application.h
@@ -404,8 +404,9 @@ class MockApplication : public ::application_manager::Application {
   MOCK_METHOD1(AddExtension,
                bool(application_manager::AppExtensionPtr extention));
   MOCK_METHOD1(RemoveExtension, bool(application_manager::AppExtensionUID uid));
-  MOCK_CONST_METHOD0(Extensions,
-                     const std::list<application_manager::AppExtensionPtr>&());
+  MOCK_CONST_METHOD0(
+      Extensions,
+      const DataAccessor<std::list<application_manager::AppExtensionPtr> >());
   MOCK_CONST_METHOD0(is_remote_control_supported, bool());
   MOCK_METHOD1(set_remote_control_supported, void(const bool allow));
   MOCK_CONST_METHOD0(cloud_app_endpoint, const std::string&());

--- a/src/components/application_manager/test/include/application_manager/mock_request.h
+++ b/src/components/application_manager/test/include/application_manager/mock_request.h
@@ -63,6 +63,8 @@ class MockRequest : public application_manager::commands::Command {
   MOCK_METHOD0(AllowedToTerminate, bool());
   MOCK_METHOD1(SetAllowedToTerminate, void(bool is_allowed));
 
+  MOCK_CONST_METHOD0(GetApplicationManager,
+                     application_manager::ApplicationManager&());
   MOCK_CONST_METHOD0(connection_key, uint32_t());
   MOCK_CONST_METHOD0(correlation_id, uint32_t());
 };

--- a/src/components/application_manager/test/include/application_manager/resumption_data_test.h
+++ b/src/components/application_manager/test/include/application_manager/resumption_data_test.h
@@ -75,6 +75,7 @@ class ResumptionDataTest : public ::testing::Test {
       , setlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , btnlock_ptr_(std::make_shared<sync_primitives::Lock>())
       , ivilock_ptr_(std::make_shared<sync_primitives::Lock>())
+      , extensions_lock_(std::make_shared<sync_primitives::RecursiveLock>())
       , window_params_map_lock_ptr_(std::make_shared<sync_primitives::Lock>()) {
   }
   virtual ~ResumptionDataTest();
@@ -162,6 +163,7 @@ class ResumptionDataTest : public ::testing::Test {
   std::shared_ptr<sync_primitives::Lock> setlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> btnlock_ptr_;
   std::shared_ptr<sync_primitives::Lock> ivilock_ptr_;
+  std::shared_ptr<sync_primitives::RecursiveLock> extensions_lock_;
   std::shared_ptr<sync_primitives::Lock> window_params_map_lock_ptr_;
   application_manager_test::MockApplicationManagerSettings
       mock_application_manager_settings_;

--- a/src/components/application_manager/test/resumption/resumption_data_test.cc
+++ b/src/components/application_manager/test/resumption/resumption_data_test.cc
@@ -383,7 +383,9 @@ void ResumptionDataTest::PrepareData() {
   mock_app_extension_ =
       std::make_shared<NiceMock<application_manager_test::MockAppExtension> >();
   extensions_.insert(extensions_.begin(), mock_app_extension_);
-  ON_CALL(*app_mock, Extensions()).WillByDefault(ReturnRef(extensions_));
+  DataAccessor<std::list<application_manager::AppExtensionPtr> > accessor(
+      extensions_, extensions_lock_);
+  ON_CALL(*app_mock, Extensions()).WillByDefault(Return(accessor));
   SetGlobalProporties();
   SetCommands();
   SetSubmenues();

--- a/src/components/include/application_manager/application_manager.h
+++ b/src/components/include/application_manager/application_manager.h
@@ -512,7 +512,6 @@ class ApplicationManager {
   get_request_timeout_handler() const = 0;
   virtual request_controller::RequestController& get_request_controller()
       const = 0;
-  virtual bool is_stopping() const = 0;
   virtual bool is_audio_pass_thru_active() const = 0;
 
   virtual uint32_t GetNextMobileCorrelationID() = 0;

--- a/src/components/include/test/application_manager/mock_application_manager.h
+++ b/src/components/include/test/application_manager/mock_application_manager.h
@@ -197,7 +197,7 @@ class MockApplicationManager : public application_manager::ApplicationManager {
   MOCK_CONST_METHOD0(
       get_request_controller,
       application_manager::request_controller::RequestController&());
-  MOCK_CONST_METHOD0(is_stopping, bool());
+  MOCK_CONST_METHOD0(IsStopping, bool());
   MOCK_CONST_METHOD0(is_audio_pass_thru_active, bool());
   MOCK_METHOD0(GetNextHMICorrelationID, uint32_t());
   MOCK_METHOD0(GetNextMobileCorrelationID, uint32_t());
@@ -236,7 +236,6 @@ class MockApplicationManager : public application_manager::ApplicationManager {
                     bool is_greyed_out));
   MOCK_CONST_METHOD1(IsAppsQueriedFrom,
                      bool(const connection_handler::DeviceHandle handle));
-  MOCK_CONST_METHOD0(IsStopping, bool());
   MOCK_METHOD0(WaitForHmiIsReady, bool());
   MOCK_METHOD1(RemoveAppFromTTSGlobalPropertiesList,
                void(const uint32_t app_id));

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -645,6 +645,7 @@ class TransportAdapterImpl : public TransportAdapter,
    **/
   ConnectionMap connections_;
 
+  mutable sync_primitives::Lock connections_dublicate;
   /**
    * @brief Queue of retry timers.
    */

--- a/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
+++ b/src/components/transport_manager/src/transport_adapter/transport_adapter_impl.cc
@@ -137,6 +137,8 @@ void TransportAdapterImpl::Terminate() {
   connections_lock_.AcquireForWriting();
   std::swap(connections, connections_);
   connections_lock_.Release();
+
+  connections_dublicate.Acquire();
   for (const auto& connection : connections) {
     auto& info = connection.second;
     if (info.connection) {
@@ -144,6 +146,7 @@ void TransportAdapterImpl::Terminate() {
     }
   }
   connections.clear();
+  connections_dublicate.Release();
 
   SDL_LOG_DEBUG("Connections deleted");
 
@@ -386,6 +389,7 @@ TransportAdapter::Error TransportAdapterImpl::DisconnectDevice(
   }
   connections_lock_.Release();
 
+  connections_dublicate.Acquire();
   for (std::vector<ConnectionInfo>::const_iterator j = to_disconnect.begin();
        j != to_disconnect.end();
        ++j) {
@@ -395,6 +399,7 @@ TransportAdapter::Error TransportAdapterImpl::DisconnectDevice(
       SDL_LOG_ERROR("Error on disconnect " << error);
     }
   }
+  connections_dublicate.Release();
 
   return error;
 }


### PR DESCRIPTION
Fixes #[12637](https://luxproject.luxoft.com/jira/browse/FORDTCN-12637)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
SDL core dump on Ignition OFF during registering 20 Apps.
During application registration, the ignition is turned off and the fields of the ApplicationManagerImpl object are deleted. We were unable to delete the fields that are deleted after exiting the destructor. Because we used them in other threads. After that, there was a hang of SDL, because we used two mutexes in different sequences in different places.
Then there was a crash due to the use of non-synchronized data in the objects of the Application.
Fixing this opened a drop in the RequestControllerImpl. The fall was due to the fact that sdl uses smart pointers, and they are copied to different threads. So I added delete mobile of the  requests in the threads processing these request.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
