### PR TITLE
Fix result code for PrepareAudioPassThru

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_audio_pass_thru_request.cc
@@ -175,6 +175,7 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
               hmi_apis::Common_Result::WRONG_LANGUAGE,
               hmi_apis::Common_Result::RETRY,
               hmi_apis::Common_Result::SAVED,
+              hmi_apis::Common_Result::TRUNCATED_DATA,
               hmi_apis::Common_Result::UNSUPPORTED_RESOURCE);
 
       if (is_tts_speak_success_unsuported) {
@@ -198,7 +199,10 @@ void PerformAudioPassThruRequest::on_event(const event_engine::Event& event) {
     return;
   }
 
-  const ResponseParams response_params = PrepareResponseParameters();
+  ResponseParams response_params = PrepareResponseParameters();
+  if (message[strings::params].keyExists(hmi_response::message)) {
+    response_params.success = false;
+  }
 
   SendResponse(
       response_params.success,
@@ -220,7 +224,9 @@ PerformAudioPassThruRequest::PrepareResponseParameters() {
 
   response_params_.success =
       PrepareResultForMobileResponse(ui_perform_info, tts_perform_info);
-  if (ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
+
+  if ((ui_perform_info.result_code == hmi_apis::Common_Result::SUCCESS) &&
+      ui_perform_info.is_ok && tts_perform_info.is_unsupported_resource &&
       HmiInterfaces::STATE_AVAILABLE == tts_perform_info.interface_state) {
     response_params_.result_code = mobile_apis::Result::WARNINGS;
     response_params_.info = app_mngr::commands::MergeInfos(
@@ -231,12 +237,13 @@ PerformAudioPassThruRequest::PrepareResponseParameters() {
 
   if (IsResultCodeUnsupported(ui_perform_info, tts_perform_info)) {
     response_params_.result_code = mobile_apis::Result::UNSUPPORTED_RESOURCE;
-  } else {
-    AudioPassThruResults results = PrepareAudioPassThruResultCodeForResponse(
-        ui_perform_info, tts_perform_info);
-    response_params_.success = results.second;
-    response_params_.result_code = results.first;
   }
+
+  AudioPassThruResults results = PrepareAudioPassThruResultCodeForResponse(
+      ui_perform_info, tts_perform_info);
+  response_params_.success = results.second;
+  response_params_.result_code = results.first;
+
   response_params_.info = app_mngr::commands::MergeInfos(
       ui_perform_info, ui_info_, tts_perform_info, tts_info_);
 
@@ -407,23 +414,19 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
   const hmi_apis::Common_Result::eType tts_result = tts_response.result_code;
   bool result = false;
 
-  if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
-      (tts_result == hmi_apis::Common_Result::SUCCESS)) {
+  if ((application_manager::commands::IsHMIResultSuccess(ui_result) ||
+       (ui_result == hmi_apis::Common_Result::UNSUPPORTED_RESOURCE)) &&
+      (application_manager::commands::IsHMIResultSuccess(tts_result) ||
+       (tts_result == hmi_apis::Common_Result::UNSUPPORTED_RESOURCE) ||
+       (tts_result == hmi_apis::Common_Result::INVALID_ENUM))) {
     result = true;
   }
 
   if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
-      (tts_result == hmi_apis::Common_Result::INVALID_ENUM)) {
-    result = true;
-  }
-
-  if ((ui_result == hmi_apis::Common_Result::SUCCESS) &&
-      (tts_result != hmi_apis::Common_Result::SUCCESS) &&
-      (tts_result != hmi_apis::Common_Result::INVALID_ENUM)) {
-    common_result = hmi_apis::Common_Result::WARNINGS;
-    result = true;
-  } else if (ui_response.is_ok &&
-             tts_result == hmi_apis::Common_Result::WARNINGS) {
+      (((tts_result != hmi_apis::Common_Result::SUCCESS) &&
+        (tts_result != hmi_apis::Common_Result::INVALID_ENUM)) ||
+       (ui_response.is_ok &&
+        tts_result == hmi_apis::Common_Result::WARNINGS))) {
     common_result = hmi_apis::Common_Result::WARNINGS;
     result = true;
   } else if (ui_result == hmi_apis::Common_Result::INVALID_ENUM) {
@@ -431,6 +434,7 @@ PerformAudioPassThruRequest::PrepareAudioPassThruResultCodeForResponse(
   } else {
     common_result = ui_result;
   }
+
   result_code = MessageHelper::HMIToMobileResult(common_result);
   return std::make_pair(result_code, result);
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_audio_pass_thru_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/perform_audio_pass_thru_test.cc
@@ -261,7 +261,7 @@ TEST_F(PerformAudioPassThruRequestTest,
 
   EXPECT_EQ((*response_to_mobile)[am::strings::msg_params][am::strings::success]
                 .asBool(),
-            false);
+            true);
   EXPECT_EQ(
       (*response_to_mobile)[am::strings::msg_params][am::strings::result_code]
           .asInt(),

--- a/src/components/utils/include/utils/helpers.h
+++ b/src/components/utils/include/utils/helpers.h
@@ -126,6 +126,15 @@ bool Compare(T what, T to, T to1, T to2, T to3, T to4, T to5) {
       Compare<T, CompareType, CmpStrategy>(what, to4, to5));
 }
 
+template <typename T,
+          bool (*CompareType)(T, T),
+          bool (*CmpStrategy)(bool, bool)>
+bool Compare(T what, T to, T to1, T to2, T to3, T to4, T to5, T to6) {
+  return CmpStrategy(
+      Compare<T, CompareType, CmpStrategy>(what, to, to1, to2, to3),
+      Compare<T, CompareType, CmpStrategy>(what, to4, to5, to6));
+}
+
 template <typename Container>
 bool in_range(const Container& container,
               const typename Container::value_type& value) {


### PR DESCRIPTION
Fixes #[12861](https://luxproject.luxoft.com/jira/browse/FORDTCN-12861)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
ATF scripts

### Summary
- Added a check success result codes in PrepareAudioPassThruResultCodeForResponse
- Modified a check result codes
- Added  a result code TRUNCATED_DATA in PerformAudioPassThruRequest::on_event 
- Added a check hmi_response::message and set success = false (in case success result code  in error structure)
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
