### PR TITLE
Deleted local hmi api factory

### DIFF
--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2567,7 +2567,7 @@ void ApplicationManagerImpl::RemoveHMIFakeParameters(
     application_manager::commands::MessageSharedPtr& message,
     const hmi_apis::FunctionID::eType& function_id) {
   SDL_LOG_AUTO_TRACE();
-  hmi_apis::HMI_API factory;
+
   if (!(*message)[jhs::S_PARAMS].keyExists(jhs::S_FUNCTION_ID)) {
     SDL_LOG_ERROR("RemoveHMIFakeParameters message missing function id");
     return;
@@ -2576,7 +2576,7 @@ void ApplicationManagerImpl::RemoveHMIFakeParameters(
       static_cast<mobile_apis::FunctionID::eType>(
           (*message)[jhs::S_PARAMS][jhs::S_FUNCTION_ID].asInt());
   (*message)[jhs::S_PARAMS][jhs::S_FUNCTION_ID] = function_id;
-  factory.attachSchema(*message, true);
+  hmi_so_factory().attachSchema(*message, true);
   (*message)[jhs::S_PARAMS][jhs::S_FUNCTION_ID] = mobile_function_id;
 }
 


### PR DESCRIPTION
Fixes #[13017](https://luxproject.luxoft.com/jira/browse/FORDTCN-13017)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Deleted local variable hmi_apis::HMI_API factory, because  here is better to use hmi_so_factory().

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
