### PR TITLE
lock read and write operations

### DIFF
--- a/src/components/transport_manager/include/transport_manager/websocket_server/websocket_session.h
+++ b/src/components/transport_manager/include/transport_manager/websocket_server/websocket_session.h
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "protocol/raw_message.h"
 #include "transport_manager/transport_adapter/transport_adapter.h"
+#include "utils/lock.h"
 #include "utils/logger.h"
 
 #ifdef ENABLE_SECURITY
@@ -103,6 +104,7 @@ class WebSocketSession
   DataSendDoneCallback data_send_done_;
   DataSendFailedCallback data_send_failed_;
   OnIOErrorCallback on_io_error_;
+  mutable sync_primitives::Lock read_write_operations_lock_;
 };
 
 }  // namespace transport_adapter

--- a/src/components/transport_manager/src/websocket_server/websocket_session.cc
+++ b/src/components/transport_manager/src/websocket_server/websocket_session.cc
@@ -89,6 +89,7 @@ void WebSocketSession<ExecutorType>::AsyncAccept() {
 template <typename ExecutorType>
 void WebSocketSession<ExecutorType>::AsyncRead(boost::system::error_code ec) {
   SDL_LOG_AUTO_TRACE();
+  sync_primitives::AutoLock lock(read_write_operations_lock_);
   if (ec) {
     auto str_err = "ErrorMessage: " + ec.message();
     SDL_LOG_ERROR(str_err);
@@ -106,6 +107,7 @@ void WebSocketSession<ExecutorType>::AsyncRead(boost::system::error_code ec) {
 
 template <typename ExecutorType>
 void WebSocketSession<ExecutorType>::WriteDown(Message message) {
+  sync_primitives::AutoLock lock(read_write_operations_lock_);
   boost::system::error_code ec;
   ws_.write(boost::asio::buffer(message->data(), message->data_size()), ec);
 


### PR DESCRIPTION
Fixes #[12727](https://luxproject.luxoft.com/jira/browse/FORDTCN-12727)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Core closes web socket connection with 'unspecified system error'. Incorrect data was read and written during the connection. Synchronized data read and write.
