### PR TITLE
Check iterator before erase in ProcessResponseFromHMI

### DIFF
--- a/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
+++ b/src/components/application_manager/include/application_manager/resumption/resumption_data_processor_impl.h
@@ -129,8 +129,9 @@ class ResumptionDataProcessorImpl
    * requests
    * @param app_id ID of application, related to event
    * @param found_request reference to found request
+   * @return true, if request is found and erased
    */
-  void EraseProcessedRequest(const uint32_t app_id,
+  bool EraseProcessedRequest(const uint32_t app_id,
                              const ResumptionRequest& found_request);
 
   /**

--- a/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_processor_impl.cc
@@ -178,7 +178,7 @@ void ResumptionDataProcessorImpl::ProcessResumptionStatus(
   }
 }
 
-void ResumptionDataProcessorImpl::EraseProcessedRequest(
+bool ResumptionDataProcessorImpl::EraseProcessedRequest(
     const uint32_t app_id, const ResumptionRequest& found_request) {
   SDL_LOG_AUTO_TRACE();
 
@@ -194,7 +194,11 @@ void ResumptionDataProcessorImpl::EraseProcessedRequest(
                             request.request_id.function_id ==
                                 found_request.request_id.function_id;
                    });
-  list_of_sent_requests.erase(request_iter);
+  if (request_iter != list_of_sent_requests.end()) {
+    list_of_sent_requests.erase(request_iter);
+    return true;
+  }
+  return false;
 }
 
 bool ResumptionDataProcessorImpl::IsResumptionFinished(
@@ -285,6 +289,7 @@ void ResumptionDataProcessorImpl::ProcessResponseFromHMI(
   SDL_LOG_DEBUG("app_id is: " << app_id);
 
   auto found_request = GetRequest(app_id, function_id, corr_id);
+
   if (!found_request) {
     SDL_LOG_ERROR("Request with function id " << function_id << " and corr id "
                                               << corr_id << " not found");
@@ -293,7 +298,11 @@ void ResumptionDataProcessorImpl::ProcessResponseFromHMI(
   auto request = *found_request;
 
   ProcessResumptionStatus(app_id, response, request);
-  EraseProcessedRequest(app_id, request);
+
+  if (!EraseProcessedRequest(app_id, request)) {
+    SDL_LOG_DEBUG("Request has already been processed");
+    return;
+  }
 
   if (!IsResumptionFinished(app_id)) {
     SDL_LOG_DEBUG("Resumption app "


### PR DESCRIPTION
Fixes #[12752](https://luxproject.luxoft.com/jira/browse/FORDTCN-12752)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
In rare case, two threads try to process response from hmi with same correlation id and function id (from HandleOnEvent and HandleOnTimeOut)

- Added a checking of iterator before an erasing of request
- Changed return value for method void EraseProcessedRequest (...) to bool IsErasedProcessedRequest(...) . It's for checking if this request has already been processed.

 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
